### PR TITLE
[SDK-1037] Add tslib as peer dependency to utils package

### DIFF
--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -44,5 +44,8 @@
     "rollup": "^1.19.4",
     "ts-jest": "^26.3.0",
     "typescript": "^4.0.2"
+  },
+  "peerDependencies": {
+    "tslib": "^1.10.0"
   }
 }

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -51,6 +51,7 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "protobufjs": "^6.9.0"
+    "protobufjs": "^6.9.0",
+    "tslib": "^1.10.0"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -51,5 +51,8 @@
     "ts-jest": "^26.3.0",
     "tslib": "^1.10.0",
     "typescript": "^4.0.2"
+  },
+  "peerDependencies": {
+    "tslib": "^1.10.0"
   }
 }


### PR DESCRIPTION
## What

Adding a peer dependency for `tslib` for the utils package. This should give a warning when trying to add `@vertexvis/utils` and the project doesn't have `tslib` as a dependency.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1037

