### PR TITLE
[SDK-841] dispose of stream when loading a new stream key

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -288,6 +288,9 @@ export class Viewer {
    */
   @Method()
   public async load(urn: string): Promise<void> {
+    if (this.streamDisposable != null) {
+      this.streamDisposable.dispose();
+    }
     if (this.commands != null && this.dimensions != null) {
       this.resource = LoadableResource.fromUrn(urn);
       await this.connectStreamingClient(this.resource);


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
If a stream disposable is present, and the client has loaded another stream key, we should dispose of the prior stream connection.

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-841

## Test Plan

<!-- Describe how your changes should be tested. -->
Switching models via the `.load()` should not switch back to the old model 

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->
N/A

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->
N/a

## Dependencies

<!-- Link to other PRs or tickets. -->
N/A