### PR TITLE
[SDK-796] Support for Transactional Queries

### DIFF
--- a/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
+++ b/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
@@ -5,75 +5,82 @@ import { UUID } from '@vertexvis/utils';
 import { QueryExpression } from '../../scenes/queries';
 import { ItemOperation } from '../../scenes/operations';
 import { fromHex } from '../../scenes/colorMaterial';
+import { QueryOperation } from '../../scenes';
 
 describe('streamCommands', () => {
   const stream = createFrameStreamingClientMock();
   const config = defaultConfig as Config;
+  const suppliedId = 'some-suppliedId';
+  const sceneItemId: UUID.UUID = UUID.create();
+  const sceneViewId = UUID.create();
+
+  const builtQueryForPart: QueryExpression = {
+    type: 'and',
+    expressions: [
+      {
+        type: 'supplied-id',
+        value: suppliedId,
+      },
+      {
+        type: 'item-id',
+        value: sceneItemId.toString(),
+      },
+    ],
+  };
+  const operationsForShowAndChangeColor: ItemOperation[] = [
+    {
+      type: 'show',
+    },
+    {
+      type: 'change-material',
+      color: fromHex('#FF00AA'),
+    },
+  ];
+
+  const expectedOperationResult = 
+  {
+    and: {
+      queries: [
+        { sceneItemQuery: { suppliedId: 'some-suppliedId' } },
+        {
+          sceneItemQuery: {
+            id: { hex: sceneItemId.toString() },
+          },
+        },
+      ],
+    },
+    operationTypes: [
+      { changeVisibility: { visible: true } },
+      {
+        changeMaterial: {
+          material: {
+            d: 100,
+            ka: { r: 0, g: 0, b: 0, a: 0 },
+            kd: { a: 255, b: 170, g: 0, r: 255 },
+            ke: { r: 0, g: 0, b: 0, a: 0 },
+            ks: { r: 0, g: 0, b: 0, a: 0 },
+            ns: 10,
+          },
+        },
+      },
+    ],
+  }
+
+  const queryOperations: QueryOperation[] = [{
+    query: builtQueryForPart,
+    operations: operationsForShowAndChangeColor,
+  }]
 
   describe('createSceneAlteration', () => {
     it('sends a create alteration request with the given params', async () => {
-      const sceneViewId = UUID.create();
-      const sceneItemId: UUID.UUID = UUID.create();
-      const suppliedId = 'some-suppliedId';
-      const builtQuery: QueryExpression = {
-        type: 'and',
-        expressions: [
-          {
-            type: 'supplied-id',
-            value: suppliedId,
-          },
-          {
-            type: 'item-id',
-            value: sceneItemId.toString(),
-          },
-        ],
-      };
-      const operations: ItemOperation[] = [
-        {
-          type: 'show',
-        },
-        {
-          type: 'change-material',
-          color: fromHex('#FF00AA'),
-        },
-      ];
       await createSceneAlteration(
         sceneViewId,
-        builtQuery,
-        operations
+        queryOperations
       )({ stream, config });
 
       expect(stream.createSceneAlteration).toHaveBeenCalledWith(
         expect.objectContaining({
-          operations: [
-            {
-              and: {
-                queries: [
-                  { sceneItemQuery: { suppliedId: 'some-suppliedId' } },
-                  {
-                    sceneItemQuery: {
-                      id: { hex: sceneItemId.toString() },
-                    },
-                  },
-                ],
-              },
-              operationTypes: [
-                { changeVisibility: { visible: true } },
-                {
-                  changeMaterial: {
-                    material: {
-                      d: 100,
-                      ka: { r: 0, g: 0, b: 0, a: 0 },
-                      kd: { a: 255, b: 170, g: 0, r: 255 },
-                      ke: { r: 0, g: 0, b: 0, a: 0 },
-                      ks: { r: 0, g: 0, b: 0, a: 0 },
-                      ns: 10,
-                    },
-                  },
-                },
-              ],
-            },
-          ],
+          operations: [expectedOperationResult],
           sceneViewId: { hex: sceneViewId.toString() },
         })
       );
@@ -81,7 +88,7 @@ describe('streamCommands', () => {
 
     it('sends a create alteration request for all with clear', async () => {
       const sceneViewId = UUID.create();
-      const builtQuery: QueryExpression = {
+      const query: QueryExpression = {
         type: 'all',
       };
       const operations: ItemOperation[] = [
@@ -89,10 +96,14 @@ describe('streamCommands', () => {
           type: 'clear-override',
         },
       ];
+      const queryOperations: QueryOperation[] = [{
+        query,
+        operations,
+      }]
+
       await createSceneAlteration(
         sceneViewId,
-        builtQuery,
-        operations
+        queryOperations
       )({ stream, config });
 
       expect(stream.createSceneAlteration).toHaveBeenCalledWith(
@@ -106,6 +117,51 @@ describe('streamCommands', () => {
                 },
               ],
             },
+          ],
+          sceneViewId: { hex: sceneViewId.toString() },
+        })
+      );
+    });
+
+    it('should support sending multiple operations in one request', async () => {
+      const sceneViewId = UUID.create();
+      const builtQueryA: QueryExpression = {
+        type: 'all',
+      };
+      const operationsA: ItemOperation[] = [
+        {
+          type: 'clear-override',
+        },
+      ];
+
+      const queryOperations: QueryOperation[] = [
+        {
+          query: builtQueryA,
+          operations: operationsA,
+        },
+        {
+          query: builtQueryForPart,
+          operations: operationsForShowAndChangeColor
+        }
+      ]
+
+      await createSceneAlteration(
+        sceneViewId,
+        queryOperations
+      )({ stream, config });
+
+      expect(stream.createSceneAlteration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operations: [
+            {
+              all: {},
+              operationTypes: [
+                {
+                  changeMaterial: {},
+                },
+              ],
+            },
+            expectedOperationResult
           ],
           sceneViewId: { hex: sceneViewId.toString() },
         })

--- a/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
+++ b/packages/viewer/src/commands/__tests__/streamCommands.spec.ts
@@ -37,8 +37,7 @@ describe('streamCommands', () => {
     },
   ];
 
-  const expectedOperationResult = 
-  {
+  const expectedOperationResult = {
     and: {
       queries: [
         { sceneItemQuery: { suppliedId: 'some-suppliedId' } },
@@ -64,12 +63,14 @@ describe('streamCommands', () => {
         },
       },
     ],
-  }
+  };
 
-  const queryOperations: QueryOperation[] = [{
-    query: builtQueryForPart,
-    operations: operationsForShowAndChangeColor,
-  }]
+  const queryOperations: QueryOperation[] = [
+    {
+      query: builtQueryForPart,
+      operations: operationsForShowAndChangeColor,
+    },
+  ];
 
   describe('createSceneAlteration', () => {
     it('sends a create alteration request with the given params', async () => {
@@ -96,10 +97,12 @@ describe('streamCommands', () => {
           type: 'clear-override',
         },
       ];
-      const queryOperations: QueryOperation[] = [{
-        query,
-        operations,
-      }]
+      const queryOperations: QueryOperation[] = [
+        {
+          query,
+          operations,
+        },
+      ];
 
       await createSceneAlteration(
         sceneViewId,
@@ -141,9 +144,9 @@ describe('streamCommands', () => {
         },
         {
           query: builtQueryForPart,
-          operations: operationsForShowAndChangeColor
-        }
-      ]
+          operations: operationsForShowAndChangeColor,
+        },
+      ];
 
       await createSceneAlteration(
         sceneViewId,
@@ -161,7 +164,7 @@ describe('streamCommands', () => {
                 },
               ],
             },
-            expectedOperationResult
+            expectedOperationResult,
           ],
           sceneViewId: { hex: sceneViewId.toString() },
         })

--- a/packages/viewer/src/commands/streamCommands.ts
+++ b/packages/viewer/src/commands/streamCommands.ts
@@ -2,8 +2,6 @@ import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { Disposable, Uri, UUID } from '@vertexvis/utils';
 import { CommandContext, Command } from './command';
 import { CommandRegistry } from './commandRegistry';
-import { ItemOperation } from '../scenes/operations';
-import { QueryExpression } from '../scenes/queries';
 import { buildSceneOperation } from './streamCommandsMapper';
 import { LoadableResource } from '../types';
 import { InvalidCredentialsError } from '../errors';
@@ -42,7 +40,9 @@ export function createSceneAlteration(
   queryOperations: QueryOperation[]
 ): Command<Promise<vertexvis.protobuf.stream.IStreamResponse>> {
   return ({ stream }: CommandContext) => {
-    const pbOperations = queryOperations.map(op => buildSceneOperation(op.query, op.operations));
+    const pbOperations = queryOperations.map(op =>
+      buildSceneOperation(op.query, op.operations)
+    );
     const request = {
       sceneViewId: {
         hex: sceneViewId,

--- a/packages/viewer/src/commands/streamCommands.ts
+++ b/packages/viewer/src/commands/streamCommands.ts
@@ -7,6 +7,7 @@ import { QueryExpression } from '../scenes/queries';
 import { buildSceneOperation } from './streamCommandsMapper';
 import { LoadableResource } from '../types';
 import { InvalidCredentialsError } from '../errors';
+import { QueryOperation } from '../scenes';
 
 export interface ConnectOptions {
   resource: LoadableResource.LoadableResource;
@@ -38,11 +39,10 @@ export function connect({
 
 export function createSceneAlteration(
   sceneViewId: UUID.UUID,
-  query: QueryExpression,
-  operations: ItemOperation[]
+  queryOperations: QueryOperation[]
 ): Command<Promise<vertexvis.protobuf.stream.IStreamResponse>> {
   return ({ stream }: CommandContext) => {
-    const pbOperations = [buildSceneOperation(query, operations)];
+    const pbOperations = queryOperations.map(op => buildSceneOperation(op.query, op.operations));
     const request = {
       sceneViewId: {
         hex: sceneViewId,

--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -8,6 +8,7 @@
     />
     <title>Stencil Component Starter</title>
 
+    <script src="https://cdn.jsdelivr.net/npm/@jaames/iro@5"></script>
     <script type="module" src="/build/viewer.esm.js"></script>
     <script nomodule src="/build/viewer.js"></script>
     <link rel="stylesheet" href="/build/viewer.css" />
@@ -22,25 +23,138 @@
       }
 
       #viewer {
-        width: 100%;
-        height: 100%;
+        width: 50%;
+        height: 50%;
+      }
+
+      #viewer-2 {
+        width: 50%;
+        height: 50%;
       }
     </style>
 
     <script type="module">
+      import {ColorMaterial} from './build/index.esm.js';
       window.addEventListener('DOMContentLoaded', () => {
         main();
       });
 
-      async function main() {
+      // let color;
+
+      // const model1 = 'Mg0yhY3fbO4SR_WEenLXIk1SvxzWu80Pcw==';
+      const model1 = 'Fjj2XlRw2d3WN4Epss6cr2AvdjarnufQhw==';
+      const model2 = 'VrXkq_6XpDlIksUOvGqFcC3CwGA5tSVZhw==';
+      let currentModel = model1;
+
+      // const clearAllButton = document.querySelector('#clear-all');
+      const switchModelButton = document.querySelector('#switch-model');
+
+
+      switchModelButton.addEventListener('click', async _ => {
         const viewer = document.querySelector('#viewer');
 
-        // await viewer.load('urn:vertexvis:stream-key:key');
+        if (currentModel === model1) {
+          currentModel = model2;
+        } else {
+          currentModel = model1;
+        }
+        await viewer.load(`urn:vertexvis:stream-key:${currentModel}`)
+      });
+
+      async function main() {
+        const viewer = document.querySelector('#viewer');
+        viewer.configEnv = 'platdev';
+/*
+bf1b9917-e13f-4842-a918-8e064fe88ed9
+572a30b6-1d1b-4ca9-a0bb-800206171ffa
+d8152e02-e2b6-415c-9c0a-4e722e60b4fc
+d40d0074-83e8-45e3-bddc-5024083d8ddb
+a0c4da20-5e87-4984-a26b-68d9dcdc20bc
+73eb38f3-3969-480b-bab8-c5607217198a
+e6f7a108-015b-4393-998b-4ab2ff225dcd
+dee78686-e8f5-42c4-b796-d2420e73b355
+e8ac8a48-07c5-4ffd-99a4-2aea9089d9d2
+441306f3-f1e6-45cc-9946-3ea4ff67498a
+c37dfa46-78c5-4b28-94b1-a6b9c00d598f
+4da8a234-cec6-4abe-9733-73eed82806a7
+*/
+        // viewer.token = 'Oe860aTcQbxU8U-Zm0Cp-NPunsQzu6B0fMwUIBxcWxY.RE9BA7JEFy0C3JiKEruih_M46Au8ztfvC9cyA7vaj5E';
+        // await viewer.load('urn:vertexvis:stream-keys:Jm_xUgf-xhOAGui2_x9WmU_M8CfqFKUcdw==');
+
+        function timeout(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+        await viewer.load(`urn:vertexvis:stream-key:${currentModel}`);
+        // const scene = await viewer.scene();
+        // await scene
+        //       .items()
+        //       .where(q => q.all())
+        //       .materialOverride(ColorMaterial.fromHex("#ede5af"))
+        //       .execute();
+
+
+
+        
+        // await viewer2.load(`urn:vertexvis:stream-key:${currentModel}`);
+        // const scene2 = await viewer2.scene();
+        // await timeout(500);
+        // await scene2.items().where(q => q.all()).hide().execute();
+        
+        // VrXkq_6XpDlIksUOvGqFcC3CwGA5tSVZhw==
+        // Mg0yhY3fbO4SR_WEenLXIk1SvxzWu80Pcw==
+
+      // GREY FOR ALL #828282
+        viewer.addEventListener('tap', async function(event) {
+          const { position } = event.detail;
+          // const viewer2 = document.querySelector('#viewer-2');
+          // viewer2.configEnv = 'platdev';
+
+          const scene = await viewer.scene();
+          // const scene2 = await viewer2.scene();
+          const raycaster = await scene.raycaster();
+          const hitItems = await raycaster.hitItems(position);
+          // console.log(hitItems);
+          // console.log(scene);
+
+          // await scene
+          //   .items(op => 
+          //     [op.where(q => q.all()).hide()]
+          //   )
+          //   .execute();
+
+            await scene
+              .items(op => 
+                [
+                  op.where(q => q.all()).hide(),
+                  op.where(q => q.withItemId(hitItems.hits[0].itemId.hex)).show(),
+                  op.where(q => q.all()).materialOverride(ColorMaterial.fromHex("#ede5af"))
+                ]
+              )
+              .execute();
+          // await scene
+          //     .items()
+          //     .where(q => q.withItemId(hitItems.hits[0].itemId.hex))
+          //     .materialOverride(ColorMaterial.fromHex("#ede5af"))
+          //     .execute();
+        });
+
       }
     </script>
   </head>
 
-  <body>
+  <body style="display:flex;">
+    <!-- <div id="picker"></div> -->
+    <div>
+
+        <button id="switch-model">Switch Model</button>
+      <!-- <button id="clear-all">Clear All</button>
+      <button id="paint-all">Paint All</button>
+      <button id="hide-all">Hide All</button>
+      <button id="show-all">Show All</button> -->
+    </div>
+    
     <vertex-viewer id="viewer" camera-controls="true"></vertex-viewer>
+    <vertex-viewer id="viewer-2" camera-controls="true"></vertex-viewer>
   </body>
 </html>
+

--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -8,7 +8,6 @@
     />
     <title>Stencil Component Starter</title>
 
-    <script src="https://cdn.jsdelivr.net/npm/@jaames/iro@5"></script>
     <script type="module" src="/build/viewer.esm.js"></script>
     <script nomodule src="/build/viewer.js"></script>
     <link rel="stylesheet" href="/build/viewer.css" />
@@ -23,138 +22,25 @@
       }
 
       #viewer {
-        width: 50%;
-        height: 50%;
-      }
-
-      #viewer-2 {
-        width: 50%;
-        height: 50%;
+        width: 100%;
+        height: 100%;
       }
     </style>
 
     <script type="module">
-      import {ColorMaterial} from './build/index.esm.js';
       window.addEventListener('DOMContentLoaded', () => {
         main();
       });
 
-      // let color;
-
-      // const model1 = 'Mg0yhY3fbO4SR_WEenLXIk1SvxzWu80Pcw==';
-      const model1 = 'Fjj2XlRw2d3WN4Epss6cr2AvdjarnufQhw==';
-      const model2 = 'VrXkq_6XpDlIksUOvGqFcC3CwGA5tSVZhw==';
-      let currentModel = model1;
-
-      // const clearAllButton = document.querySelector('#clear-all');
-      const switchModelButton = document.querySelector('#switch-model');
-
-
-      switchModelButton.addEventListener('click', async _ => {
-        const viewer = document.querySelector('#viewer');
-
-        if (currentModel === model1) {
-          currentModel = model2;
-        } else {
-          currentModel = model1;
-        }
-        await viewer.load(`urn:vertexvis:stream-key:${currentModel}`)
-      });
-
       async function main() {
         const viewer = document.querySelector('#viewer');
-        viewer.configEnv = 'platdev';
-/*
-bf1b9917-e13f-4842-a918-8e064fe88ed9
-572a30b6-1d1b-4ca9-a0bb-800206171ffa
-d8152e02-e2b6-415c-9c0a-4e722e60b4fc
-d40d0074-83e8-45e3-bddc-5024083d8ddb
-a0c4da20-5e87-4984-a26b-68d9dcdc20bc
-73eb38f3-3969-480b-bab8-c5607217198a
-e6f7a108-015b-4393-998b-4ab2ff225dcd
-dee78686-e8f5-42c4-b796-d2420e73b355
-e8ac8a48-07c5-4ffd-99a4-2aea9089d9d2
-441306f3-f1e6-45cc-9946-3ea4ff67498a
-c37dfa46-78c5-4b28-94b1-a6b9c00d598f
-4da8a234-cec6-4abe-9733-73eed82806a7
-*/
-        // viewer.token = 'Oe860aTcQbxU8U-Zm0Cp-NPunsQzu6B0fMwUIBxcWxY.RE9BA7JEFy0C3JiKEruih_M46Au8ztfvC9cyA7vaj5E';
-        // await viewer.load('urn:vertexvis:stream-keys:Jm_xUgf-xhOAGui2_x9WmU_M8CfqFKUcdw==');
 
-        function timeout(ms) {
-            return new Promise(resolve => setTimeout(resolve, ms));
-        }
-        await viewer.load(`urn:vertexvis:stream-key:${currentModel}`);
-        // const scene = await viewer.scene();
-        // await scene
-        //       .items()
-        //       .where(q => q.all())
-        //       .materialOverride(ColorMaterial.fromHex("#ede5af"))
-        //       .execute();
-
-
-
-        
-        // await viewer2.load(`urn:vertexvis:stream-key:${currentModel}`);
-        // const scene2 = await viewer2.scene();
-        // await timeout(500);
-        // await scene2.items().where(q => q.all()).hide().execute();
-        
-        // VrXkq_6XpDlIksUOvGqFcC3CwGA5tSVZhw==
-        // Mg0yhY3fbO4SR_WEenLXIk1SvxzWu80Pcw==
-
-      // GREY FOR ALL #828282
-        viewer.addEventListener('tap', async function(event) {
-          const { position } = event.detail;
-          // const viewer2 = document.querySelector('#viewer-2');
-          // viewer2.configEnv = 'platdev';
-
-          const scene = await viewer.scene();
-          // const scene2 = await viewer2.scene();
-          const raycaster = await scene.raycaster();
-          const hitItems = await raycaster.hitItems(position);
-          // console.log(hitItems);
-          // console.log(scene);
-
-          // await scene
-          //   .items(op => 
-          //     [op.where(q => q.all()).hide()]
-          //   )
-          //   .execute();
-
-            await scene
-              .items(op => 
-                [
-                  op.where(q => q.all()).hide(),
-                  op.where(q => q.withItemId(hitItems.hits[0].itemId.hex)).show(),
-                  op.where(q => q.all()).materialOverride(ColorMaterial.fromHex("#ede5af"))
-                ]
-              )
-              .execute();
-          // await scene
-          //     .items()
-          //     .where(q => q.withItemId(hitItems.hits[0].itemId.hex))
-          //     .materialOverride(ColorMaterial.fromHex("#ede5af"))
-          //     .execute();
-        });
-
+        // await viewer.load('urn:vertexvis:stream-key:key');
       }
     </script>
   </head>
 
-  <body style="display:flex;">
-    <!-- <div id="picker"></div> -->
-    <div>
-
-        <button id="switch-model">Switch Model</button>
-      <!-- <button id="clear-all">Clear All</button>
-      <button id="paint-all">Paint All</button>
-      <button id="hide-all">Hide All</button>
-      <button id="show-all">Show All</button> -->
-    </div>
-    
+  <body>
     <vertex-viewer id="viewer" camera-controls="true"></vertex-viewer>
-    <vertex-viewer id="viewer-2" camera-controls="true"></vertex-viewer>
   </body>
 </html>
-

--- a/packages/viewer/src/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/scene.spec.ts
@@ -38,7 +38,6 @@ describe(Scene, () => {
     it('should execute commands and query by itemId', () => {
       const itemId = UUID.create();
       scene.items(op => op.where(q => q.withItemId(itemId)).hide()).execute();
-      expect(executeMock).toHaveBeenCalled();
       expect(executeMock).toHaveBeenCalledWith(
         'stream.createSceneAlteration',
         sceneViewId,
@@ -77,7 +76,6 @@ describe(Scene, () => {
             .materialOverride(ColorMaterial.fromHex('#ff1122')),
         ])
         .execute();
-      expect(executeMock).toHaveBeenCalled();
       expect(executeMock).toHaveBeenCalledWith(
         'stream.createSceneAlteration',
         sceneViewId,

--- a/packages/viewer/src/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/scene.spec.ts
@@ -4,6 +4,7 @@ import { Dimensions } from '@vertexvis/geometry';
 import { frame } from '../../types/__fixtures__';
 import { CommandRegistry } from '../../commands/commandRegistry';
 import { UUID } from '@vertexvis/utils';
+import { ColorMaterial } from '../..';
 
 describe(Scene, () => {
   const executeMock = jest.fn();
@@ -12,6 +13,10 @@ describe(Scene, () => {
   } as unknown) as CommandRegistry;
   const sceneViewId: UUID.UUID = UUID.create();
   const scene = new Scene(new StreamApi(), frame, commandRegistry, sceneViewId);
+
+  afterEach(() => {
+    executeMock.mockReset();
+  });
 
   describe(Scene.prototype.camera, () => {
     const camera = scene.camera();
@@ -26,6 +31,109 @@ describe(Scene, () => {
         lookAt: camera.lookAt,
         up: camera.up,
       });
+    });
+  });
+
+  describe(Scene.prototype.items, () => {
+    it('should execute commands and query by itemId', () => {
+      const itemId = UUID.create();
+      scene.items(op => op.where(q => q.withItemId(itemId)).hide()).execute();
+      expect(executeMock).toHaveBeenCalled();
+      expect(executeMock).toHaveBeenCalledWith(
+        "stream.createSceneAlteration",
+        sceneViewId,
+        [{
+          operations: [{
+            type: "hide"
+          }],
+          query: {
+            type: "item-id",
+            value: itemId
+          }
+        }]
+      );
+    });
+
+    it('should support passing multiple operations in one request', () => {
+      const itemId = UUID.create();
+      const suppliedId = UUID.create();
+      scene
+        .items(
+          op => [
+            op.where(q => q.all()).hide(),
+            op.where(q => q.withItemId(itemId).or().withSuppliedId(suppliedId)).show(),
+            op.where(q => q.all()).materialOverride(ColorMaterial.fromHex("#ff1122"))
+          ])
+        .execute();
+      expect(executeMock).toHaveBeenCalled();
+      expect(executeMock).toHaveBeenCalledWith(
+        "stream.createSceneAlteration",
+        sceneViewId,
+        [{
+          operations: [{
+            type: "hide"
+          }],
+          query: {
+            type: "all"
+          }
+        },
+        {
+          operations: [{
+            type: "show"
+          }],
+          query: {
+            expressions: [
+              {
+                type: "item-id",
+                value: itemId
+              },
+              {
+                type: "supplied-id",
+                value: suppliedId
+              }
+            ],
+            type: "or"
+          }
+        },
+        {
+          operations: [
+            {
+              color: {
+                ambient: {
+                  a: 0,
+                  b: 0,
+                  g: 0,
+                  r: 0
+                },
+                diffuse: {
+                  a: 255,
+                  b: 34,
+                  g: 17,
+                  r: 255
+                },
+                emissive: {
+                  a: 0,
+                  b: 0,
+                  g: 0,
+                  r: 0
+                },
+                specular: {
+                  a: 0,
+                  b: 0,
+                  g: 0,
+                  r: 0
+                },
+                glossiness: 10,
+                opacity: 100
+              },
+              type: "change-material"
+            }
+          ],
+          query: {
+            type: "all"
+          }
+        }]
+      );
     });
   });
 

--- a/packages/viewer/src/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/scene.spec.ts
@@ -40,17 +40,21 @@ describe(Scene, () => {
       scene.items(op => op.where(q => q.withItemId(itemId)).hide()).execute();
       expect(executeMock).toHaveBeenCalled();
       expect(executeMock).toHaveBeenCalledWith(
-        "stream.createSceneAlteration",
+        'stream.createSceneAlteration',
         sceneViewId,
-        [{
-          operations: [{
-            type: "hide"
-          }],
-          query: {
-            type: "item-id",
-            value: itemId
-          }
-        }]
+        [
+          {
+            operations: [
+              {
+                type: 'hide',
+              },
+            ],
+            query: {
+              type: 'item-id',
+              value: itemId,
+            },
+          },
+        ]
       );
     });
 
@@ -58,81 +62,95 @@ describe(Scene, () => {
       const itemId = UUID.create();
       const suppliedId = UUID.create();
       scene
-        .items(
-          op => [
-            op.where(q => q.all()).hide(),
-            op.where(q => q.withItemId(itemId).or().withSuppliedId(suppliedId)).show(),
-            op.where(q => q.all()).materialOverride(ColorMaterial.fromHex("#ff1122"))
-          ])
+        .items(op => [
+          op.where(q => q.all()).hide(),
+          op
+            .where(q =>
+              q
+                .withItemId(itemId)
+                .or()
+                .withSuppliedId(suppliedId)
+            )
+            .show(),
+          op
+            .where(q => q.all())
+            .materialOverride(ColorMaterial.fromHex('#ff1122')),
+        ])
         .execute();
       expect(executeMock).toHaveBeenCalled();
       expect(executeMock).toHaveBeenCalledWith(
-        "stream.createSceneAlteration",
+        'stream.createSceneAlteration',
         sceneViewId,
-        [{
-          operations: [{
-            type: "hide"
-          }],
-          query: {
-            type: "all"
-          }
-        },
-        {
-          operations: [{
-            type: "show"
-          }],
-          query: {
-            expressions: [
+        [
+          {
+            operations: [
               {
-                type: "item-id",
-                value: itemId
+                type: 'hide',
               },
-              {
-                type: "supplied-id",
-                value: suppliedId
-              }
             ],
-            type: "or"
-          }
-        },
-        {
-          operations: [
-            {
-              color: {
-                ambient: {
-                  a: 0,
-                  b: 0,
-                  g: 0,
-                  r: 0
-                },
-                diffuse: {
-                  a: 255,
-                  b: 34,
-                  g: 17,
-                  r: 255
-                },
-                emissive: {
-                  a: 0,
-                  b: 0,
-                  g: 0,
-                  r: 0
-                },
-                specular: {
-                  a: 0,
-                  b: 0,
-                  g: 0,
-                  r: 0
-                },
-                glossiness: 10,
-                opacity: 100
+            query: {
+              type: 'all',
+            },
+          },
+          {
+            operations: [
+              {
+                type: 'show',
               },
-              type: "change-material"
-            }
-          ],
-          query: {
-            type: "all"
-          }
-        }]
+            ],
+            query: {
+              expressions: [
+                {
+                  type: 'item-id',
+                  value: itemId,
+                },
+                {
+                  type: 'supplied-id',
+                  value: suppliedId,
+                },
+              ],
+              type: 'or',
+            },
+          },
+          {
+            operations: [
+              {
+                color: {
+                  ambient: {
+                    a: 0,
+                    b: 0,
+                    g: 0,
+                    r: 0,
+                  },
+                  diffuse: {
+                    a: 255,
+                    b: 34,
+                    g: 17,
+                    r: 255,
+                  },
+                  emissive: {
+                    a: 0,
+                    b: 0,
+                    g: 0,
+                    r: 0,
+                  },
+                  specular: {
+                    a: 0,
+                    b: 0,
+                    g: 0,
+                    r: 0,
+                  },
+                  glossiness: 10,
+                  opacity: 100,
+                },
+                type: 'change-material',
+              },
+            ],
+            query: {
+              type: 'all',
+            },
+          },
+        ]
       );
     });
   });

--- a/packages/viewer/src/scenes/queries.ts
+++ b/packages/viewer/src/scenes/queries.ts
@@ -1,6 +1,4 @@
 import { SceneItemOperationsBuilder } from './scene';
-import { UUID } from '@vertexvis/utils';
-import { CommandRegistry } from '../commands/commandRegistry';
 
 interface AllQueryExpression {
   type: 'all';
@@ -132,20 +130,11 @@ export class AndQuery implements TerminalQuery, ItemQuery<AndQuery> {
 }
 
 export class SceneItemQueryExecutor {
-  public constructor(
-    private sceneViewId: UUID.UUID,
-    private commands: CommandRegistry
-  ) {}
-
   public where(
     query: (q: RootQuery) => TerminalQuery
   ): SceneItemOperationsBuilder {
     const expression: QueryExpression = query(new RootQuery()).build();
 
-    return new SceneItemOperationsBuilder(
-      this.sceneViewId,
-      this.commands,
-      expression
-    );
+    return new SceneItemOperationsBuilder(expression);
   }
 }

--- a/packages/viewer/src/scenes/queries.ts
+++ b/packages/viewer/src/scenes/queries.ts
@@ -1,4 +1,4 @@
-import { SceneItemOperationsExecutor } from './scene';
+import { SceneItemOperationsBuilder } from './scene';
 import { UUID } from '@vertexvis/utils';
 import { CommandRegistry } from '../commands/commandRegistry';
 
@@ -139,10 +139,10 @@ export class SceneItemQueryExecutor {
 
   public where(
     query: (q: RootQuery) => TerminalQuery
-  ): SceneItemOperationsExecutor {
+  ): SceneItemOperationsBuilder {
     const expression: QueryExpression = query(new RootQuery()).build();
 
-    return new SceneItemOperationsExecutor(
+    return new SceneItemOperationsBuilder(
       this.sceneViewId,
       this.commands,
       expression

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -4,7 +4,11 @@ import { Camera } from './camera';
 import { Dimensions } from '@vertexvis/geometry';
 import { Raycaster } from './raycaster';
 import { ColorMaterial } from './colorMaterial';
-import { SceneItemOperations, SceneOperationBuilder, ItemOperation } from './operations';
+import {
+  SceneItemOperations,
+  SceneOperationBuilder,
+  ItemOperation,
+} from './operations';
 import { QueryExpression, SceneItemQueryExecutor } from './queries';
 import { CommandRegistry } from '../commands/commandRegistry';
 import { UUID } from '@vertexvis/utils';
@@ -17,19 +21,15 @@ import { UUID } from '@vertexvis/utils';
 export class SceneItemOperationsBuilder
   implements SceneItemOperations<SceneItemOperationsBuilder> {
   private builder: SceneOperationBuilder;
-  private queryOperations: QueryOperation[];
 
   public constructor(
     private sceneViewId: UUID.UUID,
     private commands: CommandRegistry,
     private query: QueryExpression,
-    givenBuilder?: SceneOperationBuilder,
-    queryOperations?: QueryOperation[]
+    givenBuilder?: SceneOperationBuilder
   ) {
     this.builder =
       givenBuilder != null ? givenBuilder : new SceneOperationBuilder();
-
-    this.queryOperations = queryOperations != null ? queryOperations : [];
   }
 
   public materialOverride(color: ColorMaterial): SceneItemOperationsBuilder {
@@ -37,8 +37,7 @@ export class SceneItemOperationsBuilder
       this.sceneViewId,
       this.commands,
       this.query,
-      this.builder.materialOverride(color),
-      this.queryOperations,
+      this.builder.materialOverride(color)
     );
   }
 
@@ -47,8 +46,7 @@ export class SceneItemOperationsBuilder
       this.sceneViewId,
       this.commands,
       this.query,
-      this.builder.hide(),
-      this.queryOperations,
+      this.builder.hide()
     );
   }
 
@@ -57,8 +55,7 @@ export class SceneItemOperationsBuilder
       this.sceneViewId,
       this.commands,
       this.query,
-      this.builder.show(),
-      this.queryOperations,
+      this.builder.show()
     );
   }
 
@@ -67,8 +64,7 @@ export class SceneItemOperationsBuilder
       this.sceneViewId,
       this.commands,
       this.query,
-      this.builder.clearMaterialOverrides(),
-      this.queryOperations
+      this.builder.clearMaterialOverrides()
     );
   }
 
@@ -101,7 +97,9 @@ export class ItemsOperationExecutor {
   }
 }
 
-export type TerminalItemOperationBuilder = SceneItemOperationsBuilder | SceneItemOperationsBuilder[];
+export type TerminalItemOperationBuilder =
+  | SceneItemOperationsBuilder
+  | SceneItemOperationsBuilder[];
 
 /**
  * A class that represents the `Scene` that has been loaded into the viewer. On
@@ -117,19 +115,32 @@ export class Scene {
     private sceneViewId: UUID.UUID
   ) {}
 
-
   /**
    * Returns an executor that accepts a function as a parameter that contains one or many operations to apply
    * to the scene view. The operations will be applied transactionally.
-   * @param operations 
+   * @param operations
    */
-  public items(operations: (q: SceneItemQueryExecutor) => TerminalItemOperationBuilder): ItemsOperationExecutor {
-    const sceneOperations: TerminalItemOperationBuilder = operations(new SceneItemQueryExecutor(this.sceneViewId, this.commands));
+  public items(
+    operations: (q: SceneItemQueryExecutor) => TerminalItemOperationBuilder
+  ): ItemsOperationExecutor {
+    const sceneOperations: TerminalItemOperationBuilder = operations(
+      new SceneItemQueryExecutor(this.sceneViewId, this.commands)
+    );
     if (Array.isArray(sceneOperations)) {
-      const operationList = sceneOperations.reduce((acc, builder: SceneItemOperationsBuilder) => acc.concat(builder.build()), []);
-      return new ItemsOperationExecutor(this.sceneViewId, this.commands, operationList)
+      const operationList = sceneOperations.reduce(
+        (acc, builder: SceneItemOperationsBuilder) =>
+          acc.concat(builder.build()),
+        []
+      );
+      return new ItemsOperationExecutor(
+        this.sceneViewId,
+        this.commands,
+        operationList
+      );
     } else {
-      return new ItemsOperationExecutor(this.sceneViewId, this.commands, [sceneOperations.build()]);
+      return new ItemsOperationExecutor(this.sceneViewId, this.commands, [
+        sceneOperations.build(),
+      ]);
     }
   }
 


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
You should be able to do multiple operations in one transactional request to the server. IE, if you want to do a show only on an item, today you would have to do two separate executions:
```
   await scene.items().where(q => q.all()).hide().execute();
   await scene.items().where(q => q.withItemId(ITEM_ID)).show().execute();
```

This PR includes changes to allow you to pass multiple operations inside one execution context. This will break syntax of existing consumers, but will break type checking if you happen to be using typescript. 

Introducing the new syntax for item operations:
```
      scene
        .items(
          op => [
            op.where(q => q.all()).hide(),
            op.where(q => q.withItemId(itemId).or().withSuppliedId(suppliedId)).show(),
            op.where(q => q.all()).materialOverride(ColorMaterial.fromHex("#ff1122"))
          ])
        .execute();
```

Now instead of items returning the scene item operations executor, that entity has been modified to become a builder where you may include one or many operations. The `items()` expects a function that returns either a single op, or an array of ops. Ie, you can use the above syntax, or simply just do one operation in your items invocation:

```
      scene
        .items(
            op => op.where(q => q.withItemId(itemId)).hide())
        .execute();
```

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-796

## Test Plan

<!-- Describe how your changes should be tested. -->
Try to bundle multiple operations. Your first frame that responds should have applied all of the operations you specified. 
For example, you can do a show only lie this:
```
      scene
        .items(
          op => [
            op.where(q => q.all()).hide(),
            op.where(q => q.withItemId(YOUR_ITEM)).show()
          ])
        .execute();
```

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->
Item operations

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->
N/A

## Dependencies

<!-- Link to other PRs or tickets. -->
N/A
