### PR TITLE
[SDK-850] Default to prod environment for websdk

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.spec.ts
+++ b/packages/viewer/src/components/viewer/viewer.spec.ts
@@ -25,6 +25,17 @@ describe('vertex-viewer', () => {
 
       expect(viewer.getConfig()).toMatchObject({
         network: {
+          apiHost: 'https://platform.platprod.vertexvis.io',
+          renderingHost: 'wss://stream.platprod.vertexvis.io',
+        },
+      });
+    });
+
+    it('allows for platdev via the config route', async () => {
+      const viewer = await createViewerSpec(`<vertex-viewer></vertex-viewer>`);
+      viewer.configEnv = 'platdev';
+      expect(viewer.getConfig()).toMatchObject({
+        network: {
           apiHost: 'https://platform.platdev.vertexvis.io',
           renderingHost: 'wss://stream.platdev.vertexvis.io',
         },

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -69,7 +69,7 @@ export class Viewer {
    *
    * @see Viewer.config
    */
-  @Prop() public configEnv: Environment = 'platdev';
+  @Prop() public configEnv: Environment = 'platprod';
 
   /**
    * Enables or disables the default mouse and touch interactions provided by

--- a/packages/viewer/src/config/config.ts
+++ b/packages/viewer/src/config/config.ts
@@ -32,7 +32,6 @@ function getEnvironmentConfig(environment: Environment): Config {
   switch (environment) {
     case 'platdev':
       return platdevConfig;
-    case 'platprod':
     default:
       return platprodConfig;
   }

--- a/packages/viewer/src/config/config.ts
+++ b/packages/viewer/src/config/config.ts
@@ -21,12 +21,25 @@ const platdevConfig: Config = {
   },
 };
 
+const platprodConfig: Config = {
+  network: {
+    apiHost: 'https://platform.platprod.vertexvis.io',
+    renderingHost: 'wss://stream.platprod.vertexvis.io',
+  },
+};
+
 function getEnvironmentConfig(environment: Environment): Config {
-  return platdevConfig;
+  switch (environment) {
+    case 'platdev':
+      return platdevConfig;
+    case 'platprod':
+    default:
+      return platprodConfig;
+  }
 }
 
 export function parseConfig(
-  environment: Environment = 'platdev',
+  environment: Environment = 'platprod',
   config?: string | DeepPartial<Config>
 ): Config {
   if (typeof config === 'string') {

--- a/packages/viewer/src/config/environment.ts
+++ b/packages/viewer/src/config/environment.ts
@@ -1,1 +1,1 @@
-export type Environment = 'platdev';
+export type Environment = 'platdev' | 'platprod';


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
Expose production environment for vertex web sdk and use it as the default. 

To leverage the viewer and use a development environment, you will have to pass the env to the viewer. 

```
        const viewer = document.querySelector('#viewer');
        viewer.configEnv = 'platdev';
```

## Test Plan

<!-- Describe how your changes should be tested. -->
Ensure rendering works for platprod and platdev

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->
N/A

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->
N/A

## Dependencies

<!-- Link to other PRs or tickets. -->
N/A