### PR TITLE
[SDK-954] Fix check for promises used in Angular

### DIFF
--- a/packages/utils/src/__tests__/async.test.ts
+++ b/packages/utils/src/__tests__/async.test.ts
@@ -22,7 +22,7 @@ describe(timeout, () => {
   });
 
   it('resolves promise if completed within timeout', async () => {
-    const result = timeout(20, delay(10, Promise.resolve(1)));
+    const result = timeout(50, delay(10, Promise.resolve(1)));
     expect(await result).toBe(1);
   });
 });

--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -34,13 +34,15 @@
 
       async function main() {
         const viewer = document.querySelector('#viewer');
-
-        // await viewer.load('urn:vertexvis:stream-key:key');
       }
     </script>
   </head>
 
   <body>
-    <vertex-viewer id="viewer" camera-controls="true"></vertex-viewer>
+    <vertex-viewer
+      id="viewer"
+      config-env="platdev"
+      src="urn:vertexvis:stream-key:key"
+    ></vertex-viewer>
   </body>
 </html>

--- a/packages/viewer/src/metrics/timing.ts
+++ b/packages/viewer/src/metrics/timing.ts
@@ -1,3 +1,5 @@
+import { isPromise } from '../types';
+
 interface Timing {
   startTime: number;
   duration: number;
@@ -38,7 +40,7 @@ export class TimingMeter {
    */
   public measure<T>(target: Promise<T>): Promise<T>;
   public measure<T>(target: (() => T) | Promise<T>): T | Promise<T> {
-    if (target instanceof Promise) {
+    if (isPromise(target)) {
       const mark = this.begin();
       return target.finally(() => this.end(mark));
     } else if (typeof target === 'function') {

--- a/packages/viewer/src/types/__tests__/typeGuards.spec.ts
+++ b/packages/viewer/src/types/__tests__/typeGuards.spec.ts
@@ -1,0 +1,22 @@
+import { isPromise } from '../typeGuards';
+
+describe(isPromise, () => {
+  it('returns true if a promise', () => {
+    const promise = Promise.resolve();
+    expect(isPromise(promise)).toBe(true);
+  });
+
+  it('returns true if promise like', () => {
+    const promise = {
+      then: () => undefined,
+      catch: () => undefined,
+      finally: () => undefined,
+    };
+    expect(isPromise(promise)).toBe(true);
+  });
+
+  it('returns false if not promise like', () => {
+    const promise = { then: '', catch: '', finally: '' };
+    expect(isPromise(promise)).toBe(false);
+  });
+});

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -5,4 +5,6 @@ import * as LoadableResource from './loadableResource';
 
 export * from './synchronizedClock';
 
+export * from './typeGuards';
+
 export { Flags, Frame, FrameCamera, LoadableResource };

--- a/packages/viewer/src/types/typeGuards.ts
+++ b/packages/viewer/src/types/typeGuards.ts
@@ -1,0 +1,9 @@
+export function isPromise<T>(obj: unknown): obj is Promise<T> {
+  return (
+    obj != null &&
+    obj['then'] instanceof Function &&
+    obj['catch'] instanceof Function &&
+    // NOTE: Should be removed if we do not target ES2018.
+    obj['finally'] instanceof Function
+  );
+}


### PR DESCRIPTION
## What

Angular appears to use it's own version of a Promise, and our type check would fail. Adding a type guard to check if an object is promise like.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-954

## Test Plan

1. Use viewer in an Angular app.
2. Validate that the viewer loads a model and is interactable.

