### PR TITLE
[SDK-962] Resolve Console Errors

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -402,9 +402,11 @@ export class Viewer {
 
       await this.waitNextDrawnFrame(15 * 1000);
     } catch (e) {
-      this.errorMessage = 'Unable to establish connection to Vertex.';
-      console.error('Failed to establish WS connection', e);
-      throw new WebsocketConnectionError(this.errorMessage, e);
+      if (this.lastFrame == null) {
+        this.errorMessage = 'Unable to establish connection to Vertex.';
+        console.error('Failed to establish WS connection', e);
+        throw new WebsocketConnectionError(this.errorMessage, e);
+      }
     }
   }
 

--- a/packages/viewer/src/rendering/__tests__/remote.spec.ts
+++ b/packages/viewer/src/rendering/__tests__/remote.spec.ts
@@ -39,8 +39,8 @@ describe(createStreamApiRenderer, () => {
     expect(resp.frame.sequenceNumber).toBe(1);
   });
 
-  it('should not throw an exception ', async () => {
-    const req = render({ correlationId, camera });
-    await expect(req).not.toThrow;
+  it('throws exception if render times out', async () => {
+    const req = render({ correlationId, camera, timeoutInMs: 10 });
+    await expect(req).rejects.toThrow();
   });
 });

--- a/packages/viewer/src/rendering/__tests__/remote.spec.ts
+++ b/packages/viewer/src/rendering/__tests__/remote.spec.ts
@@ -39,8 +39,8 @@ describe(createStreamApiRenderer, () => {
     expect(resp.frame.sequenceNumber).toBe(1);
   });
 
-  it('throws exception if render times out', async () => {
-    const req = render({ correlationId, camera, timeoutInMs: 10 });
-    await expect(req).rejects.toThrow();
+  it('should not throw an exception ', async () => {
+    const req = render({ correlationId, camera });
+    await expect(req).not.toThrow
   });
 });

--- a/packages/viewer/src/rendering/__tests__/remote.spec.ts
+++ b/packages/viewer/src/rendering/__tests__/remote.spec.ts
@@ -41,6 +41,6 @@ describe(createStreamApiRenderer, () => {
 
   it('should not throw an exception ', async () => {
     const req = render({ correlationId, camera });
-    await expect(req).not.toThrow
+    await expect(req).not.toThrow;
   });
 });

--- a/packages/viewer/src/rendering/canvas.ts
+++ b/packages/viewer/src/rendering/canvas.ts
@@ -46,7 +46,11 @@ function reportTimings(api: StreamApi, meter: TimingMeter): void {
     .map(t => ({ receiveToPaintDuration: toProtoDuration(t.duration) }));
 
   if (timings.length > 0) {
-    api.recordPerformance({ timings: timings }, false);
+    try {
+      api.recordPerformance({ timings: timings }, false);
+    } catch (e) {
+      console.warn('Unable to record performance: ', e);
+    }
   }
 }
 

--- a/packages/viewer/src/rendering/remote.ts
+++ b/packages/viewer/src/rendering/remote.ts
@@ -1,10 +1,8 @@
-import { Async, UUID } from '@vertexvis/utils';
+import { UUID } from '@vertexvis/utils';
 import { FrameCamera, Frame } from '../types';
 import { StreamApi, protoToDate } from '@vertexvis/stream-api';
 import { ifDrawFrame } from './utils';
 import { FrameRenderer } from './renderer';
-
-const DEFAULT_TIMEOUT_IN_MS = 10 * 1000; // 10 seconds
 
 export interface FrameRequest {
   correlationId?: string;
@@ -50,7 +48,6 @@ function requestFrame(api: StreamApi): RemoteRenderer {
 
   return req => {
     const corrId = req.correlationId || UUID.create();
-    const timeout = req.timeoutInMs || DEFAULT_TIMEOUT_IN_MS;
     const update = new Promise<FrameResponse>(resolve => {
       requests.set(corrId, resolve);
 
@@ -60,9 +57,9 @@ function requestFrame(api: StreamApi): RemoteRenderer {
       );
     });
 
-    return Async.timeout(timeout, update).finally(() =>
-      requests.delete(corrId)
-    );
+    return update.finally(() => {
+      requests.delete(corrId);
+    });
   };
 }
 

--- a/packages/viewer/src/rendering/remote.ts
+++ b/packages/viewer/src/rendering/remote.ts
@@ -18,9 +18,6 @@ export interface FrameResponse {
   frame: Frame.Frame;
 }
 
-let count = 0;
-let recievedCount = 0;
-
 export type RemoteRenderer = FrameRenderer<FrameRequest, FrameResponse>;
 
 function requestFrame(api: StreamApi): RemoteRenderer {
@@ -39,9 +36,8 @@ function requestFrame(api: StreamApi): RemoteRenderer {
         }),
         frame: Frame.fromProto(frame),
       };
+
       if (frame.frameCorrelationIds) {
-        recievedCount++;
-        console.log('sent: ', count, 'recieved: ', recievedCount);
         frame.frameCorrelationIds.forEach(id => {
           const callback = requests.get(id);
           if (callback != null) {
@@ -57,7 +53,6 @@ function requestFrame(api: StreamApi): RemoteRenderer {
     const timeout = req.timeoutInMs || DEFAULT_TIMEOUT_IN_MS;
     const update = new Promise<FrameResponse>(resolve => {
       requests.set(corrId, resolve);
-      count++;
       api.replaceCamera(
         { camera: req.camera, frameCorrelationId: { value: corrId } },
         false

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -68,7 +68,11 @@ export class Camera implements FrameCamera.FrameCamera {
    * promise will resolve when a frame is received that contains this camera.
    */
   public async render(): Promise<void> {
-    await this.renderer({ camera: this.data });
+    try {
+      await this.renderer({ camera: this.data });
+    } catch (e) {
+      console.warn('Error when requesting new frame: ', e);
+    }
   }
 
   /**


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
These changes are to include some better error handling, as well as not throwing console exceptions on the event that the client is dropping frames. After investigation into the issue noted in the ticket, I noticed that when this event was happening, it happened when the frames got backed up, and then the user switches scenes. This would then close the old WS, and open a new one. This led me to find that the issue was that somewhere the client was resolving the promises, even though none of the responses were coming from the server. The root issue, pertains to setting a timeout on the frames. I am proposing in these changes that we remove this timeout so that on the event of dropped frames these errors don't show up to the client.

If there is an argument for keeping the timeout in, another change could be included to catch the exception and do a `console.warn` instead of the errors currently seen today. 

I noted another issue in the SDK where switching between scenes rapidly would cause the `Error Connecting to Vertex` message would show, in addition to a console error. This was caused by some changes late last week pertaining to the `.load` functionality. The changes included here are to _not_ show that exception if there is a frame present on the current scene. These changes are the ones in the file `viewer.tsx`.

A third issue I noticed was when changing between scenes rapidly, the call to notify on performance was failing as this call happens _last_ in a chain of events. For now I propose this exception be caught, and replaced with a `console.warn` as seen below. 

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-962

## Test Plan

<!-- Describe how your changes should be tested. -->

Initial error:
- Switch around the scenes and zoom/interact with each scene. Do this until you can see even a slight delay in the frames being returned.
- Immediately switch scenes and let it sit for 10s. You should see no errors in your console. 

Switching Scenes Rapidly & performance exceptions:
- Given the example in the ticket with 5+ scenes, load the example, and rapidly click 5 distinct buttons (thus initiating 5 separate scene loads)
- You should see the final scene load in
- Wait 15s. You should not see the connection error message, nor a console exception pertaining to a promise timeout. 
- Take a look at the console. You should only see warnings pertaining to the performance calls, not console errors. 

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->
N/A

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->
N/A

## Dependencies

<!-- Link to other PRs or tickets. -->
N/A
