### PR TITLE
restore websocket.send to sendRequestWithId

### DIFF
--- a/packages/stream-api/src/__tests__/streamApi.spec.ts
+++ b/packages/stream-api/src/__tests__/streamApi.spec.ts
@@ -2,6 +2,7 @@ import {
   WebSocketClient,
   connectMock,
   restoreMocks,
+  sendMock,
   simulateResponse,
   closeMock,
 } from '../__mocks__/webSocketClient';
@@ -39,6 +40,7 @@ describe(StreamApi, () => {
 
     it('should complete promise immediately when no requestId is provided', () => {
       const result = api.beginInteraction();
+      expect(sendMock).toHaveBeenCalled();
       return result;
     });
 
@@ -51,6 +53,7 @@ describe(StreamApi, () => {
         requestId: { value: requestId },
         hitItems: {},
       });
+      expect(sendMock).toHaveBeenCalled();
       return result;
     });
   });

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -104,6 +104,9 @@ export class StreamApi {
           subscription.dispose();
         }
       });
+      this.websocket.send(
+        vertexvis.protobuf.stream.StreamMessage.encode({ request }).finish()
+      );
     });
   }
 


### PR DESCRIPTION
## What

e0e65d93315efe4f4863c496010c63c18be26987 did not include the `websocket.send` in the `sendWithRequestId` method so the hit items does not submit the request and return data

## Ticket

https://jira.vertexvis.net/browse/SDK-735

## Test Plan

see https://github.com/Vertexvis/vertex-web-sdk/pull/14

## Areas of Possible Regression

n/a

## Out of scope changes made in PR

n/a

## Dependencies

n/a
