### PR TITLE
[SDK-885] Omit responses for interaction camera requests

### DIFF
--- a/packages/viewer/src/interactions/interactionApi.ts
+++ b/packages/viewer/src/interactions/interactionApi.ts
@@ -69,7 +69,7 @@ export class InteractionApi {
       const scene = this.getScene();
       this.currentCamera = t(this.currentCamera, scene.viewport());
 
-      await this.currentCamera?.render();
+      await this.currentCamera?.render(!this.isInteracting());
     }
   }
 

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -70,13 +70,14 @@ describe(Camera, () => {
     (api.replaceCamera as jest.Mock).mockResolvedValue(undefined);
 
     it('should render using camera', async () => {
-      camera.render();
+      camera.render(true);
       expect(api.replaceCamera).toHaveBeenCalledWith(
         expect.objectContaining({
           camera: expect.objectContaining({
             position: Vector3.forward(),
           }),
-        })
+        }),
+        true
       );
     });
   });

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -66,10 +66,14 @@ export class Camera implements FrameCamera.FrameCamera {
   /**
    * Queues the rendering for a new frame using this camera. The returned
    * promise will resolve when a frame is rendered that contains this camera.
+   *
+   * @param waitResponse Indicates if the returned promise should resolve when
+   *  the server has acknowledged the request. It's recommended to disable
+   *  responses for performance critical situations, such as interactions.
    */
-  public render(): Promise<void> {
+  public render(waitResponse = true): Promise<void> {
     return this.stream
-      .replaceCamera({ camera: this.data })
+      .replaceCamera({ camera: this.data }, waitResponse)
       .then(_ => undefined);
   }
 


### PR DESCRIPTION
## What

Add option to omit responses for camera updates. This will disable a server acknowledgement and is helpful to reduce network congestion for performance sensitive situations, such as interactions.

By default, responses will be omitted for camera interactions.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-885