### PR TITLE
[SDK-797] Fix release script check to verify master branch

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(pwd)"/scripts/utils.sh
 
-if test "$(git rev-parse --abbrev-ref HEAD) != master"
+if test "$(git rev-parse --abbrev-ref HEAD)" != "master"
 then
   echo "Cannot release from non-master branch"
   exit 1


### PR DESCRIPTION
## What

Fixes a bug with checking that the release script is being run on a master branch.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-797

## Test Plan

N/A

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
