### PR TITLE
[SDK-1015] Add configuration options for adaptive rendering

### DIFF
--- a/packages/stream-api/src/index.ts
+++ b/packages/stream-api/src/index.ts
@@ -2,7 +2,12 @@ export * from './connection';
 
 export * from './encoder';
 
-export { Settings, FrameDeliverySettings } from './settings';
+export {
+  Settings,
+  FrameDeliverySettings,
+  AdaptiveRenderingSettings,
+  QualityOfServiceSettings,
+} from './settings';
 
 export * from './streamApi';
 

--- a/packages/viewer/src/commands/streamCommands.ts
+++ b/packages/viewer/src/commands/streamCommands.ts
@@ -29,6 +29,13 @@ export function connect({
           ...config.EXPERIMENTAL_frameDelivery,
           rateLimitingEnabled: config.flags.throttleFrameDelivery,
         },
+        EXPERIMENTAL_adaptiveRendering: {
+          ...config.EXPERIMENTAL_adaptiveRendering,
+          enabled: config.flags.adaptiveRendering,
+        },
+        EXPERIMENTAL_qualityOfService: {
+          ...config.EXPERIMENTAL_qualityOfService,
+        },
       };
 
       return stream.connect(descriptor, settings);

--- a/packages/viewer/src/config/config.ts
+++ b/packages/viewer/src/config/config.ts
@@ -2,6 +2,10 @@ import { Objects, DeepPartial } from '@vertexvis/utils';
 import { Environment } from './environment';
 import { Flags } from '../types';
 import { FrameDeliverySettings } from '@vertexvis/stream-api';
+import {
+  AdaptiveRenderingSettings,
+  QualityOfServiceSettings,
+} from '@vertexvis/stream-api';
 
 interface NetworkConfig {
   apiHost: string;
@@ -15,6 +19,8 @@ export interface Config {
     FrameDeliverySettings,
     'rateLimitingEnabled'
   >;
+  EXPERIMENTAL_adaptiveRendering: Omit<AdaptiveRenderingSettings, 'enabled'>;
+  EXPERIMENTAL_qualityOfService: QualityOfServiceSettings;
 }
 
 type PartialConfig = DeepPartial<Config>;
@@ -28,6 +34,8 @@ const platdevConfig: Config = {
   },
   flags: Flags.defaultFlags,
   EXPERIMENTAL_frameDelivery: {},
+  EXPERIMENTAL_adaptiveRendering: {},
+  EXPERIMENTAL_qualityOfService: {},
 };
 
 const platprodConfig: Config = {
@@ -37,6 +45,8 @@ const platprodConfig: Config = {
   },
   flags: Flags.defaultFlags,
   EXPERIMENTAL_frameDelivery: {},
+  EXPERIMENTAL_adaptiveRendering: {},
+  EXPERIMENTAL_qualityOfService: {},
 };
 
 function getEnvironmentConfig(environment: Environment): Config {

--- a/packages/viewer/src/types/flags.ts
+++ b/packages/viewer/src/types/flags.ts
@@ -8,6 +8,12 @@ type Flag =
   | 'throttleFrameDelivery'
 
   /**
+   * Enables or disables automatic quality adjustments of rendered frames to
+   * improve the performance of delivering frames to the client.
+   */
+  | 'adaptiveRendering'
+
+  /**
    * Enables or disables logging of WS message payloads.
    */
   | 'logWsMessages';
@@ -20,6 +26,7 @@ export type Flags = { [K in Flag]: boolean };
 
 export const defaultFlags: Flags = {
   throttleFrameDelivery: false,
+  adaptiveRendering: false,
   logWsMessages: false,
 };
 

--- a/packages/viewer/tsconfig.json
+++ b/packages/viewer/tsconfig.json
@@ -6,7 +6,7 @@
     "experimentalDecorators": true,
     "jsx": "react",
     "jsxFactory": "h",
-    "target": "es2017",
+    "target": "es2017"
   },
   "include": ["src", "types/*.d.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## What

Adding options to configure adaptive rendering.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1015

## Test Plan

Rendering without adaptive rendering should not be impacted.

