### PR TITLE
[SDK-797] Release script changes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
   ],
   "command": {
     "version": {
-      "allowBranch": "master"
+      "allowBranch": "release-temp/*"
     }
   }
 }

--- a/scripts/detect_publish.sh
+++ b/scripts/detect_publish.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+. "$(pwd)"/scripts/utils.sh
+
 # Internal script used by CI to detect if we need to publish packages to NPM.
 
 set -e
 
-version=v`jq -r '.version' ./lerna.json`
+version=v$(get_version)
 
 git fetch --tags
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+set -e
+
+. "$(pwd)"/scripts/utils.sh
+
+if test "$(git rev-parse --abbrev-ref HEAD) != master"
+then
+  echo "Cannot release from non-master branch"
+  exit 1
+fi
+
 # Check if the local repo is clean
 if test -n "$(git status --porcelain --untracked-files=no)"
 then
@@ -14,34 +24,20 @@ then
   exit 1
 fi
 
-# Ensure remote tags are pulled before running `lerna version`
-git pull
-
-remote_tags=`git ls-remote --tags`
 timestamp=$(date "+%s")
-local_branch=release-$timestamp
+local_branch=release-temp/$timestamp
 git checkout -tb $local_branch
 
 npx lerna version --no-push --no-git-tag-version --exact
 
+version="v$(get_version)"
+remote_branch="release/$version"
+
 message="Release Changes\n"
-packages=`cat lerna.json | jq -r '.packages[]'`
-package_directories=($packages)
 
-for package_path in "${package_directories[@]}"; do
-  package_json="$package_path/package.json"
-  package_name=`jq '.name' -r $package_json`
-  package_version=`jq '.version' -r $package_json`
-  message+="$package_name@v$package_version\n"
-done
-
-echo $message > temp.txt
-
-git commit -a --file="temp.txt"
-git push origin $local_branch
+git commit -a -m "Release $version"
+git push origin $local_branch:$remote_branch
 git checkout master
 git branch -D $local_branch
 
-rm temp.txt
-
-echo "Pushed $local_branch. Open a PR and merge to publish the release."
+echo "Pushed $remote_branch. Open a PR and merge to publish the release."

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+function get_version {
+  jq -r '.version' ./lerna.json
+}


### PR DESCRIPTION
## What

Making a couple changes with our release script with the new Lerna process:

* `lerna version` will only run from within a `release-temp/*` branch
* Remove the git commit message. Prior script would include the changed version of each package. Since we're using fixed versioning, all packages should have the same version.
* You can only initiate a release now from the `master` branch.
* Pushed branch has the format: `release/v[major].[minor].[patch]`

## Ticket

https://vertexvis.atlassian.net/browse/SDK-797

## Test Plan

1. Merge
2. Run `yarn release`

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
