### PR TITLE
[SDK-1161] Clear streamId on viewer.dispose()

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -356,10 +356,10 @@ export class Viewer {
   @Method()
   public async unload(): Promise<void> {
     if (this.streamDisposable != null) {
+      this.streamId = undefined;
       this.streamDisposable.dispose();
       this.lastFrame = undefined;
       this.sceneViewId = undefined;
-      this.streamId = undefined;
       this.clock = undefined;
       this.errorMessage = undefined;
       this.resource = undefined;
@@ -388,6 +388,23 @@ export class Viewer {
    */
   public getStreamApi(): ViewerStreamApi {
     return this.stream;
+  }
+
+  /**
+   * @private Used for testing.
+   */
+  public async handleWebSocketClose(): Promise<void> {
+    if (this.isStreamStarted) {
+      this.isStreamStarted = false;
+
+      if (
+        this.streamId != null &&
+        this.resource != null &&
+        !this.isReconnecting
+      ) {
+        await this.reconnectWebSocket(this.resource, this.streamId);
+      }
+    }
   }
 
   private async connectStreamingClient(
@@ -519,20 +536,6 @@ export class Viewer {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (result as any).viewer = this.hostElement;
       });
-  }
-
-  private async handleWebSocketClose(): Promise<void> {
-    if (this.isStreamStarted) {
-      this.isStreamStarted = false;
-
-      if (
-        this.streamId != null &&
-        this.resource != null &&
-        !this.isReconnecting
-      ) {
-        await this.reconnectWebSocket(this.resource, this.streamId);
-      }
-    }
   }
 
   private async handleStreamRequest(

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -359,6 +359,7 @@ export class Viewer {
       this.streamDisposable.dispose();
       this.lastFrame = undefined;
       this.sceneViewId = undefined;
+      this.streamId = undefined;
       this.clock = undefined;
       this.errorMessage = undefined;
       this.resource = undefined;


### PR DESCRIPTION
## What

Fixes an issue with loading of a second scene in the viewer where the `streamId` was not cleared out and would cause a problem opening a second connection. With the `streamId` and `resource` defined, the WS connection would attempt to reconnect when closed, rather than start a stream, which introduced a problem when a `reconnect` happened before the `startStream`, and cause the second connection to fail.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1161

## Test Plan

- Test loading the html in the above ticket with these changes
```
-  <link rel="stylesheet" href="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.css" />
-  <script type="module" src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.esm.js"></script>
-  <script nomodule src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer.js"></script>

+  <link rel="stylesheet" href="https://c24f1d432f34.ngrok.io/viewer/viewer.css" />
+  <script type="module" src="https://c24f1d432f34.ngrok.io/viewer/viewer.esm.js"></script>
+  <script nomodule src="https://c24f1d432f34.ngrok.io/viewer.js"></script>
```

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A

@Vertexvis/sdk 
PTAL