### PR TITLE
[SDK-740] stream api improvements

### DIFF
--- a/packages/stream-api/src/__tests__/streamApi.spec.ts
+++ b/packages/stream-api/src/__tests__/streamApi.spec.ts
@@ -57,4 +57,24 @@ describe(StreamApi, () => {
       return result;
     });
   });
+
+  describe('replace camera', () => {
+    beforeEach(() => api.connect(url));
+    it('should complete promise with updated camera when requestId provided', () => {
+      const requestId = UUID.create();
+      const result = api.replaceCamera(requestId, {
+        camera: {
+          position: { x: 0, y: 0, z: 0 },
+          lookAt: { x: 0, y: 0, z: 0 },
+          up: { x: 0, y: 0, z: 0 },
+        },
+      });
+      simulateResponse({
+        requestId: { value: requestId },
+        updateCamera: {},
+      });
+      expect(sendMock).toHaveBeenCalled();
+      return result;
+    });
+  });
 });

--- a/packages/stream-api/src/__tests__/streamApi.spec.ts
+++ b/packages/stream-api/src/__tests__/streamApi.spec.ts
@@ -49,7 +49,7 @@ describe(StreamApi, () => {
     beforeEach(() => api.connect(url));
 
     it('should complete promise immediately when no requestId is provided', () => {
-      const result = api.beginInteraction();
+      const result = api.beginInteraction(false);
       expect(sendMock).toHaveBeenCalled();
       return result;
     });

--- a/packages/stream-api/src/__tests__/streamApi.spec.ts
+++ b/packages/stream-api/src/__tests__/streamApi.spec.ts
@@ -8,9 +8,19 @@ import {
 } from '../__mocks__/webSocketClient';
 import { StreamApi } from '../streamApi';
 import { UrlDescriptor } from '../url';
+jest.mock('@vertexvis/utils', () => {
+  const utils = jest.requireActual('@vertexvis/utils');
+  return {
+    ...utils,
+    UUID: {
+      create: jest.fn().mockReturnValue('11111111-0000-1111-1111-111111111111'),
+    },
+  };
+});
 import { UUID } from '@vertexvis/utils';
 
 describe(StreamApi, () => {
+  const requestId = UUID.create();
   jest.setTimeout(100);
   const ws = new WebSocketClient();
   const api = new StreamApi(ws);
@@ -45,10 +55,14 @@ describe(StreamApi, () => {
     });
 
     it('should complete promise when response is received with requestId matching request', () => {
-      const requestId = UUID.create();
-      const result = api.hitItems(requestId, {
-        point: { x: 10, y: 10 },
-      });
+      const result = api
+        .hitItems(
+          {
+            point: { x: 10, y: 10 },
+          },
+          true
+        )
+        .then(resp => expect(resp).toBeDefined());
       simulateResponse({
         requestId: { value: requestId },
         hitItems: {},
@@ -61,14 +75,18 @@ describe(StreamApi, () => {
   describe('replace camera', () => {
     beforeEach(() => api.connect(url));
     it('should complete promise with updated camera when requestId provided', () => {
-      const requestId = UUID.create();
-      const result = api.replaceCamera(requestId, {
-        camera: {
-          position: { x: 0, y: 0, z: 0 },
-          lookAt: { x: 0, y: 0, z: 0 },
-          up: { x: 0, y: 0, z: 0 },
-        },
-      });
+      const result = api
+        .replaceCamera(
+          {
+            camera: {
+              position: { x: 0, y: 0, z: 0 },
+              lookAt: { x: 0, y: 0, z: 0 },
+              up: { x: 0, y: 0, z: 0 },
+            },
+          },
+          true
+        )
+        .then(resp => expect(resp).toBeDefined());
       simulateResponse({
         requestId: { value: requestId },
         updateCamera: {},

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -54,112 +54,72 @@ export class StreamApi {
 
   public startStream(
     data: StartStreamPayload,
-    withResponse: boolean
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse>;
-
-  public startStream(...args: unknown[]): unknown {
-    const request = this.parseArgs<
-      vertexvis.protobuf.stream.StartStreamPayload
-    >(args);
-    return this.sendRequest({
-      requestId: request.requestId,
-      startStream: { ...request.data },
-    });
+    withResponse = true
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse | void> {
+    return this.sendRequest(
+      {
+        startStream: data,
+      },
+      withResponse
+    );
   }
-
-  public beginInteraction(): Promise<void>;
 
   public beginInteraction(
-    withResponse: boolean
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse>;
-
-  public beginInteraction(...args: unknown[]): unknown {
-    const request = this.parseArgs<
-      vertexvis.protobuf.stream.BeginInteractionPayload
-    >(args);
-    return this.sendRequest({
-      requestId: request.requestId,
-      beginInteraction: { ...request.data },
-    });
+    withResponse = true
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse | void> {
+    return this.sendRequest(
+      {
+        beginInteraction: {},
+      },
+      withResponse
+    );
   }
-
-  public replaceCamera({ camera }: ReplaceCameraPayload): Promise<void>;
 
   public replaceCamera(
     { camera }: ReplaceCameraPayload,
-    withResponse: boolean
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse>;
-
-  public replaceCamera(...args: unknown[]): unknown {
-    const request = this.parseArgs<
-      vertexvis.protobuf.stream.IUpdateCameraPayload
-    >(args);
-    const requestPayload = {
-      requestId: request.requestId,
-      updateCamera: { ...request.data },
-    };
-    return this.sendRequest(requestPayload);
+    withResponse = true
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse | void> {
+    return this.sendRequest({ updateCamera: { camera } }, withResponse);
   }
-
-  public hitItems({ point }: HitItemsPayload): Promise<void>;
 
   public hitItems(
     { point }: HitItemsPayload,
-    withResponse: boolean
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse>;
-
-  public hitItems(...args: unknown[]): unknown {
-    const request = this.parseArgs<vertexvis.protobuf.stream.IHitItemsPayload>(
-      args
+    withResponse = true
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse | void> {
+    return this.sendRequest(
+      {
+        hitItems: { point },
+      },
+      withResponse
     );
-    return this.sendRequest({
-      requestId: request.requestId,
-      hitItems: { ...request.data },
-    });
   }
-
-  public endInteraction(): Promise<void>;
 
   public endInteraction(
-    withResponse: boolean
-  ): Promise<vertexvis.protobuf.stream.IBeginInteractionResult>;
-
-  public endInteraction(...args: unknown[]): unknown {
-    const request = this.parseArgs<
-      vertexvis.protobuf.stream.IBeginInteractionPayload
-    >(args);
-    return this.sendRequest({
-      requestId: request.requestId,
-      endInteraction: {},
-    });
-  }
-
-  private parseArgs<T>(args: unknown[]): ParseArgsRequest<T> {
-    // assumption is that withResponse always the last argument
-    const withResponseIndex = args.findIndex(args => typeof args === 'boolean');
-    const dataIndex = args.findIndex(args => typeof args === 'object');
-    const requestId =
-      withResponseIndex > -1 && args[withResponseIndex]
-        ? { value: UUID.create() }
-        : undefined;
-    const data = dataIndex > -1 ? (args[dataIndex] as T) : undefined;
-    const request: ParseArgsRequest<T> = {
-      requestId,
-      data,
-    };
-    return request;
+    withResponse = true
+  ): Promise<vertexvis.protobuf.stream.IBeginInteractionResult | void> {
+    return this.sendRequest(
+      {
+        endInteraction: {},
+      },
+      withResponse
+    );
   }
 
   private sendRequest(
-    request: vertexvis.protobuf.stream.IStreamRequest
+    request: vertexvis.protobuf.stream.IStreamRequest,
+    withResponse: boolean
   ): Promise<void | vertexvis.protobuf.stream.IStreamResponse> {
-    if (request.requestId?.value != null) {
+    if (withResponse) {
+      const requestId = UUID.create();
+      request = {
+        requestId: {
+          value: requestId,
+        },
+        ...request,
+      };
       return new Promise(resolve => {
         const subscription = this.onResponse(response => {
-          if (
-            request.requestId?.value != null &&
-            request.requestId?.value === response.requestId?.value
-          ) {
+          if (requestId === response.requestId?.value) {
             resolve(response);
             subscription.dispose();
           }

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -1,12 +1,17 @@
 import { WebSocketClient } from './webSocketClient';
 import { UrlProvider } from './url';
 import { parseResponse } from './responses';
-import { vertexvis } from '@vertexvis/frame-streaming-protos';
-import { Disposable, EventDispatcher } from '@vertexvis/utils';
+import { vertexvis, google } from '@vertexvis/frame-streaming-protos';
+import { Disposable, EventDispatcher, UUID } from '@vertexvis/utils';
 
 type ResponseHandler = (
   response: vertexvis.protobuf.stream.IStreamResponse
 ) => void;
+
+interface ParseArgsRequest {
+  requestId?: google.protobuf.IStringValue;
+  data: any;
+}
 
 export class StreamApi {
   private onResponseDispatcher = new EventDispatcher<
@@ -38,76 +43,123 @@ export class StreamApi {
 
   public startStream(
     data: vertexvis.protobuf.stream.IStartStreamPayload
-  ): Promise<void> {
+  ): Promise<void>;
+
+  public startStream(
+    requestId: UUID.UUID,
+    data: vertexvis.protobuf.stream.IStartStreamPayload
+  ): Promise<vertexvis.protobuf.stream.IStartStreamResult>;
+
+  public startStream(...args: unknown[]): unknown {
+    const request = this.parseArgs(args);
     return this.sendRequest({
+      ...request.requestId,
       startStream: {
-        ...data,
+        ...request.data,
       },
     });
   }
 
-  public beginInteraction(): Promise<void> {
+  public beginInteraction(): Promise<void>;
+
+  public beginInteraction(
+    requestId: UUID.UUID
+  ): Promise<vertexvis.protobuf.stream.IBeginInteractionResult>;
+
+  public beginInteraction(...args: unknown[]): unknown {
+    const request = this.parseArgs(args);
     return this.sendRequest({
+      ...request.requestId,
       beginInteraction: {},
     });
   }
 
   public replaceCamera({
     camera,
-  }: vertexvis.protobuf.stream.IUpdateCameraPayload): Promise<void> {
-    return this.sendRequest({
+  }: vertexvis.protobuf.stream.IUpdateCameraPayload): Promise<void>;
+
+  public replaceCamera(
+    requestId: UUID.UUID,
+    { camera }: vertexvis.protobuf.stream.IUpdateCameraPayload
+  ): Promise<vertexvis.protobuf.stream.IUpdateCameraResult>;
+
+  public replaceCamera(...args: unknown[]): unknown {
+    const request = this.parseArgs(args);
+    const requestPayload = {
+      ...request.requestId,
       updateCamera: {
-        camera,
+        camera: request.data as vertexvis.protobuf.stream.ICamera,
       },
-    });
+    };
+    return this.sendRequest(requestPayload);
   }
+
+  public hitItems({
+    point,
+  }: vertexvis.protobuf.stream.IHitItemsPayload): Promise<void>;
 
   public hitItems(
     requestId: string,
     { point }: vertexvis.protobuf.stream.IHitItemsPayload
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
-    return this.sendRequestWithId({
-      requestId: {
-        value: requestId,
-      },
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse>;
+
+  public hitItems(...args: unknown[]): unknown {
+    const request = this.parseArgs(args);
+    return this.sendRequest({
+      ...request.requestId,
       hitItems: {
-        point,
+        point: request.data as vertexvis.protobuf.stream.IPoint,
       },
     });
   }
 
-  public endInteraction(): Promise<void> {
+  public endInteraction(): Promise<void>;
+
+  public endInteraction(
+    requestId: UUID.UUID
+  ): Promise<vertexvis.protobuf.stream.IBeginInteractionResult>;
+
+  public endInteraction(...args: unknown[]): unknown {
+    const request = this.parseArgs(args);
     return this.sendRequest({
+      ...request.requestId,
       endInteraction: {},
     });
   }
 
+  private parseArgs(args: unknown[]): ParseArgsRequest {
+    const requestId =
+      typeof args[0] === 'string' ? { requestId: { value: args[0] } } : {};
+    const request = {
+      ...requestId,
+      data: typeof args[0] === 'object' ? args[0] : args[1],
+    };
+    return request;
+  }
+
   private sendRequest(
     request: vertexvis.protobuf.stream.IStreamRequest
-  ): Promise<void> {
+  ): Promise<void | vertexvis.protobuf.stream.IStreamResponse> {
+    if (request.requestId?.value != null) {
+      return new Promise(resolve => {
+        const subscription = this.onResponse(response => {
+          if (
+            request.requestId?.value != null &&
+            request.requestId?.value === response.requestId?.value
+          ) {
+            resolve(response);
+            subscription.dispose();
+          }
+        });
+        this.websocket.send(
+          vertexvis.protobuf.stream.StreamMessage.encode({ request }).finish()
+        );
+      });
+    }
     this.websocket.send(
       vertexvis.protobuf.stream.StreamMessage.encode({ request }).finish()
     );
     return Promise.resolve();
-  }
-
-  private sendRequestWithId(
-    request: vertexvis.protobuf.stream.IStreamRequest
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
-    return new Promise(resolve => {
-      const subscription = this.onResponse(response => {
-        if (
-          request.requestId?.value != null &&
-          request.requestId?.value === response.requestId?.value
-        ) {
-          resolve(response);
-          subscription.dispose();
-        }
-      });
-      this.websocket.send(
-        vertexvis.protobuf.stream.StreamMessage.encode({ request }).finish()
-      );
-    });
   }
 
   private handleMessage(message: MessageEvent): void {

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -50,12 +50,10 @@ export class StreamApi {
     return this.onResponseDispatcher.on(handler);
   }
 
-  public startStream(data: StartStreamPayload): Promise<void>;
-
   public startStream(
     data: StartStreamPayload,
     withResponse = true
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse | void> {
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
     return this.sendRequest(
       {
         startStream: data,
@@ -66,7 +64,7 @@ export class StreamApi {
 
   public beginInteraction(
     withResponse = true
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse | void> {
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
     return this.sendRequest(
       {
         beginInteraction: {},
@@ -78,14 +76,14 @@ export class StreamApi {
   public replaceCamera(
     { camera }: ReplaceCameraPayload,
     withResponse = true
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse | void> {
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
     return this.sendRequest({ updateCamera: { camera } }, withResponse);
   }
 
   public hitItems(
     { point }: HitItemsPayload,
     withResponse = true
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse | void> {
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
     return this.sendRequest(
       {
         hitItems: { point },
@@ -96,7 +94,7 @@ export class StreamApi {
 
   public endInteraction(
     withResponse = true
-  ): Promise<vertexvis.protobuf.stream.IBeginInteractionResult | void> {
+  ): Promise<vertexvis.protobuf.stream.IBeginInteractionResult> {
     return this.sendRequest(
       {
         endInteraction: {},
@@ -108,7 +106,7 @@ export class StreamApi {
   private sendRequest(
     request: vertexvis.protobuf.stream.IStreamRequest,
     withResponse: boolean
-  ): Promise<void | vertexvis.protobuf.stream.IStreamResponse> {
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
     if (withResponse) {
       const requestId = UUID.create();
       request = {
@@ -132,7 +130,7 @@ export class StreamApi {
     this.websocket.send(
       vertexvis.protobuf.stream.StreamMessage.encode({ request }).finish()
     );
-    return Promise.resolve();
+    return Promise.resolve({});
   }
 
   private handleMessage(message: MessageEvent): void {

--- a/packages/stream-api/src/types.ts
+++ b/packages/stream-api/src/types.ts
@@ -1,0 +1,17 @@
+import { DeepRequired } from '@vertexvis/utils';
+import { vertexvis } from '@vertexvis/frame-streaming-protos';
+
+export type StartStreamPayload = DeepRequired<
+  vertexvis.protobuf.stream.IStartStreamPayload,
+  ['frameCorrelationId']
+>;
+
+export type ReplaceCameraPayload = DeepRequired<
+  vertexvis.protobuf.stream.IUpdateCameraPayload,
+  ['frameCorrelationId']
+>;
+
+export type HitItemsPayload = DeepRequired<
+  vertexvis.protobuf.stream.IHitItemsPayload,
+  []
+>;

--- a/packages/utils/src/mappedTypes.ts
+++ b/packages/utils/src/mappedTypes.ts
@@ -15,3 +15,40 @@
 export type DeepPartial<T> = T extends object
   ? { [K in keyof T]?: DeepPartial<T[K]> }
   : T;
+
+/**
+ * A type that recursively makes each property of `T` required.
+ * Optionally excluding a nested path specified by a list of keys.
+ *
+ * @example
+ * type Foo = { a?: { c?: number }, b?: string };
+ * type Bar = { foo: Foo };
+ * type Baz = DeepRequired<Bar, []>; // { foo: { a: { c: number }, b: string } }
+ * type Baz = DeepRequired<Bar, ['a', 'c']>; // { foo: { a: { c?: number }, b: string } }
+ */
+// https://stackoverflow.com/a/57837897
+export type DeepRequired<T, P extends string[]> = T extends object
+  ? Pick<T, Extract<keyof T, P[0]>> &
+      Required<
+        {
+          [K in Exclude<keyof T, P[0]>]: NonNullable<
+            DeepRequired<T[K], ShiftUnion<K, P>>
+          >;
+        }
+      >
+  : T;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type Shift<T extends any[]> = ((...t: T) => any) extends (
+  first: any,
+  ...rest: infer Rest
+) => any
+  ? Rest
+  : never;
+
+type ShiftUnion<P extends PropertyKey, T extends any[]> = T extends any[]
+  ? T[0] extends P
+    ? Shift<T>
+    : never
+  : never;
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/viewer/src/commands/streamCommands.ts
+++ b/packages/viewer/src/commands/streamCommands.ts
@@ -1,10 +1,10 @@
-import { Uri } from '@vertexvis/utils';
-import { CommandContext, Command } from './command';
-import { Disposable } from '@vertexvis/utils';
+import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { Dimensions } from '@vertexvis/geometry';
-import { CommandRegistry } from './commandRegistry';
+import { Disposable, Uri } from '@vertexvis/utils';
 import { UrlDescriptor } from '@vertexvis/stream-api';
 import { InvalidCredentialsError } from '../errors';
+import { CommandContext, Command } from './command';
+import { CommandRegistry } from './commandRegistry';
 
 export interface ConnectOptions {
   sceneId?: string;
@@ -38,7 +38,7 @@ export function connect({ sceneId }: ConnectOptions = {}): Command<
 
 export function startStream(
   dimensions: Dimensions.Dimensions
-): Command<Promise<void>> {
+): Command<Promise<vertexvis.protobuf.stream.IStreamResponse>> {
   return ({ stream }: CommandContext) => {
     return stream.startStream({
       width: dimensions.width,

--- a/packages/viewer/src/scenes/__tests__/raycaster.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/raycaster.spec.ts
@@ -15,10 +15,10 @@ describe(Raycaster, () => {
     it('returns hit items', () => {
       raycaster.hitItems(Point.create(10, 10));
       expect(api.hitItems).toHaveBeenCalledWith(
-        expect.anything(),
         expect.objectContaining({
           point: Point.create(10, 10),
-        })
+        }),
+        true
       );
     });
   });

--- a/packages/viewer/src/scenes/raycaster.ts
+++ b/packages/viewer/src/scenes/raycaster.ts
@@ -17,7 +17,9 @@ export class Raycaster {
    */
   public async hitItems(
     point: Point.Point
-  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
-    return this.stream.hitItems(UUID.create(), { point });
+  ): Promise<vertexvis.protobuf.stream.IHitItemsResult> {
+    return this.stream
+      .hitItems(UUID.create(), { point })
+      .then(resp => resp.hitItems);
   }
 }

--- a/packages/viewer/src/scenes/raycaster.ts
+++ b/packages/viewer/src/scenes/raycaster.ts
@@ -16,7 +16,13 @@ export class Raycaster {
    */
   public async hitItems(
     point: Point.Point
-  ): Promise<vertexvis.protobuf.stream.IHitItemsResult> {
-    return this.stream.hitItems({ point }, true).then(resp => resp.hitItems);
+  ): Promise<vertexvis.protobuf.stream.IHitItemsResult | void> {
+    return this.stream
+      .hitItems({ point }, true)
+      .then(
+        (...args: unknown[]) =>
+          args.length === 1 &&
+          (args[0] as vertexvis.protobuf.stream.IStreamResponse).hitItems
+      );
   }
 }

--- a/packages/viewer/src/scenes/raycaster.ts
+++ b/packages/viewer/src/scenes/raycaster.ts
@@ -1,7 +1,6 @@
 import { StreamApi } from '@vertexvis/stream-api';
 import { Point } from '@vertexvis/geometry';
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
-import { UUID } from '@vertexvis/utils';
 
 /**
  * The `Raycaster` class is here.
@@ -18,8 +17,6 @@ export class Raycaster {
   public async hitItems(
     point: Point.Point
   ): Promise<vertexvis.protobuf.stream.IHitItemsResult> {
-    return this.stream
-      .hitItems(UUID.create(), { point })
-      .then(resp => resp.hitItems);
+    return this.stream.hitItems({ point }, true).then(resp => resp.hitItems);
   }
 }

--- a/packages/viewer/src/scenes/raycaster.ts
+++ b/packages/viewer/src/scenes/raycaster.ts
@@ -17,12 +17,6 @@ export class Raycaster {
   public async hitItems(
     point: Point.Point
   ): Promise<vertexvis.protobuf.stream.IHitItemsResult | void> {
-    return this.stream
-      .hitItems({ point }, true)
-      .then(
-        (...args: unknown[]) =>
-          args.length === 1 &&
-          (args[0] as vertexvis.protobuf.stream.IStreamResponse).hitItems
-      );
+    return this.stream.hitItems({ point }, true).then(resp => resp.hitItems);
   }
 }


### PR DESCRIPTION
## What

- stream-api should be able to tag a request as a fire-and-forget type of requests. In this scenario, a returned promise should resolve immediately without a response.
- stream-api should be able to tag a request as a request-response. In this scenario, a returned promise should resolve with the response it receives from FSS, or with an error.
- stream-api should expose typings of request bodies with optional fields marked as nullable, and required fields marked as non-null.

## Ticket

https://jira.vertexvis.net/browse/SDK-740

## Test Plan

TBD

## Areas of Possible Regression

TBD

## Out of scope changes made in PR

TBD

## Dependencies

n/a
