### PR TITLE
[SDK-791] Support for query by all, and clear operations

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.0.20",
+    "@vertexvis/frame-streaming-protos": "^0.0.21",
     "@vertexvis/geometry": "0.3.2",
     "@vertexvis/stream-api": "0.1.1",
     "@vertexvis/utils": "0.6.1",

--- a/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
+++ b/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
@@ -98,5 +98,42 @@ describe('streamCommands', () => {
         })
       );
     });
+
+    it('sends a create alteration request for all with clear', async () => {
+      const sceneViewId = UUID.create();
+      const builtQuery: QueryExpression = {
+        type: 'all',
+      };
+      const operations: ItemOperation[] = [
+        {
+          type: 'clear',
+        },
+      ];
+      await createSceneAlteration(
+        sceneViewId,
+        builtQuery,
+        operations
+      )({
+        stream,
+        tokenProvider: tokenProvider,
+        config,
+      });
+
+      expect(stream.createSceneAlteration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operations: [
+            {
+              all: {},
+              operationTypes: [
+                {
+                  changeMaterial: {},
+                },
+              ],
+            },
+          ],
+          sceneViewId: { hex: sceneViewId.toString() },
+        })
+      );
+    });
   });
 });

--- a/packages/viewer/src/commands/streamCommandsMapper.ts
+++ b/packages/viewer/src/commands/streamCommandsMapper.ts
@@ -27,6 +27,11 @@ export function buildSceneOperation(
         },
         operationTypes,
       };
+    case 'all':
+      return {
+        all: {},
+        operationTypes,
+      };
     default:
       return {};
   }
@@ -68,6 +73,10 @@ function buildOperationTypes(
               ke: op.color.emissive,
             },
           },
+        };
+      case 'clear':
+        return {
+          changeMaterial: {},
         };
       case 'hide':
         return {

--- a/packages/viewer/src/scenes/__tests__/operations.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/operations.spec.ts
@@ -10,6 +10,13 @@ describe(SceneOperationBuilder, () => {
     expect(definitions).toEqual([{ type: 'hide' }]);
   });
 
+  it('creates a clear operation', () => {
+    const builder = new SceneOperationBuilder();
+    const definitions = builder.clear().build();
+
+    expect(definitions).toEqual([{ type: 'clear' }]);
+  });
+
   it('creates a show operation', () => {
     const builder = new SceneOperationBuilder();
     const definitions = builder.show().build();

--- a/packages/viewer/src/scenes/__tests__/queries.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/queries.spec.ts
@@ -23,6 +23,14 @@ describe(RootQuery, () => {
     });
   });
 
+  it('should support query by all', () => {
+    const itemQueryBuilder = new RootQuery().all();
+
+    expect(itemQueryBuilder.build()).toEqual({
+      type: 'all',
+    });
+  });
+
   it('should support single or multiple queries', () => {
     const itemQueryBuilder = new RootQuery()
       .withItemId(itemId.toString())

--- a/packages/viewer/src/scenes/operations.ts
+++ b/packages/viewer/src/scenes/operations.ts
@@ -8,6 +8,10 @@ interface HideItemOperation {
   type: 'hide';
 }
 
+interface ClearItemOperation {
+  type: 'clear';
+}
+
 export interface ChangeMaterialOperation {
   type: 'change-material';
   color: ColorMaterial;
@@ -16,12 +20,14 @@ export interface ChangeMaterialOperation {
 export type ItemOperation =
   | ShowItemOperation
   | HideItemOperation
-  | ChangeMaterialOperation;
+  | ChangeMaterialOperation
+  | ClearItemOperation;
 
 export interface SceneItemOperations<T> {
   materialOverride(color: ColorMaterial): T;
   show(): T;
   hide(): T;
+  clear(): T;
 }
 
 /**
@@ -58,6 +64,12 @@ export class SceneOperationBuilder
   public hide(): SceneOperationBuilder {
     return new SceneOperationBuilder(
       this.operations.concat([{ type: 'hide' }])
+    );
+  }
+
+  public clear(): SceneOperationBuilder {
+    return new SceneOperationBuilder(
+      this.operations.concat([{ type: 'clear' }])
     );
   }
 }

--- a/packages/viewer/src/scenes/queries.ts
+++ b/packages/viewer/src/scenes/queries.ts
@@ -148,4 +148,16 @@ export class SceneItemQueryExecutor {
       expression
     );
   }
+
+  public all(): SceneItemOperationsExecutor {
+    const allExpresion: QueryExpression = {
+      type: 'all',
+    };
+
+    return new SceneItemOperationsExecutor(
+      this.sceneViewId,
+      this.commands,
+      allExpresion
+    );
+  }
 }

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -55,6 +55,15 @@ export class SceneItemOperationsExecutor
     );
   }
 
+  public clear(): SceneItemOperationsExecutor {
+    return new SceneItemOperationsExecutor(
+      this.sceneViewId,
+      this.commands,
+      this.query,
+      this.builder.clear()
+    );
+  }
+
   public execute(): void {
     const operations = this.builder.build();
     this.commands.execute(

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -593,10 +593,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@vertexvis%2fframe-streaming-protos/-/frame-streaming-protos-0.0.19.tgz#b03b06252a6144d43ccb95e5613eefdeb85bcb83"
-  integrity sha512-xVfNuMGEXOCxak+Ho5ihZeLaIuSx7YsvL5zZgO6Pi+mSblcEFhCil5B+D6zbrc3XZ7nlqAEHSOgs4SIruPEznA==
+"@vertexvis/frame-streaming-protos@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.0.21.tgz#397bd976d203a0e587a9cd0090328c40c7bb5186"
+  integrity sha512-AVYR8nRKOrFqi8Jn9k1hjsFptxihK2YFQQ4ILs0NoGluzGjgjkZ4xuTQXTbFTEhqCBU58WzDMDULG3NcFwPyQA==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.1.1":
   version "0.1.1"


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
Support for query by `.all()` and support to clear materials overrides. 

ie:
```
            await scene
              .items()
              .all()
              .hide()
              .execute();

           await scene
              .items()
              .where(q => q.withItemId(YOUR_ITEM_ID))
              .clear()
              .execute()
```

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-791

## Test Plan

<!-- Describe how your changes should be tested. -->
Ensure that the given operations are applying to all for the all query, and that operations are being cleared on the clear operation

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->
N/A

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->
N/A

## Dependencies

<!-- Link to other PRs or tickets. -->
N/A