### PR TITLE
[SDK-1064] Update protos to include item supplied ids in hit results

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.1.5",
+    "@vertexvis/frame-streaming-protos": "^0.3.0",
     "@vertexvis/utils": "0.9.7"
   },
   "devDependencies": {

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -659,10 +659,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.1.5.tgz#eac6b0df86fff77c5667d0ce43b13d481dc68f88"
-  integrity sha512-uJRhrHvNgBp2ih9fx5U6tVwkisc4n9+XtS+4KIO/0Da8LfuBzWJfRHL6VTuxdjgm78yW1RVIOeffYW2clh/cMA==
+"@vertexvis/frame-streaming-protos@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.0.tgz#e1d86f8ce564e91a70b432c5055f340832208a89"
+  integrity sha512-BKjffEomGPtH3GIMIwAiT3MfpEu2nzRbs63bxtMYOUAQ1MhntFeF3B3pPoeUZZeUd59xbH8/nfHg52gXMzUj7g==
 
 "@vertexvis/jest-config-vertexvis@^0.5.0":
   version "0.5.0"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.1.5",
+    "@vertexvis/frame-streaming-protos": "^0.3.0",
     "@vertexvis/geometry": "0.9.7",
     "@vertexvis/stream-api": "0.9.7",
     "@vertexvis/utils": "0.9.7",

--- a/packages/viewer/src/metrics/timing.ts
+++ b/packages/viewer/src/metrics/timing.ts
@@ -1,6 +1,6 @@
 import { isPromise } from '../types';
 
-interface Timing {
+export interface Timing {
   startTime: number;
   duration: number;
 }

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -641,10 +641,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.1.5.tgz#eac6b0df86fff77c5667d0ce43b13d481dc68f88"
-  integrity sha512-uJRhrHvNgBp2ih9fx5U6tVwkisc4n9+XtS+4KIO/0Da8LfuBzWJfRHL6VTuxdjgm78yW1RVIOeffYW2clh/cMA==
+"@vertexvis/frame-streaming-protos@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.0.tgz#e1d86f8ce564e91a70b432c5055f340832208a89"
+  integrity sha512-BKjffEomGPtH3GIMIwAiT3MfpEu2nzRbs63bxtMYOUAQ1MhntFeF3B3pPoeUZZeUd59xbH8/nfHg52gXMzUj7g==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What

Updates the protos so they include the correct type for item supplied ids in hit results. Also includes a fix for update dimensions causing warnings in FSS. This call was being made before the stream was started in FSS.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1064

## Test Plan

```html
<!DOCTYPE html>
<html dir="ltr" lang="en">
  <head>
    <meta charset="utf-8" />
    <meta
      name="viewport"
      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
    />
    <title>Stencil Component Starter</title>

    <script type="module" src="/build/viewer.esm.js"></script>
    <script nomodule src="/build/viewer.js"></script>
    <link rel="stylesheet" href="/build/viewer.css" />

    <style>
      html,
      body {
        width: 100%;
        height: 100%;
        padding: 0;
        margin: 0;
      }

      #viewer {
        width: 100%;
        height: 100%;
      }
    </style>

    <script type="module">
      window.addEventListener('DOMContentLoaded', () => {
        main();
      });

      async function main() {
        const viewer = document.querySelector('#viewer');
        viewer.config = {
          flags: { logWsMessages: true },
        };

        viewer.addEventListener('tap', async event => {
          const pt = event.detail;
          console.log('pt', pt.position);
          const scene = await viewer.scene();
          const raycaster = scene.raycaster();
          const hits = await raycaster.hitItems(pt.position);

          console.log('hits', hits);
          console.log('itemsuppliedid', hits.hits[0].itemSuppliedId.value);
        });
      }
    </script>
  </head>

  <body>
    <vertex-viewer
      id="viewer"
      config-env="platdev"
      src="urn:vertexvis:stream-key:Rf9Y5sais-HjJOTQeW9VPSD5GRe-wSjhtgZM"
    ></vertex-viewer>
  </body>
</html>

```

