### PR TITLE
[SDK-898] Generate frames using the background color of the viewer

### DIFF
--- a/packages/stream-api/jest.config.js
+++ b/packages/stream-api/jest.config.js
@@ -4,10 +4,10 @@ module.exports = {
   ...jestConfig,
   coverageThreshold: {
     global: {
-      branches: 30,
-      functions: 40,
-      lines: 50,
-      statements: 50,
+      branches: 40,
+      functions: 45,
+      lines: 55,
+      statements: 55,
     },
   },
 };

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.1.0",
+    "@vertexvis/frame-streaming-protos": "^0.1.3",
     "@vertexvis/utils": "0.7.0"
   },
   "devDependencies": {

--- a/packages/stream-api/src/__tests__/streamApi.spec.ts
+++ b/packages/stream-api/src/__tests__/streamApi.spec.ts
@@ -7,7 +7,6 @@ import {
   closeMock,
 } from '../__mocks__/webSocketClient';
 import { StreamApi } from '../streamApi';
-import { UrlDescriptor } from '../url';
 jest.mock('@vertexvis/utils', () => {
   const utils = jest.requireActual('@vertexvis/utils');
   return {
@@ -24,9 +23,7 @@ describe(StreamApi, () => {
   jest.setTimeout(100);
   const ws = new WebSocketClient();
   const streamApi = new StreamApi(ws);
-  const url = (): UrlDescriptor => ({
-    url: 'ws://foo.com',
-  });
+  const descriptor = { url: 'ws://foo.com' };
 
   beforeEach(() => {
     restoreMocks();
@@ -34,29 +31,24 @@ describe(StreamApi, () => {
 
   describe('connect', () => {
     it('should open a ws connection', () => {
-      streamApi.connect(url);
+      streamApi.connect(descriptor);
       expect(connectMock).toHaveBeenCalled();
     });
 
     it('should close ws when returned disposable is called', async () => {
-      const disposable = await streamApi.connect(url);
+      const disposable = await streamApi.connect(descriptor);
       disposable.dispose();
       expect(closeMock).toHaveBeenCalled();
     });
   });
 
   describe('reconnect', () => {
-    beforeEach(() => streamApi.connect(url));
+    beforeEach(() => streamApi.connect(descriptor));
 
     it('should open a ws connection', () => {
       const reconnectPayload = {
-        streamId: {
-          hex: UUID.create(),
-        },
-        dimensions: {
-          width: 500,
-          height: 500,
-        },
+        streamId: { hex: UUID.create() },
+        dimensions: { width: 500, height: 500 },
       };
       streamApi.reconnect(reconnectPayload);
       expect(connectMock).toHaveBeenCalled();
@@ -64,13 +56,8 @@ describe(StreamApi, () => {
 
     it('should throw if the url provider is not set', async () => {
       const reconnectPayload = {
-        streamId: {
-          hex: UUID.create(),
-        },
-        dimensions: {
-          width: 500,
-          height: 500,
-        },
+        streamId: { hex: UUID.create() },
+        dimensions: { width: 500, height: 500 },
       };
       const newStreamApi = new StreamApi(ws);
 
@@ -85,7 +72,7 @@ describe(StreamApi, () => {
   });
 
   describe('send createSceneAlteration', () => {
-    beforeEach(() => streamApi.connect(url));
+    beforeEach(() => streamApi.connect(descriptor));
 
     it('should send a request with Id', () => {
       const request = {};
@@ -95,7 +82,7 @@ describe(StreamApi, () => {
   });
 
   describe('send request', () => {
-    beforeEach(() => streamApi.connect(url));
+    beforeEach(() => streamApi.connect(descriptor));
 
     it('should complete promise immediately when no requestId is provided', () => {
       const result = streamApi.beginInteraction(false);
@@ -122,7 +109,7 @@ describe(StreamApi, () => {
   });
 
   describe('replace camera', () => {
-    beforeEach(() => streamApi.connect(url));
+    beforeEach(() => streamApi.connect(descriptor));
     it('should complete promise with updated camera when requestId provided', () => {
       const result = streamApi
         .replaceCamera(

--- a/packages/stream-api/src/connection.ts
+++ b/packages/stream-api/src/connection.ts
@@ -1,0 +1,4 @@
+export interface ConnectionDescriptor {
+  url: string;
+  protocols?: string | string[];
+}

--- a/packages/stream-api/src/index.ts
+++ b/packages/stream-api/src/index.ts
@@ -2,4 +2,4 @@ export * from './streamApi';
 
 export * from './webSocketClient';
 
-export * from './url';
+export * from './connection';

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -1,5 +1,5 @@
 import { WebSocketClient } from './webSocketClient';
-import { UrlProvider } from './url';
+import { ConnectionDescriptor } from './connection';
 import { parseStreamMessage } from './responses';
 import {
   HitItemsPayload,
@@ -44,7 +44,7 @@ export class StreamApi {
    * @param descriptor A function that returns a description of how to establish
    * a WS connection.
    */
-  public async connect(descriptor: UrlProvider): Promise<Disposable> {
+  public async connect(descriptor: ConnectionDescriptor): Promise<Disposable> {
     await this.websocket.connect(descriptor);
     this.messageSubscription = this.websocket.onMessage(message => {
       this.handleMessage(message);

--- a/packages/stream-api/src/types.ts
+++ b/packages/stream-api/src/types.ts
@@ -3,12 +3,12 @@ import { vertexvis } from '@vertexvis/frame-streaming-protos';
 
 export type StartStreamPayload = DeepRequired<
   vertexvis.protobuf.stream.IStartStreamPayload,
-  ['frameCorrelationId']
+  ['frameCorrelationId'] | ['frameBackgroundColor']
 >;
 
 export type ReconnectPayload = DeepRequired<
   vertexvis.protobuf.stream.IReconnectPayload,
-  ['frameCorrelationId']
+  ['frameCorrelationId'] | ['frameBackgroundColor']
 >;
 
 export type ReplaceCameraPayload = DeepRequired<

--- a/packages/stream-api/src/url.ts
+++ b/packages/stream-api/src/url.ts
@@ -1,6 +1,0 @@
-export interface UrlDescriptor {
-  url: string;
-  protocols?: string | string[];
-}
-
-export type UrlProvider = () => UrlDescriptor;

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -573,10 +573,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.1.0.tgz#963baa83c1bb9378438407ed49a2732feec13180"
-  integrity sha512-7t3h3uBQtKI8KJfVpZS/vZi1DT4ZrpOcoCtXq5KDj/CK/Brz2ztrl0eeOZ5UzfHF0UNBVrPrRd27/vjxtDXQpw==
+"@vertexvis/frame-streaming-protos@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.1.3.tgz#9aad2e350b30a595257d50ab858fac3c3af6a6e6"
+  integrity sha512-zGwdASqAnbsUYniQuuxRZz0U8zi5JcCz1OLJT8s491yAe2mtPdP7PwF36Osf3KeEfijXxUv0AHc7IW4VbBdqJw==
 
 "@vertexvis/jest-config-vertexvis@0.4.4":
   version "0.4.4"

--- a/packages/utils/src/mappedTypes.ts
+++ b/packages/utils/src/mappedTypes.ts
@@ -25,6 +25,7 @@ export type DeepPartial<T> = T extends object
  * type Bar = { foo: Foo };
  * type Baz = DeepRequired<Bar, []>; // { foo: { a: { c: number }, b: string } }
  * type Baz = DeepRequired<Bar, ['a', 'c']>; // { foo: { a: { c?: number }, b: string } }
+ * type Baz = DeepRequired<Bar, ['a'] | ['b']>; // { foo: { a: { c?: number }, b?: string } }
  */
 // https://stackoverflow.com/a/57837897
 export type DeepRequired<T, P extends string[]> = T extends object

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.1.0",
+    "@vertexvis/frame-streaming-protos": "^0.1.3",
     "@vertexvis/geometry": "0.7.0",
     "@vertexvis/stream-api": "0.7.0",
     "@vertexvis/utils": "0.7.0",

--- a/packages/viewer/src/__mocks__/@vertexvis/stream-api.ts
+++ b/packages/viewer/src/__mocks__/@vertexvis/stream-api.ts
@@ -1,0 +1,5 @@
+const api = jest.genMockFromModule('@vertexvis/stream-api') as any;
+
+export const StreamApi = api.StreamApi;
+
+export const WebSocketClient = api.WebSocketClient;

--- a/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
+++ b/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
@@ -1,5 +1,4 @@
-import { startStream, createSceneAlteration } from '../streamCommands';
-import { Dimensions } from '@vertexvis/geometry';
+import { createSceneAlteration } from '../streamCommands';
 import { createFrameStreamingClientMock } from '../../testing';
 import { defaultConfig, Config } from '../../config/config';
 import { UUID } from '@vertexvis/utils';
@@ -10,15 +9,6 @@ import { fromHex } from '../../scenes/colorMaterial';
 describe('streamCommands', () => {
   const stream = createFrameStreamingClientMock();
   const config = defaultConfig as Config;
-  const dimensions = Dimensions.create(100, 100);
-
-  describe('startStream', () => {
-    it('starts a stream with the provided dimensions', async () => {
-      await startStream(dimensions)({ stream, config });
-
-      expect(stream.startStream).toHaveBeenCalledWith({ dimensions });
-    });
-  });
 
   describe('createSceneAlteration', () => {
     it('sends a create alteration request with the given params', async () => {

--- a/packages/viewer/src/commands/streamCommands.ts
+++ b/packages/viewer/src/commands/streamCommands.ts
@@ -1,7 +1,5 @@
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
-import { Dimensions } from '@vertexvis/geometry';
 import { Disposable, Uri, UUID } from '@vertexvis/utils';
-import { UrlDescriptor } from '@vertexvis/stream-api';
 import { CommandContext, Command } from './command';
 import { CommandRegistry } from './commandRegistry';
 import { ItemOperation } from '../scenes/operations';
@@ -19,32 +17,22 @@ export function connect({
 }: ConnectOptions): Command<Promise<Disposable>> {
   return ({ stream, config }) => {
     if (resource.type === 'stream-key') {
-      const urlProvider = (): UrlDescriptor => {
-        const uri = Uri.appendPath(
-          `/stream-keys/${resource.id}/session`,
-          Uri.parse(config.network.renderingHost)
-        );
+      const uri = Uri.appendPath(
+        `/stream-keys/${resource.id}/session`,
+        Uri.parse(config.network.renderingHost)
+      );
 
-        return {
-          url: Uri.toString(uri),
-          protocols: ['ws.vertexvis.com'],
-        };
+      const descriptor = {
+        url: Uri.toString(uri),
+        protocols: ['ws.vertexvis.com'],
       };
 
-      return stream.connect(urlProvider);
+      return stream.connect(descriptor);
     } else {
       throw new InvalidCredentialsError(
         `Cannot load resource. Invalid type ${resource.type}`
       );
     }
-  };
-}
-
-export function startStream(
-  dimensions: Dimensions.Dimensions
-): Command<Promise<vertexvis.protobuf.stream.IStreamResponse>> {
-  return ({ stream }: CommandContext) => {
-    return stream.startStream({ dimensions });
   };
 }
 
@@ -68,6 +56,5 @@ export function createSceneAlteration(
 
 export function registerCommands(commands: CommandRegistry): void {
   commands.register('stream.connect', connect);
-  commands.register('stream.start', startStream);
   commands.register('stream.createSceneAlteration', createSceneAlteration);
 }

--- a/packages/viewer/src/components/viewer/__mocks__/utils.ts
+++ b/packages/viewer/src/components/viewer/__mocks__/utils.ts
@@ -1,0 +1,3 @@
+export const getElementBackgroundColor = jest.fn();
+
+export const getElementBoundingClientRect = jest.fn();

--- a/packages/viewer/src/components/viewer/utils.ts
+++ b/packages/viewer/src/components/viewer/utils.ts
@@ -1,0 +1,12 @@
+import { Color } from '@vertexvis/utils';
+
+export function getElementBackgroundColor(
+  element: HTMLElement
+): Color.Color | undefined {
+  const styles = window.getComputedStyle(element);
+  return Color.fromCss(styles.backgroundColor);
+}
+
+export function getElementBoundingClientRect(element: HTMLElement): ClientRect {
+  return element.getBoundingClientRect();
+}

--- a/packages/viewer/src/components/viewer/viewer.css
+++ b/packages/viewer/src/components/viewer/viewer.css
@@ -1,14 +1,14 @@
 :host {
   /**
-   * @prop --canvas-background: The background color of the rendered image. Defaults to
-   * #FFFFFF.
+   * @prop --image-background: The background color of the rendered image.
+   * Defaults to `--viewer-background`.
    */
-  --canvas-background: var(--canvas-background);
+  --image-background: var(--image-background);
 
   /**
-   * @prop --viewer-background: The background color of the viewer bounds. This will be visible 
-   * if the size of the viewer becomes greater than the maximum image size of 1280x1280. 
-   * Defaults to #FFFFFF.
+   * @prop --viewer-background: The background color of the viewer component.
+   * This will be visible if the size of the viewer becomes greater than the
+   * maximum image size of 1280x1280. Defaults to #FFFFFF.
    */
   --viewer-background: var(--viewer-background);
 
@@ -25,7 +25,7 @@
   width: 100%;
   height: 100%;
   position: relative;
-  background: var(--canvas-background, #ffffff);
+  background: var(--image-background, var(--viewer-background, #ffffff));
 }
 
 .viewer-container {

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -598,10 +598,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.1.0.tgz#963baa83c1bb9378438407ed49a2732feec13180"
-  integrity sha512-7t3h3uBQtKI8KJfVpZS/vZi1DT4ZrpOcoCtXq5KDj/CK/Brz2ztrl0eeOZ5UzfHF0UNBVrPrRd27/vjxtDXQpw==
+"@vertexvis/frame-streaming-protos@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.1.3.tgz#9aad2e350b30a595257d50ab858fac3c3af6a6e6"
+  integrity sha512-zGwdASqAnbsUYniQuuxRZz0U8zi5JcCz1OLJT8s491yAe2mtPdP7PwF36Osf3KeEfijXxUv0AHc7IW4VbBdqJw==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.1.2":
   version "0.1.2"


### PR DESCRIPTION
## What

Generates JPEG frames using the background color of the viewer. The viewer background color can be set using the `--viewer-background` CSS variable:

```css
.viewer {
  --viewer-background: red;
}
```

## Ticket

https://vertexvis.atlassian.net/browse/SDK-898

## Test Plan

You shouldn't see a light gray background with rendered frames.

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

https://github.com/Vertexvis/frame-streaming-service/pull/83
