### PR TITLE
[SDK-737] Add Scene class that will be used to modify a loaded scene

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../errors';
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { StreamApi, WebSocketClient } from '@vertexvis/stream-api';
+import { Scene } from '../../scenes/scene';
 
 interface LoadedImage extends Disposable {
   image: HTMLImageElement | ImageBitmap;
@@ -53,7 +54,7 @@ export class Viewer {
    *
    *  * `urn:vertexvis:scene:<sceneid>`
    */
-  @Prop() public scene?: string;
+  @Prop() public src?: string;
 
   /**
    * An object or JSON encoded string that defines configuration settings for
@@ -150,8 +151,8 @@ export class Viewer {
 
     this.calculateComponentDimensions();
 
-    if (this.scene != null) {
-      this.load(this.scene);
+    if (this.src != null) {
+      this.load(this.src);
     }
 
     if (this.cameraControls) {
@@ -283,8 +284,8 @@ export class Viewer {
     return this.interactionHandlers;
   }
 
-  @Watch('scene')
-  public handleSceneChanged(scene: string | undefined): void {
+  @Watch('src')
+  public handleSrcChanged(scene: string | undefined): void {
     if (scene != null) {
       this.load(scene);
     } else {
@@ -312,6 +313,11 @@ export class Viewer {
         'Cannot load scene. Viewer has not been initialized.'
       );
     }
+  }
+
+  @Method()
+  public async scene(): Promise<Scene> {
+    return new Scene(this.stream);
   }
 
   @Method()

--- a/packages/viewer/src/scenes/index.ts
+++ b/packages/viewer/src/scenes/index.ts
@@ -1,0 +1,1 @@
+export * from './scene';

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -1,0 +1,5 @@
+import { StreamApi } from '@vertexvis/stream-api';
+
+export class Scene {
+  public constructor(private stream: StreamApi) {}
+}


### PR DESCRIPTION
## What

Adds a `Scene` class that will be used in future PRs to modify a loaded scene. Example:

```ts
const scene = await viewer.scene();

// Perform a camera operation
scene.camera().position(1, 2, 3);

// Perform a hit operation
scene.raycaster().hit({x: 1, y: 2});
```

## Ticket

https://jira.vertexvis.net/browse/SDK-737

## Test Plan

Unit tests

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
