### PR TITLE
[SDK-1089] Enable flags for adaptive rendering and rate limited delivery

### DIFF
--- a/packages/viewer/src/types/flags.ts
+++ b/packages/viewer/src/types/flags.ts
@@ -25,8 +25,8 @@ type Flag =
 export type Flags = { [K in Flag]: boolean };
 
 export const defaultFlags: Flags = {
-  throttleFrameDelivery: false,
-  adaptiveRendering: false,
+  throttleFrameDelivery: true,
+  adaptiveRendering: true,
   logWsMessages: false,
 };
 


### PR DESCRIPTION
## What

Defaults the flags to on for adaptive rendering and rate limited frame delivery.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1089

