### PR TITLE
[SDK-738] Add operations to modify the scene camera

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: "Install"
         run: "yarn install"
-      - name: "Bootstrap"
-        run: "yarn bootstrap"
       - name: "Build"
         run: "yarn build"
       - name: "Test"

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -8,8 +8,6 @@ type ResponseHandler = (
   response: vertexvis.protobuf.stream.IStreamResponse
 ) => void;
 
-type RecursiveRequired<T> = { [P in keyof T]-?: RecursiveRequired<T[P]> };
-
 export class StreamApi {
   private onResponseDispatcher = new EventDispatcher<
     vertexvis.protobuf.stream.IStreamResponse
@@ -39,9 +37,9 @@ export class StreamApi {
   }
 
   public startStream(
-    data: RecursiveRequired<vertexvis.protobuf.stream.IStartStreamPayload>
+    data: vertexvis.protobuf.stream.IStartStreamPayload
   ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
-    return this.send({
+    return this.sendRequest({
       startStream: {
         ...data,
       },
@@ -51,17 +49,17 @@ export class StreamApi {
   public beginInteraction(): Promise<
     vertexvis.protobuf.stream.IStreamResponse
   > {
-    return this.send({
+    return this.sendRequest({
       beginInteraction: {},
     });
   }
 
   public replaceCamera({
     camera,
-  }: RecursiveRequired<
-    vertexvis.protobuf.stream.IUpdateCameraPayload
-  >): Promise<vertexvis.protobuf.stream.IStreamResponse> {
-    return this.send({
+  }: vertexvis.protobuf.stream.IUpdateCameraPayload): Promise<
+    vertexvis.protobuf.stream.IStreamResponse
+  > {
+    return this.sendRequest({
       updateCamera: {
         camera,
       },
@@ -69,12 +67,12 @@ export class StreamApi {
   }
 
   public endInteraction(): Promise<vertexvis.protobuf.stream.IStreamResponse> {
-    return this.send({
+    return this.sendRequest({
       endInteraction: {},
     });
   }
 
-  private send(
+  private sendRequest(
     request: vertexvis.protobuf.stream.IStreamRequest
   ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
     return new Promise(resolve => {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -36,7 +36,6 @@
     "@types/classnames": "2.2.3",
     "@vertexvis/frame-streaming-protos": "^0.0.18",
     "@vertexvis/geometry": "0.3.2",
-    "@vertexvis/poc-graphics-3d": "0.1.1",
     "@vertexvis/stream-api": "0.1.0",
     "@vertexvis/utils": "0.6.1",
     "classnames": "2.2.6",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.0.16",
+    "@vertexvis/frame-streaming-protos": "^0.0.18",
     "@vertexvis/geometry": "0.3.2",
     "@vertexvis/poc-graphics-3d": "0.1.1",
     "@vertexvis/stream-api": "0.1.0",

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -13,6 +13,7 @@ import { Frame } from "./types";
 import { Disposable } from "@vertexvis/utils";
 import { CommandFactory } from "./commands/command";
 import { InteractionHandler } from "./interactions/interactionHandler";
+import { Scene } from "./scenes/scene";
 export namespace Components {
     interface SvgIcon {
     }
@@ -49,10 +50,11 @@ export namespace Components {
           * @returns - A promise containing the disposable to use to deregister the handler.
          */
         "registerInteractionHandler": (interactionHandler: InteractionHandler) => Promise<Disposable>;
+        "scene": () => Promise<Scene>;
         /**
           * A URN of the scene resource to load when the component is mounted in the DOM tree. The specified resource is a URN in the following format:    * `urn:vertexvis:scene:<sceneid>`
          */
-        "scene"?: string;
+        "src"?: string;
         /**
           * An authentication token used to grant access to Vertex.
          */
@@ -113,7 +115,7 @@ declare namespace LocalJSX {
         /**
           * A URN of the scene resource to load when the component is mounted in the DOM tree. The specified resource is a URN in the following format:    * `urn:vertexvis:scene:<sceneid>`
          */
-        "scene"?: string;
+        "src"?: string;
         /**
           * An authentication token used to grant access to Vertex.
          */

--- a/packages/viewer/src/components/viewer/readme.md
+++ b/packages/viewer/src/components/viewer/readme.md
@@ -10,7 +10,7 @@
 | `cameraControls` | `camera-controls` | Enables or disables the default mouse and touch interactions provided by the viewer. Enabled by default.                                                                         | `boolean`          | `true`      |
 | `config`         | `config`          | An object or JSON encoded string that defines configuration settings for the viewer.                                                                                             | `Config \| string` | `undefined` |
 | `configEnv`      | `config-env`      | Sets the default environment for the viewer. This setting is used for auto-configuring network hosts.  Use the `config` property for manually setting hosts.                     | `"platdev"`        | `'platdev'` |
-| `scene`          | `scene`           | A URN of the scene resource to load when the component is mounted in the DOM tree. The specified resource is a URN in the following format:    * `urn:vertexvis:scene:<sceneid>` | `string`           | `undefined` |
+| `src`            | `src`             | A URN of the scene resource to load when the component is mounted in the DOM tree. The specified resource is a URN in the following format:    * `urn:vertexvis:scene:<sceneid>` | `string`           | `undefined` |
 | `token`          | `token`           | An authentication token used to grant access to Vertex.                                                                                                                          | `string`           | `undefined` |
 
 
@@ -82,6 +82,16 @@ the default camera controls provided by the viewer.
 #### Returns
 
 Type: `Promise<Disposable>`
+
+
+
+### `scene() => Promise<Scene>`
+
+
+
+#### Returns
+
+Type: `Promise<Scene>`
 
 
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -317,7 +317,13 @@ export class Viewer {
 
   @Method()
   public async scene(): Promise<Scene> {
-    return new Scene(this.stream);
+    if (this.frameAttributes != null) {
+      return new Scene(this.stream, this.frameAttributes);
+    } else {
+      throw new IllegalStateError(
+        'Cannot retrieve scene. Frame has not been rendered'
+      );
+    }
   }
 
   @Method()
@@ -536,8 +542,7 @@ export class Viewer {
             'Cannot retrieve scene. Frame has not been rendered'
           );
         }
-
-        return this.frameAttributes.scene;
+        return new Scene(this.stream, this.frameAttributes);
       },
       this.tap
     );

--- a/packages/viewer/src/interactions/__tests__/interactionApi.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/interactionApi.spec.ts
@@ -1,6 +1,7 @@
-import { Scene, Camera } from '@vertexvis/poc-graphics-3d';
-import { Dimensions, Point } from '@vertexvis/geometry';
+import { Scene } from '../../scenes';
+import { Point } from '@vertexvis/geometry';
 import { InteractionApi } from '../interactionApi';
+import { frame } from '../../types/__fixtures__';
 
 describe(InteractionApi, () => {
   const ImageStreamingClientMock = jest.fn().mockImplementation(() => {
@@ -11,11 +12,10 @@ describe(InteractionApi, () => {
     };
   });
 
-  const scene = Scene.create(Camera.create(), Dimensions.create(200, 100));
-
-  const sceneProvider = (): Scene.Scene => scene;
   const emit = jest.fn();
   const stream = new ImageStreamingClientMock();
+  const scene = new Scene(stream, frame);
+  const sceneProvider = (): Scene => scene;
 
   let api: InteractionApi;
 

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -1,0 +1,83 @@
+jest.mock('@vertexvis/stream-api');
+
+import { StreamApi } from '@vertexvis/stream-api';
+import { Camera } from '../camera';
+import { FrameCamera } from '../../types';
+import { Vector3, BoundingBox, Angle } from '@vertexvis/geometry';
+
+describe(Camera, () => {
+  const api = new StreamApi();
+  const data = FrameCamera.create({ position: Vector3.create(1, 2, 3) });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe(Camera.prototype.fitToBoundingBox, () => {
+    describe('when aspect ratio < 1', () => {
+      const camera = new Camera(api, 0.5, data);
+
+      it('updates the camera with near and far values scaled relative to the smaller aspect ratio', () => {
+        const updatedCamera = camera.fitToBoundingBox(
+          BoundingBox.create(Vector3.up(), Vector3.down())
+        );
+        expect(updatedCamera.position.x).toBeCloseTo(1.419);
+        expect(updatedCamera.position.y).toBeCloseTo(2.838);
+        expect(updatedCamera.position.z).toBeCloseTo(4.258);
+      });
+    });
+  });
+
+  describe(Camera.prototype.rotateAroundAxis, () => {
+    const camera = new Camera(api, 1, { ...data, position: Vector3.back() });
+
+    it('returns camera with position rotated around axis', () => {
+      const degrees = Angle.toRadians(90);
+      const axis = Vector3.up();
+
+      const result = camera.rotateAroundAxis(degrees, axis);
+      expect(result.position.x).toBeCloseTo(1, 5);
+      expect(result.position.y).toBeCloseTo(0, 5);
+      expect(result.position.z).toBeCloseTo(0, 5);
+    });
+  });
+
+  describe(Camera.prototype.moveBy, () => {
+    const camera = new Camera(api, 1, { ...data, position: Vector3.origin() });
+
+    it('shifts the position and lookat by the given delta', () => {
+      const delta = Vector3.right();
+      const result = camera.moveBy(delta);
+      expect(result).toMatchObject({
+        position: Vector3.right(),
+        lookAt: Vector3.right(),
+      });
+    });
+  });
+
+  describe(Camera.prototype.viewVector, () => {
+    const camera = new Camera(api, 1, { ...data, position: Vector3.forward() });
+
+    it('returns the vector between the position and lookat', () => {
+      const viewVector = camera.viewVector();
+      expect(viewVector).toEqual(Vector3.back());
+    });
+  });
+
+  describe(Camera.prototype.render, () => {
+    const camera = new Camera(api, 1, { ...data, position: Vector3.forward() });
+    (api.replaceCamera as jest.Mock).mockResolvedValue(undefined);
+
+    it('should render using camera', async () => {
+      camera.render();
+      expect(api.replaceCamera).toHaveBeenCalledWith(
+        expect.objectContaining({
+          camera: expect.objectContaining({
+            position: Vector3.forward(),
+          }),
+        })
+      );
+    });
+  });
+});

--- a/packages/viewer/src/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/scene.spec.ts
@@ -1,0 +1,30 @@
+import { Scene } from '../scene';
+import { StreamApi } from '@vertexvis/stream-api';
+import { Dimensions } from '@vertexvis/geometry';
+import { frame } from '../../types/__fixtures__';
+
+describe(Scene, () => {
+  const scene = new Scene(new StreamApi(), frame);
+
+  describe(Scene.prototype.camera, () => {
+    const camera = scene.camera();
+
+    it('should return camera with aspect ratio of current scene', () => {
+      expect(camera.aspectRatio).toBe(2);
+    });
+
+    it('should return camera with latest camera from frame', () => {
+      expect(camera).toMatchObject({
+        position: camera.position,
+        lookAt: camera.lookAt,
+        up: camera.up,
+      });
+    });
+  });
+
+  describe(Scene.prototype.viewport, () => {
+    it('should return dimensions of latest frame', () => {
+      expect(scene.viewport()).toEqual(Dimensions.create(100, 50));
+    });
+  });
+});

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -1,0 +1,156 @@
+import { FrameCamera } from '../types';
+import { StreamApi } from '@vertexvis/stream-api';
+import { Vector3, BoundingBox } from '@vertexvis/geometry';
+
+const PI_OVER_360 = 0.008726646259972;
+
+/**
+ * The `Camera` class contains properties that reflect a world space position, a
+ * view direction (lookAt), and normalized vector representing the up direction.
+ *
+ * It also provides utility methods to update orientation of the camera and
+ * rerender the scene.
+ *
+ * This class in intended to treated as an immutable type. Any mutations return
+ * a new instance of the class with the updated properties.
+ */
+export class Camera implements FrameCamera.FrameCamera {
+  public constructor(
+    private stream: StreamApi,
+    private aspect: number,
+    private data: FrameCamera.FrameCamera
+  ) {}
+
+  /**
+   * Updates the position of the camera such that the given bounding box will
+   * be contained within the camera's view.
+   *
+   * @param boundingBox The bounding box to position to.
+   */
+  public fitToBoundingBox(boundingBox: BoundingBox.BoundingBox): Camera {
+    const radius =
+      1.1 *
+      Vector3.magnitude(
+        Vector3.subtract(boundingBox.max, BoundingBox.center(boundingBox))
+      );
+
+    // height (of scene?) over diameter
+    let hOverD = Math.tan(this.fovY * PI_OVER_360);
+
+    if (this.aspectRatio < 1.0) {
+      hOverD *= this.aspectRatio;
+    }
+
+    const distance = Math.abs(radius / hOverD);
+    const vvec = Vector3.scale(distance, Vector3.normalize(this.viewVector()));
+
+    const lookAt = BoundingBox.center(boundingBox);
+    const position = Vector3.subtract(lookAt, vvec);
+
+    return this.update({ lookAt, position });
+  }
+
+  /**
+   * Shifts the position of the camera by the given delta.
+   *
+   * @param delta The number of units to shift the camera on the X, Y, and Z
+   * axis.
+   */
+  public moveBy(delta: Vector3.Vector3): Camera {
+    return this.update({
+      position: Vector3.add(this.position, delta),
+      lookAt: Vector3.add(this.lookAt, delta),
+    });
+  }
+
+  /**
+   * Queues the rendering for a new frame using this camera. The returned
+   * promise will resolve when a frame is rendered that contains this camera.
+   */
+  public render(): Promise<void> {
+    return this.stream
+      .replaceCamera({ camera: this.data })
+      .then(_ => undefined);
+  }
+
+  /**
+   * Repositions the camera by rotating its current position around an axis.
+   *
+   * @param angleInRadians The angle, in radians, to rotate.
+   * @param axis A normalized vector to rotate around.
+   */
+  public rotateAroundAxis(
+    angleInRadians: number,
+    axis: Vector3.Vector3
+  ): Camera {
+    return this.update({
+      position: Vector3.rotateAboutAxis(
+        angleInRadians,
+        this.position,
+        axis,
+        this.lookAt
+      ),
+      up: Vector3.rotateAboutAxis(
+        angleInRadians,
+        this.up,
+        axis,
+        Vector3.origin()
+      ),
+    });
+  }
+
+  /**
+   * Updates the `position`, `lookAt` and/or `up` vectors of the camera.
+   *
+   * @param camera The values to update the camera to.
+   */
+  public update(camera: Partial<FrameCamera.FrameCamera>): Camera {
+    return new Camera(this.stream, this.aspectRatio, {
+      ...this.data,
+      ...camera,
+    });
+  }
+
+  /**
+   * Returns the view vector for the camera, which is the direction between the
+   * `position` and `lookAt` vectors.
+   */
+  public viewVector(): Vector3.Vector3 {
+    return Vector3.subtract(this.lookAt, this.position);
+  }
+
+  /**
+   * The position vector for the camera, in world space coordinates.
+   */
+  public get position(): Vector3.Vector3 {
+    return { ...this.data.position };
+  }
+
+  /**
+   * A normalized vector representing the up direction.
+   */
+  public get up(): Vector3.Vector3 {
+    return { ...this.data.up };
+  }
+
+  /**
+   * A vector, in world space coordinates, of where the camera is pointed at.
+   */
+  public get lookAt(): Vector3.Vector3 {
+    return { ...this.data.lookAt };
+  }
+
+  /**
+   * The camera's field of view.
+   */
+  public get fovY(): number {
+    return 45;
+  }
+
+  /**
+   * The aspect ratio of the camera.
+   */
+  public get aspectRatio(): number {
+    return this.aspect;
+  }
+}

--- a/packages/viewer/src/scenes/index.ts
+++ b/packages/viewer/src/scenes/index.ts
@@ -1,1 +1,3 @@
+export * from './camera';
+
 export * from './scene';

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -1,5 +1,32 @@
 import { StreamApi } from '@vertexvis/stream-api';
+import { Frame } from '../types';
+import { Camera } from './camera';
+import { Dimensions } from '@vertexvis/geometry';
 
+/**
+ * A class that represents the `Scene` that has been loaded into the viewer. On
+ * it, you can retrieve attributes of the scene, such as the camera. It also
+ * contains methods for updating the scene and performing requests to rerender
+ * the scene.
+ */
 export class Scene {
-  public constructor(private stream: StreamApi) {}
+  public constructor(private stream: StreamApi, private frame: Frame.Frame) {}
+
+  /**
+   * An instance of the current camera of the scene.
+   */
+  public camera(): Camera {
+    return new Camera(
+      this.stream,
+      Dimensions.aspectRatio(this.viewport()),
+      this.frame.sceneAttributes.camera
+    );
+  }
+
+  /**
+   * The current viewport of the scene, in pixels.
+   */
+  public viewport(): Dimensions.Dimensions {
+    return this.frame.imageAttributes.frameDimensions;
+  }
 }

--- a/packages/viewer/src/types/__fixtures__/index.ts
+++ b/packages/viewer/src/types/__fixtures__/index.ts
@@ -1,0 +1,14 @@
+import * as Frame from '../frame';
+import * as FrameCamera from '../frameCamera';
+import { Dimensions, Rectangle } from '@vertexvis/geometry';
+
+export const frame: Frame.Frame = {
+  correlationIds: [],
+  imageAttributes: {
+    frameDimensions: Dimensions.create(100, 50),
+    imageRect: Rectangle.create(0, 0, 100, 50),
+    scaleFactor: 1,
+  },
+  sceneAttributes: { camera: FrameCamera.create() },
+  sequenceNumber: 1,
+};

--- a/packages/viewer/src/types/frame.ts
+++ b/packages/viewer/src/types/frame.ts
@@ -1,36 +1,56 @@
-import { Scene, Camera } from '@vertexvis/poc-graphics-3d';
-import { Dimensions, Vector3 } from '@vertexvis/geometry';
+import { Dimensions, Vector3, Rectangle } from '@vertexvis/geometry';
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
+import * as FrameCamera from './frameCamera';
 
 export interface Frame {
-  operationIds: string[];
-  imageSize: Dimensions.Dimensions;
-  scene: Scene.Scene;
+  correlationIds: string[];
+  imageAttributes: ImageAttributes;
+  sceneAttributes: SceneAttributes;
   sequenceNumber: number;
+}
+
+export interface ImageAttributes {
+  frameDimensions: Dimensions.Dimensions;
+  imageRect: Rectangle.Rectangle;
+  scaleFactor: number;
+}
+
+export interface SceneAttributes {
+  camera: FrameCamera.FrameCamera;
 }
 
 export const fromProto = (
   frameResult: vertexvis.protobuf.stream.IFrameResult
 ): Frame => {
-  const { imageAttributes, sceneAttributes, sequenceNumber } = frameResult;
+  const {
+    frameCorrelationIds,
+    imageAttributes,
+    sceneAttributes,
+    sequenceNumber,
+  } = frameResult;
 
   return {
-    operationIds: [],
-    imageSize: Dimensions.create(
-      imageAttributes.imageRect.width,
-      imageAttributes.imageRect.height
-    ),
-    scene: Scene.create(
-      Camera.create({
-        position: Vector3.create(sceneAttributes.camera.position),
-        upvector: Vector3.create(sceneAttributes.camera.up),
-        lookat: Vector3.create(sceneAttributes.camera.lookAt),
-      }),
-      Dimensions.create(
+    correlationIds: frameCorrelationIds || [],
+    imageAttributes: {
+      frameDimensions: Dimensions.create(
         imageAttributes.frameDimensions.width,
         imageAttributes.frameDimensions.height
-      )
-    ),
+      ),
+      imageRect: Rectangle.create(
+        imageAttributes.imageRect.x,
+        imageAttributes.imageRect.y,
+        imageAttributes.imageRect.width,
+        imageAttributes.imageRect.height
+      ),
+      scaleFactor: imageAttributes.scaleFactor,
+    },
+    sceneAttributes: {
+      camera: FrameCamera.create({
+        position: Vector3.create(sceneAttributes.camera.position),
+        lookAt: Vector3.create(sceneAttributes.camera.lookAt),
+        up: Vector3.create(sceneAttributes.camera.up),
+      }),
+    },
     sequenceNumber,
   };
 };

--- a/packages/viewer/src/types/frameCamera.ts
+++ b/packages/viewer/src/types/frameCamera.ts
@@ -1,0 +1,15 @@
+import { Vector3 } from '@vertexvis/geometry';
+
+export interface FrameCamera {
+  position: Vector3.Vector3;
+  lookAt: Vector3.Vector3;
+  up: Vector3.Vector3;
+}
+
+export function create(data: Partial<FrameCamera> = {}): FrameCamera {
+  return {
+    position: data.position || Vector3.origin(),
+    lookAt: data.lookAt || Vector3.origin(),
+    up: data.up || Vector3.up(),
+  };
+}

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -1,4 +1,5 @@
+import * as FrameCamera from './frameCamera';
 import * as Frame from './frame';
 import * as SceneResource from './sceneResource';
 
-export { Frame, SceneResource };
+export { Frame, FrameCamera, SceneResource };

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -593,10 +593,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@vertexvis%2fframe-streaming-protos/-/frame-streaming-protos-0.0.16.tgz#a534347e5923e78bc2463ef1f6c7598462b097a2"
-  integrity sha512-H1kxC7QZ1kfQt7KvnwRo3oYDNrw7okPXwBrtoDY4tvFkwA+Jkb65X6vmDelA1ZJZKEA16FefI245s9Ti7DGLSA==
+"@vertexvis/frame-streaming-protos@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@vertexvis%2fframe-streaming-protos/-/frame-streaming-protos-0.0.18.tgz#59aab9615da30dec52bf85eee2bcfc6a084fc423"
+  integrity sha512-LRDoQ5WFipFiNbTm9XVTZAjWtHY3FmjH/j/G1MDXDZInV+Ya++s3Bs+09a9sFinafvDVKUfFckyGYepQ8+WE+A==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.1.1":
   version "0.1.1"


### PR DESCRIPTION
## What

This adds operations to the scene to modify its camera. Example usage:

```ts
const scene = await viewer.scene();

// update the position
let camera = scene.camera().update({ position: Vector3.forward() });

// rotate around an axis
camera = camera.rotateAroundAxis(Math.PI / 2, Vector3.up());

// fit to a bounding box
camera = camera.fitToBoundingBox(BoundingBox.create(...));

// finally queue a frame to render
camera.render()
```

## Ticket

https://jira.vertexvis.net/browse/SDK-738

## Test Plan

Unit tests

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
