### PR TITLE
[SDK-896] Update the viewer to use new message for drawing frames

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.0.21",
+    "@vertexvis/frame-streaming-protos": "^0.1.0",
     "@vertexvis/utils": "0.6.1"
   },
   "devDependencies": {

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -10,23 +10,17 @@ import {
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { Disposable, EventDispatcher, UUID } from '@vertexvis/utils';
 
-type ResponseHandler = (
+type ResponseMessageHandler = (
   response: vertexvis.protobuf.stream.IStreamResponse
 ) => void;
 
-type RequestHandler = (
+type RequestMessageHandler = (
   request: vertexvis.protobuf.stream.IStreamRequest
 ) => void;
 
-interface StringValue {
-  value?: string;
-}
-
-interface ParseArgsRequest<T> {
-  requestId?: StringValue;
-  data?: T;
-}
-
+/**
+ * The API client to interact with Vertex's streaming API.
+ */
 export class StreamApi {
   private onResponseDispatcher = new EventDispatcher<
     vertexvis.protobuf.stream.IStreamResponse
@@ -42,8 +36,16 @@ export class StreamApi {
     private websocket: WebSocketClient = new WebSocketClient()
   ) {}
 
-  public async connect(urlProvider: UrlProvider): Promise<Disposable> {
-    await this.websocket.connect(urlProvider);
+  /**
+   * Initiates a websocket connection to Vertex's streaming API. Returns a
+   * promise that resolves once the connection is established and can begin
+   * accepting messages.
+   *
+   * @param descriptor A function that returns a description of how to establish
+   * a WS connection.
+   */
+  public async connect(descriptor: UrlProvider): Promise<Disposable> {
+    await this.websocket.connect(descriptor);
     this.messageSubscription = this.websocket.onMessage(message => {
       this.handleMessage(message);
     });
@@ -51,19 +53,40 @@ export class StreamApi {
     return { dispose: () => this.dispose() };
   }
 
+  /**
+   * Closes any open WS connections and disposes of resources.
+   */
   public dispose(): void {
     this.websocket.close();
     this.messageSubscription?.dispose();
   }
 
-  public onResponse(handler: ResponseHandler): Disposable {
-    return this.onResponseDispatcher.on(handler);
-  }
-
-  public onRequest(handler: RequestHandler): Disposable {
+  /**
+   * Adds a callback that is invoked when the client receives a request from the
+   * server. Returns a `Disposable` that can be used to remove the listener.
+   *
+   * @param handler A handler function.
+   */
+  public onRequest(handler: RequestMessageHandler): Disposable {
     return this.onRequestDispatcher.on(handler);
   }
 
+  /**
+   * Sends a request to initiate a streaming session.
+   *
+   * The payload accepts an optional `frameCorrelationId` that will be sent
+   * back on the frame that is associated to this request. Use `onRequest` to
+   * add a callback that'll be invoked when the server sends a request to draw
+   * the frame.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param data The payload of the request.
+   * @param withResponse Indicates if the server should reply with a response.
+   * Defaults to `true`.
+   */
   public startStream(
     data: StartStreamPayload,
     withResponse = true
@@ -76,6 +99,22 @@ export class StreamApi {
     );
   }
 
+  /**
+   * Sends a request to reconnect to an existing streaming session.
+   *
+   * The payload accepts an optional `frameCorrelationId` that will be sent
+   * back on the frame that is associated to this request. Use `onRequest` to
+   * add a callback that'll be invoked when the server sends a request to draw
+   * the frame.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param data The payload of the request.
+   * @param withResponse Indicates if the server should reply with a response.
+   * Defaults to `true`.
+   */
   public async reconnect(
     data: ReconnectPayload,
     withResponse = true
@@ -88,6 +127,21 @@ export class StreamApi {
     );
   }
 
+  /**
+   * Sends a request to signal to the rendering pipeline that an interaction has
+   * started. The rendering pipeline will use this as a hint to perform more
+   * aggressive rendering optimizations at the expense of rendering quality.
+   * Call `endInteraction` to signal to the rendering pipeline that an
+   * interaction has finished.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param data The payload of the request.
+   * @param withResponse Indicates if the server should reply with a response.
+   * Defaults to `true`.
+   */
   public beginInteraction(
     withResponse = true
   ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
@@ -99,6 +153,22 @@ export class StreamApi {
     );
   }
 
+  /**
+   * Sends a request to update the position of the scene's camera.
+   *
+   * The payload accepts an optional `frameCorrelationId` that will be sent
+   * back on the frame that is associated to this request. Use `onRequest` to
+   * add a callback that'll be invoked when the server sends a request to draw
+   * the frame.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param data The payload of the request.
+   * @param withResponse Indicates if the server should reply with a response.
+   * Defaults to `true`.
+   */
   public replaceCamera(
     { camera }: ReplaceCameraPayload,
     withResponse = true
@@ -106,6 +176,17 @@ export class StreamApi {
     return this.sendRequest({ updateCamera: { camera } }, withResponse);
   }
 
+  /**
+   * Sends a request to perform hit detection.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param data The payload of the request.
+   * @param withResponse Indicates if the server should reply with a response.
+   * Defaults to `true`.
+   */
   public hitItems(
     { point }: HitItemsPayload,
     withResponse = true
@@ -118,18 +199,42 @@ export class StreamApi {
     );
   }
 
+  /**
+   * Sends a request to perform an alteration to a scene. Alterations include
+   * changing item visibility and changing the materials of items.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param data The payload of the request.
+   * @param withResponse Indicates if the server should reply with a response.
+   * Defaults to `true`.
+   */
   public createSceneAlteration(
-    request: vertexvis.protobuf.stream.ICreateSceneAlterationRequest,
+    payload: vertexvis.protobuf.stream.ICreateSceneAlterationPayload,
     withResponse = true
   ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
     return this.sendRequest(
       {
-        createSceneAlteration: request,
+        createSceneAlteration: payload,
       },
       withResponse
     );
   }
 
+  /**
+   * Sends a request to tell the rendering pipeline that an interaction has
+   * ended.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param data The payload of the request.
+   * @param withResponse Indicates if the server should reply with a response.
+   * Defaults to `true`.
+   */
   public endInteraction(
     withResponse = true
   ): Promise<vertexvis.protobuf.stream.IBeginInteractionResult> {
@@ -174,12 +279,16 @@ export class StreamApi {
   private handleMessage(message: MessageEvent): void {
     const messagePayload = parseStreamMessage(message.data);
 
-    if (messagePayload != null && messagePayload.response != null) {
+    if (messagePayload?.response != null) {
       this.onResponseDispatcher.emit(messagePayload.response);
     }
 
-    if (messagePayload != null && messagePayload.request != null) {
+    if (messagePayload?.request != null) {
       this.onRequestDispatcher.emit(messagePayload.request);
     }
+  }
+
+  private onResponse(handler: ResponseMessageHandler): Disposable {
+    return this.onResponseDispatcher.on(handler);
   }
 }

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -573,10 +573,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.0.21.tgz#397bd976d203a0e587a9cd0090328c40c7bb5186"
-  integrity sha512-AVYR8nRKOrFqi8Jn9k1hjsFptxihK2YFQQ4ILs0NoGluzGjgjkZ4xuTQXTbFTEhqCBU58WzDMDULG3NcFwPyQA==
+"@vertexvis/frame-streaming-protos@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.1.0.tgz#963baa83c1bb9378438407ed49a2732feec13180"
+  integrity sha512-7t3h3uBQtKI8KJfVpZS/vZi1DT4ZrpOcoCtXq5KDj/CK/Brz2ztrl0eeOZ5UzfHF0UNBVrPrRd27/vjxtDXQpw==
 
 "@vertexvis/jest-config-vertexvis@0.4.4":
   version "0.4.4"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.0.21",
+    "@vertexvis/frame-streaming-protos": "^0.1.0",
     "@vertexvis/geometry": "0.6.1",
     "@vertexvis/stream-api": "0.6.1",
     "@vertexvis/utils": "0.6.1",

--- a/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
+++ b/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
@@ -16,7 +16,7 @@ describe('streamCommands', () => {
     it('starts a stream with the provided dimensions', async () => {
       await startStream(dimensions)({ stream, config });
 
-      expect(stream.startStream).toHaveBeenCalledWith({ ...dimensions });
+      expect(stream.startStream).toHaveBeenCalledWith({ dimensions });
     });
   });
 

--- a/packages/viewer/src/commands/streamCommands.ts
+++ b/packages/viewer/src/commands/streamCommands.ts
@@ -44,10 +44,7 @@ export function startStream(
   dimensions: Dimensions.Dimensions
 ): Command<Promise<vertexvis.protobuf.stream.IStreamResponse>> {
   return ({ stream }: CommandContext) => {
-    return stream.startStream({
-      width: dimensions.width,
-      height: dimensions.height,
-    });
+    return stream.startStream({ dimensions });
   };
 }
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -387,21 +387,12 @@ export class Viewer {
     throw new UnsupportedOperationError('Unsupported operation.');
   }
 
-  /**
-   * @deprecated responses from the stream can be handled directly.
-   */
-  private handleStreamResponse(
-    response: vertexvis.protobuf.stream.IStreamResponse
-  ): void {
-    if (response.frame != null) {
-      this.drawFrame(response.frame);
-    }
-  }
-
   private async handleStreamRequest(
     request: vertexvis.protobuf.stream.IStreamRequest
   ): Promise<void> {
-    if (request.gracefulReconnection != null) {
+    if (request.drawFrame != null) {
+      this.drawFrame(request.drawFrame);
+    } else if (request.gracefulReconnection != null) {
       await this.reconnectStreamingClient(
         this.resource,
         request.gracefulReconnection.streamId.hex
@@ -410,7 +401,7 @@ export class Viewer {
   }
 
   private async drawFrame(
-    frame: vertexvis.protobuf.stream.IFrameResult
+    frame: vertexvis.protobuf.stream.IDrawFramePayload
   ): Promise<void> {
     const frameNumber = this.lastFrameNumber + 1;
 
@@ -537,8 +528,6 @@ export class Viewer {
   }
 
   private setupStreamListeners(): void {
-    this.stream.onResponse(response => this.handleStreamResponse(response));
-
     this.stream.onRequest(request => this.handleStreamRequest(request));
   }
 

--- a/packages/viewer/src/testing/frameStreamingClient.ts
+++ b/packages/viewer/src/testing/frameStreamingClient.ts
@@ -13,11 +13,12 @@ function mockConnect(): jest.Mock<any, any> {
 }
 
 function mockStartStream(): jest.Mock<any, any> {
-  const frameResponse: vertexvis.protobuf.stream.IFrameResult = {
-    image: new Uint8Array(100),
+  const result: vertexvis.protobuf.stream.IStartStreamResult = {
+    streamId: { hex: 'stream-id' },
+    sceneViewId: { hex: 'scene-view-id' },
   };
 
-  return jest.fn().mockResolvedValue(frameResponse);
+  return jest.fn().mockResolvedValue(result);
 }
 
 function mockCreateSceneAlteration(): jest.Mock<any, any> {

--- a/packages/viewer/src/types/frame.ts
+++ b/packages/viewer/src/types/frame.ts
@@ -20,14 +20,14 @@ export interface SceneAttributes {
 }
 
 export const fromProto = (
-  frameResult: vertexvis.protobuf.stream.IFrameResult
+  payload: vertexvis.protobuf.stream.IDrawFramePayload
 ): Frame => {
   const {
     frameCorrelationIds,
     imageAttributes,
     sceneAttributes,
     sequenceNumber,
-  } = frameResult;
+  } = payload;
 
   return {
     correlationIds: frameCorrelationIds || [],

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -598,10 +598,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.0.21.tgz#397bd976d203a0e587a9cd0090328c40c7bb5186"
-  integrity sha512-AVYR8nRKOrFqi8Jn9k1hjsFptxihK2YFQQ4ILs0NoGluzGjgjkZ4xuTQXTbFTEhqCBU58WzDMDULG3NcFwPyQA==
+"@vertexvis/frame-streaming-protos@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.1.0.tgz#963baa83c1bb9378438407ed49a2732feec13180"
+  integrity sha512-7t3h3uBQtKI8KJfVpZS/vZi1DT4ZrpOcoCtXq5KDj/CK/Brz2ztrl0eeOZ5UzfHF0UNBVrPrRd27/vjxtDXQpw==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.1.2":
   version "0.1.2"


### PR DESCRIPTION
## What

Includes updates for breaking protobuf changes that were introduced as part of https://github.com/Vertexvis/frame-streaming-protos/pull/34. 

## Ticket

https://vertexvis.atlassian.net/browse/SDK-896

## Test Plan

Verify that models are rendered in the viewer.

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
