### PR TITLE
[SDK-997] Add flags and settings for configuring frame delivery

### DIFF
--- a/packages/stream-api/src/__tests__/paramsBuilder.spec.ts
+++ b/packages/stream-api/src/__tests__/paramsBuilder.spec.ts
@@ -1,0 +1,52 @@
+import {
+  defineBoolean,
+  defineNumber,
+  defineString,
+  defineParams,
+} from '../paramsBuilder';
+
+interface Foo<T> {
+  value: T;
+}
+
+describe(defineBoolean, () => {
+  const builder = defineBoolean<Foo<boolean>>('param', 'value');
+
+  it('converts true to `on`', () => {
+    expect(builder({ value: true })).toMatchObject({ param: 'on' });
+  });
+
+  it('converts false to `off`', () => {
+    expect(builder({ value: false })).toMatchObject({ param: 'off' });
+  });
+});
+
+describe(defineNumber, () => {
+  const builder = defineNumber<Foo<number>>('param', 'value');
+
+  it('converts number to string', () => {
+    expect(builder({ value: 1.5 })).toMatchObject({ param: '1.5' });
+  });
+});
+
+describe(defineString, () => {
+  const builder = defineString<Foo<string>>('param', 'value');
+
+  it('sets string', () => {
+    expect(builder({ value: 'str' })).toMatchObject({ param: 'str' });
+  });
+});
+
+describe(defineParams, () => {
+  const builder = defineParams<{ foo: number; bar: number }>(
+    defineNumber('param1', 'foo'),
+    defineNumber('param2', 'bar')
+  );
+
+  it('applies each definition', () => {
+    expect(builder({ foo: 1, bar: 2 })).toMatchObject({
+      param1: '1',
+      param2: '2',
+    });
+  });
+});

--- a/packages/stream-api/src/__tests__/settings.spec.ts
+++ b/packages/stream-api/src/__tests__/settings.spec.ts
@@ -1,0 +1,21 @@
+import { appendSettingsToUrl, Settings } from '../settings';
+
+describe(appendSettingsToUrl, () => {
+  const url = 'wss://example.com';
+  const settings: Settings = {
+    EXPERIMENTAL_frameDelivery: {
+      rateLimitingEnabled: true,
+      packetLossThreshold: 1,
+    },
+  };
+
+  it('appends each setting as url param to input url', () => {
+    expect(appendSettingsToUrl(url, settings)).toBe(
+      'wss://example.com?frame-delivery.rate-limit-enabled=on&frame-delivery.packet-loss-threshold=1'
+    );
+  });
+
+  it('appends nothing if settings are empty', () => {
+    expect(appendSettingsToUrl(url, {})).toBe(url);
+  });
+});

--- a/packages/stream-api/src/index.ts
+++ b/packages/stream-api/src/index.ts
@@ -1,13 +1,15 @@
-export * from './streamApi';
-
-export * from './webSocketClient';
-
 export * from './connection';
 
 export * from './encoder';
+
+export { Settings, FrameDeliverySettings } from './settings';
+
+export * from './streamApi';
+
+export * from './testing';
 
 export * from './time';
 
 export * from './types';
 
-export * from './testing';
+export * from './webSocketClient';

--- a/packages/stream-api/src/paramsBuilder.ts
+++ b/packages/stream-api/src/paramsBuilder.ts
@@ -1,0 +1,56 @@
+export type ParamsBuilder<S> = (settings: S) => Record<string, string>;
+
+export function defineParams<S>(
+  ...definitions: ParamsBuilder<S>[]
+): ParamsBuilder<S> {
+  return settings => {
+    return definitions.reduce(
+      (result, def) => ({ ...result, ...def(settings) }),
+      {}
+    );
+  };
+}
+
+export function defineBoolean<S, P extends keyof S = keyof S>(
+  param: string,
+  prop: P
+): ParamsBuilder<S> {
+  return defineValue(param, prop, v => {
+    if (typeof v === 'boolean') {
+      return v ? 'on' : 'off';
+    } else {
+      return undefined;
+    }
+  });
+}
+
+export function defineNumber<S, P extends keyof S = keyof S>(
+  param: string,
+  prop: P
+): ParamsBuilder<S> {
+  return defineValue(param, prop, v =>
+    typeof v === 'number' ? v.toString() : undefined
+  );
+}
+
+export function defineString<S, P extends keyof S = keyof S>(
+  param: string,
+  prop: P
+): ParamsBuilder<S> {
+  return defineValue(param, prop, v => (typeof v === 'string' ? v : undefined));
+}
+
+function defineValue<S, P extends keyof S = keyof S>(
+  param: string,
+  prop: P,
+  f: (prop: unknown) => string | undefined
+): ParamsBuilder<S> {
+  return settings => {
+    const value = f(settings[prop]);
+    if (value != null) {
+      return { [param]: value };
+    } else {
+      return {};
+    }
+  };
+}

--- a/packages/stream-api/src/settings.ts
+++ b/packages/stream-api/src/settings.ts
@@ -1,0 +1,104 @@
+import { Uri, Objects } from '@vertexvis/utils';
+import {
+  defineParams,
+  defineBoolean,
+  defineNumber,
+  defineString,
+  ParamsBuilder,
+} from './paramsBuilder';
+
+/**
+ * Settings to configure the delivery of images over the websocket connection.
+ */
+export interface FrameDeliverySettings {
+  /**
+   * Indicates if the rate limiting of frame delivery is enabled based on
+   * detected internet throughput.
+   */
+  rateLimitingEnabled?: boolean;
+
+  /**
+   * Enables rate limiting when the variation coefficient of frame latencies
+   * exceeds this threshold. The variation coefficient is defined by the
+   * standard deviation of latencies over the average of recorded latencies.
+   *
+   * Lower numbers will increase the aggressiveness of packet loss detection,
+   * but may trigger unexpected delivery rate limiting.
+   */
+  packetLossThreshold?: number;
+
+  /**
+   * The maximum number of latencies to record. Higher numbers could result in
+   * more delay before packet loss is detected. Lower numbers could result in
+   * packet loss not being detected.
+   */
+  historyMaxSize?: number;
+
+  /**
+   * The duration at which point a frame will be considered failed if the server
+   * has not received an acknowledgement.
+   */
+  timeout?: string;
+
+  /**
+   * Enables rate limiting when the number of frames that failed to receive an
+   * acknowledgement within the timeout window exceeds this ratio.
+   */
+  timeoutRatioThreshold?: number;
+}
+
+/**
+ * Settings to configure the frame stream and its websocket connection.
+ */
+export interface Settings {
+  /**
+   * **EXPERIMENTAL.** Settings to configure the delivery of frames.
+   */
+  EXPERIMENTAL_frameDelivery?: FrameDeliverySettings;
+}
+
+export function appendSettingsToUrl(url: string, settings: Settings): string {
+  const defaults: Settings = {
+    // Settings that you want to set on each WS connection should go here.
+  };
+
+  const uri = Uri.parse(url);
+  const builder = defineParams(
+    toFrameDeliverySettingsParams(defaults.EXPERIMENTAL_frameDelivery)
+  );
+  const params = builder(settings);
+  return Uri.toString(Uri.addQueryParams(params, uri));
+}
+
+function toFrameDeliverySettingsParams(
+  defaults: FrameDeliverySettings | undefined
+): ParamsBuilder<Settings> {
+  return defineSettings(
+    s => s.EXPERIMENTAL_frameDelivery,
+    defaults,
+    defineParams(
+      defineBoolean('frame-delivery.rate-limit-enabled', 'rateLimitingEnabled'),
+      defineNumber(
+        'frame-delivery.packet-loss-threshold',
+        'packetLossThreshold'
+      ),
+      defineNumber('frame-delivery.history-max-size', 'historyMaxSize'),
+      defineString('frame-delivery.timeout', 'timeout'),
+      defineNumber(
+        'frame-delivery.timeout-ratio-threshold',
+        'timeoutRatioThreshold'
+      )
+    )
+  );
+}
+
+function defineSettings<S, T>(
+  getter: (settings: S) => T | undefined,
+  defaults: T | undefined,
+  builder: ParamsBuilder<T>
+): ParamsBuilder<S> {
+  return settings => {
+    const merged = Objects.defaults(getter(settings) || {}, defaults);
+    return builder(merged);
+  };
+}

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -18,6 +18,7 @@ import { Disposable, EventDispatcher, UUID } from '@vertexvis/utils';
 import { currentDateAsProtoTimestamp } from './time';
 import { encode, decode } from './encoder';
 import { StreamRequestError } from './errors';
+import { appendSettingsToUrl, Settings } from './settings';
 
 export type RequestMessageHandler = (msg: RequestMessage) => void;
 
@@ -43,9 +44,17 @@ export class StreamApi {
    *
    * @param descriptor A function that returns a description of how to establish
    * a WS connection.
+   * @param settings A configuration to use when initializing the WS connection.
    */
-  public async connect(descriptor: ConnectionDescriptor): Promise<Disposable> {
-    await this.websocket.connect(descriptor);
+  public async connect(
+    descriptor: ConnectionDescriptor,
+    settings: Settings = {}
+  ): Promise<Disposable> {
+    const desc = {
+      ...descriptor,
+      url: appendSettingsToUrl(descriptor.url, settings),
+    };
+    await this.websocket.connect(desc);
     this.messageSubscription = this.websocket.onMessage(message => {
       this.handleMessage(message);
     });

--- a/packages/viewer/src/components/viewer/viewer.spec.ts
+++ b/packages/viewer/src/components/viewer/viewer.spec.ts
@@ -119,7 +119,8 @@ describe('vertex-viewer', () => {
       expect(api.connect).toHaveBeenCalledWith(
         expect.objectContaining({
           url: expect.stringContaining('/stream-keys/123/session'),
-        })
+        }),
+        expect.anything()
       );
       expect(api.startStream).toHaveBeenCalled();
     });

--- a/packages/viewer/src/config/config.ts
+++ b/packages/viewer/src/config/config.ts
@@ -1,6 +1,7 @@
 import { Objects, DeepPartial } from '@vertexvis/utils';
 import { Environment } from './environment';
 import { Flags } from '../types';
+import { FrameDeliverySettings } from '@vertexvis/stream-api';
 
 interface NetworkConfig {
   apiHost: string;
@@ -10,6 +11,10 @@ interface NetworkConfig {
 export interface Config {
   network: NetworkConfig;
   flags: Flags.Flags;
+  EXPERIMENTAL_frameDelivery: Omit<
+    FrameDeliverySettings,
+    'rateLimitingEnabled'
+  >;
 }
 
 type PartialConfig = DeepPartial<Config>;
@@ -22,6 +27,7 @@ const platdevConfig: Config = {
     renderingHost: 'wss://stream.platdev.vertexvis.io',
   },
   flags: Flags.defaultFlags,
+  EXPERIMENTAL_frameDelivery: {},
 };
 
 const platprodConfig: Config = {
@@ -30,6 +36,7 @@ const platprodConfig: Config = {
     renderingHost: 'wss://stream.platprod.vertexvis.io',
   },
   flags: Flags.defaultFlags,
+  EXPERIMENTAL_frameDelivery: {},
 };
 
 function getEnvironmentConfig(environment: Environment): Config {

--- a/packages/viewer/src/types/flags.ts
+++ b/packages/viewer/src/types/flags.ts
@@ -1,23 +1,25 @@
 import { Objects } from '@vertexvis/utils';
 
-/**
- * A set of experimental features that can be enabled through the viewer's
- * config.
- */
-export interface Flags {
+type Flag =
   /**
-   * Enables or disables a buffer for delivery of images over websockets.
+   * Enables or disables a throttling of image delivery based on detected
+   * network conditions.
    */
-  bufferFrameDelivery: boolean;
+  | 'throttleFrameDelivery'
 
   /**
    * Enables or disables logging of WS message payloads.
    */
-  logWsMessages: boolean;
-}
+  | 'logWsMessages';
+
+/**
+ * A set of experimental features that can be enabled through the viewer's
+ * config.
+ */
+export type Flags = { [K in Flag]: boolean };
 
 export const defaultFlags: Flags = {
-  bufferFrameDelivery: false,
+  throttleFrameDelivery: false,
   logWsMessages: false,
 };
 


### PR DESCRIPTION
## What

Exposes settings and flags to configure the delivery of frames.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-997

## Test Plan

```js
const viewer = document.querySelector('#viewer');
viewer.config = {
  EXPERIMENTAL_frameDelivery: {
    packetLossThreshold: 1,
  },
};
```

This should pass a URL param on the websocket to configure the packet loss threshold.