### PR TITLE
[SDK-1147] Support for double tap and long press events

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -108,6 +108,10 @@ declare namespace LocalJSX {
          */
         "onFrameReceived"?: (event: CustomEvent<Frame.Frame>) => void;
         /**
+          * Emits an event whenever the user taps or clicks a location in the viewer and the configured amount of time passes without receiving a mouseup or touchend. The event includes the location of the tap or click.
+         */
+        "onLongpress"?: (event: CustomEvent<TapEventDetails>) => void;
+        /**
           * Emits an event whenever the user taps or clicks a location in the viewer. The event includes the location of the tap or click.
          */
         "onTap"?: (event: CustomEvent<TapEventDetails>) => void;

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -96,6 +96,10 @@ declare namespace LocalJSX {
          */
         "configEnv"?: Environment;
         /**
+          * Emits an event whenever the user double taps or clicks a location in the viewer. The event includes the location of the first tap or click.
+         */
+        "onDoubletap"?: (event: CustomEvent<TapEventDetails>) => void;
+        /**
           * Emits an event when a frame has been drawn to the viewer's canvas. The event will include details about the drawn frame, such as the `Scene` information related to the scene.
          */
         "onFrameDrawn"?: (event: CustomEvent<Frame.Frame>) => void;

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -113,6 +113,13 @@ export class Viewer {
   @Event() public doubletap!: EventEmitter<TapEventDetails>;
 
   /**
+   * Emits an event whenever the user taps or clicks a location in the viewer and the
+   * configured amount of time passes without receiving a mouseup or touchend.
+   * The event includes the location of the tap or click.
+   */
+  @Event() public longpress!: EventEmitter<TapEventDetails>;
+
+  /**
    * Emits an event when a frame has been received by the viewer. The event
    * will include details about the drawn frame, such as the `Scene` information
    * related to the scene.
@@ -660,7 +667,8 @@ export class Viewer {
       this.stream,
       () => this.createScene(),
       this.tap,
-      this.doubletap
+      this.doubletap,
+      this.longpress
     );
   }
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -198,7 +198,9 @@ export class Viewer {
       this.registerInteractionHandler(new TouchInteractionHandler());
     }
 
-    this.registerInteractionHandler(new TapInteractionHandler());
+    this.registerInteractionHandler(
+      new TapInteractionHandler(() => this.getConfig())
+    );
 
     this.injectViewerApi();
   }

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -107,6 +107,12 @@ export class Viewer {
   @Event() public tap!: EventEmitter<TapEventDetails>;
 
   /**
+   * Emits an event whenever the user double taps or clicks a location in the viewer.
+   * The event includes the location of the first tap or click.
+   */
+  @Event() public doubletap!: EventEmitter<TapEventDetails>;
+
+  /**
    * Emits an event when a frame has been received by the viewer. The event
    * will include details about the drawn frame, such as the `Scene` information
    * related to the scene.
@@ -650,7 +656,12 @@ export class Viewer {
       );
     }
 
-    return new InteractionApi(this.stream, () => this.createScene(), this.tap);
+    return new InteractionApi(
+      this.stream,
+      () => this.createScene(),
+      this.tap,
+      this.doubletap
+    );
   }
 
   private createScene(): Scene {

--- a/packages/viewer/src/config/config.ts
+++ b/packages/viewer/src/config/config.ts
@@ -1,6 +1,6 @@
 import { Objects, DeepPartial } from '@vertexvis/utils';
 import { Environment } from './environment';
-import { Flags } from '../types';
+import { Flags, Events } from '../types';
 import { FrameDeliverySettings } from '@vertexvis/stream-api';
 import {
   AdaptiveRenderingSettings,
@@ -15,6 +15,7 @@ interface NetworkConfig {
 export interface Config {
   network: NetworkConfig;
   flags: Flags.Flags;
+  events: Events.EventConfig;
   EXPERIMENTAL_frameDelivery: Omit<
     FrameDeliverySettings,
     'rateLimitingEnabled'
@@ -33,6 +34,7 @@ const platdevConfig: Config = {
     renderingHost: 'wss://stream.platdev.vertexvis.io',
   },
   flags: Flags.defaultFlags,
+  events: Events.defaultEventConfig,
   EXPERIMENTAL_frameDelivery: {},
   EXPERIMENTAL_adaptiveRendering: {},
   EXPERIMENTAL_qualityOfService: {},
@@ -44,6 +46,7 @@ const platprodConfig: Config = {
     renderingHost: 'wss://stream.platprod.vertexvis.io',
   },
   flags: Flags.defaultFlags,
+  events: Events.defaultEventConfig,
   EXPERIMENTAL_frameDelivery: {},
   EXPERIMENTAL_adaptiveRendering: {},
   EXPERIMENTAL_qualityOfService: {},

--- a/packages/viewer/src/interactions/__tests__/tapInteractionHandler.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/tapInteractionHandler.spec.ts
@@ -4,6 +4,7 @@ jest.mock('../mouseInteractions');
 import { TapInteractionHandler } from '../tapInteractionHandler';
 import { InteractionApi } from '../interactionApi';
 import { Point } from '@vertexvis/geometry';
+import { parseConfig } from '../../config/config';
 
 const InteractionApiMock = InteractionApi as jest.Mock<InteractionApi>;
 
@@ -29,18 +30,34 @@ describe(TapInteractionHandler, () => {
     clientX: 15,
     clientY: 15,
   });
+  const mouseMove1 = new MouseEvent('mousemove', {
+    clientX: 15,
+    clientY: 15,
+  });
+  const mouseMove2 = new MouseEvent('mousemove', {
+    clientX: 11,
+    clientY: 10,
+  });
   const touchStart = new Event('touchstart', {
     touches: [{ clientX: 10, clientY: 10, identifier: 1 }],
-  } as unknown);
+  } as any);
   const touchEnd = new Event('touchend', {
     touches: [{ clientX: 10, clientY: 10, identifier: 1 }],
-  } as unknown);
+  } as any);
+  const touchMove1 = new Event('touchmove', {
+    touches: [{ clientX: 15, clientY: 15, identifier: 1 }],
+  } as any);
+  const touchMove2 = new Event('touchmove', {
+    touches: [{ clientX: 11, clientY: 10, identifier: 1 }],
+  } as any);
 
-  const handler = new TapInteractionHandler();
+  const handler = new TapInteractionHandler(() => parseConfig('platdev'));
 
   beforeEach(() => {
     jest.resetAllMocks();
     jest.clearAllMocks();
+    jest.useRealTimers();
+    jest.clearAllTimers();
 
     handler.initialize(div, api);
   });
@@ -68,5 +85,185 @@ describe(TapInteractionHandler, () => {
     window.dispatchEvent(mouseUp2);
 
     expect(api.tap).not.toHaveBeenCalledWith(Point.create(15, 15), keyDetails);
+  });
+
+  it('should emit a double tap if two taps occur within the configured time period of one another', () => {
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchEnd);
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should not emit a double tap if the second tap occurs after the time period', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchEnd);
+    jest.advanceTimersByTime(5000);
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.doubleTap).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should emit a double tap if two clicks occur within the configured time period of one another', () => {
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseUp1);
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseUp1);
+
+    expect(api.doubleTap).toHaveBeenCalledWith(
+      Point.create(10, 10),
+      keyDetails
+    );
+  });
+
+  it('should not emit a double tap if the second click occurs after the time period', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseUp1);
+    jest.advanceTimersByTime(5000);
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseUp1);
+
+    expect(api.doubleTap).not.toHaveBeenCalledWith(
+      Point.create(10, 10),
+      keyDetails
+    );
+  });
+
+  it('should not emit a double tap if a touch move has occurred >= 2 pixels away from the touch start', () => {
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchEnd);
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchMove1);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.doubleTap).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should emit a double tap if a touch move has occurred < 2 pixels away from the touch start', () => {
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchEnd);
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchMove2);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should not emit a double tap if a mouse move has occurred >= 2 pixels away from the mouse down', () => {
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseUp1);
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseMove1);
+    window.dispatchEvent(mouseUp1);
+
+    expect(api.doubleTap).not.toHaveBeenCalledWith(
+      Point.create(10, 10),
+      keyDetails
+    );
+  });
+
+  it('should emit a double tap if a mouse move has occurred < 2 pixels away from the mouse down', () => {
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseUp1);
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseMove2);
+    window.dispatchEvent(mouseUp1);
+
+    expect(api.doubleTap).toHaveBeenCalledWith(
+      Point.create(10, 10),
+      keyDetails
+    );
+  });
+
+  it('should emit a long press if a touch start occurs and a touch end does not occur within the configured time threshold', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(touchStart);
+    jest.advanceTimersByTime(5000);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.longPress).toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should not emit a long press if a touch start occurs and a touch end occurs within the configured time threshold', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(touchStart);
+    jest.advanceTimersByTime(200);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.longPress).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should emit a long press if a mouse down occurs and a mouse up does not occur within the configured time threshold', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(mouseDown);
+    jest.advanceTimersByTime(5000);
+    window.dispatchEvent(mouseUp1);
+
+    expect(api.longPress).toHaveBeenCalledWith(
+      Point.create(10, 10),
+      keyDetails
+    );
+  });
+
+  it('should not emit a long press if a mouse down occurs and a mouse up occurs within the configured time threshold', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(mouseDown);
+    jest.advanceTimersByTime(200);
+    window.dispatchEvent(mouseUp1);
+
+    expect(api.longPress).not.toHaveBeenCalledWith(
+      Point.create(10, 10),
+      keyDetails
+    );
+  });
+
+  it('should not emit a long press if a touch move has occurred >= 2 pixels away from the touch start', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchMove1);
+    jest.advanceTimersByTime(5000);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.longPress).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should emit a long press if a touch move has occurred < 2 pixels away from the touch start', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchMove2);
+    jest.advanceTimersByTime(5000);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.longPress).toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should not emit a long press if a mouse move has occurred >= 2 pixels away from the mouse down', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseMove1);
+    jest.advanceTimersByTime(5000);
+    window.dispatchEvent(mouseUp1);
+
+    expect(api.longPress).not.toHaveBeenCalledWith(
+      Point.create(10, 10),
+      keyDetails
+    );
+  });
+
+  it('should emit a long press if a mouse move has occurred < 2 pixels away from the mouse down', () => {
+    jest.useFakeTimers();
+    div.dispatchEvent(mouseDown);
+    jest.advanceTimersByTime(5000);
+    window.dispatchEvent(mouseMove2);
+    window.dispatchEvent(mouseUp1);
+
+    expect(api.longPress).toHaveBeenCalledWith(
+      Point.create(10, 10),
+      keyDetails
+    );
   });
 });

--- a/packages/viewer/src/interactions/interactionApi.ts
+++ b/packages/viewer/src/interactions/interactionApi.ts
@@ -22,10 +22,13 @@ export class InteractionApi {
     private stream: StreamApi,
     private getScene: SceneProvider,
     private tapEmitter: EventEmitter<TapEventDetails>,
-    private doubleTapEmitter: EventEmitter<TapEventDetails>
+    private doubleTapEmitter: EventEmitter<TapEventDetails>,
+    private longPressEmitter: EventEmitter<TapEventDetails>
   ) {
     this.tap = this.tap.bind(this);
     this.doubleTap = this.doubleTap.bind(this);
+    this.longPress = this.longPress.bind(this);
+    this.emitTapEvent = this.emitTapEvent.bind(this);
   }
 
   /**
@@ -40,32 +43,21 @@ export class InteractionApi {
     position: Point.Point,
     keyDetails: Partial<TapEventKeys> = {}
   ): Promise<void> {
-    const {
-      altKey = false,
-      ctrlKey = false,
-      metaKey = false,
-      shiftKey = false,
-    } = keyDetails;
-    this.tapEmitter.emit({ position, altKey, ctrlKey, metaKey, shiftKey });
+    this.emitTapEvent(this.tapEmitter.emit, position, keyDetails);
   }
 
   public async doubleTap(
     position: Point.Point,
     keyDetails: Partial<TapEventKeys> = {}
   ): Promise<void> {
-    const {
-      altKey = false,
-      ctrlKey = false,
-      metaKey = false,
-      shiftKey = false,
-    } = keyDetails;
-    this.doubleTapEmitter.emit({
-      position,
-      altKey,
-      ctrlKey,
-      metaKey,
-      shiftKey,
-    });
+    this.emitTapEvent(this.doubleTapEmitter.emit, position, keyDetails);
+  }
+
+  public async longPress(
+    position: Point.Point,
+    keyDetails: Partial<TapEventKeys> = {}
+  ): Promise<void> {
+    this.emitTapEvent(this.longPressEmitter.emit, position, keyDetails);
   }
 
   /**
@@ -197,5 +189,25 @@ export class InteractionApi {
    */
   public isInteracting(): boolean {
     return this.currentCamera != null;
+  }
+
+  private emitTapEvent(
+    emit: (details: TapEventDetails) => void,
+    position: Point.Point,
+    keyDetails: Partial<TapEventKeys> = {}
+  ): void {
+    const {
+      altKey = false,
+      ctrlKey = false,
+      metaKey = false,
+      shiftKey = false,
+    } = keyDetails;
+    emit({
+      position,
+      altKey,
+      ctrlKey,
+      metaKey,
+      shiftKey,
+    });
   }
 }

--- a/packages/viewer/src/interactions/interactionApi.ts
+++ b/packages/viewer/src/interactions/interactionApi.ts
@@ -21,8 +21,12 @@ export class InteractionApi {
   public constructor(
     private stream: StreamApi,
     private getScene: SceneProvider,
-    private tapEmitter: EventEmitter<TapEventDetails>
-  ) {}
+    private tapEmitter: EventEmitter<TapEventDetails>,
+    private doubleTapEmitter: EventEmitter<TapEventDetails>
+  ) {
+    this.tap = this.tap.bind(this);
+    this.doubleTap = this.doubleTap.bind(this);
+  }
 
   /**
    * Emits a tap event with the provided position relative to the viewer
@@ -43,6 +47,25 @@ export class InteractionApi {
       shiftKey = false,
     } = keyDetails;
     this.tapEmitter.emit({ position, altKey, ctrlKey, metaKey, shiftKey });
+  }
+
+  public async doubleTap(
+    position: Point.Point,
+    keyDetails: Partial<TapEventKeys> = {}
+  ): Promise<void> {
+    const {
+      altKey = false,
+      ctrlKey = false,
+      metaKey = false,
+      shiftKey = false,
+    } = keyDetails;
+    this.doubleTapEmitter.emit({
+      position,
+      altKey,
+      ctrlKey,
+      metaKey,
+      shiftKey,
+    });
   }
 
   /**

--- a/packages/viewer/src/interactions/tapInteractionHandler.ts
+++ b/packages/viewer/src/interactions/tapInteractionHandler.ts
@@ -20,8 +20,8 @@ export class TapInteractionHandler implements InteractionHandler {
   private firstPointerDownPosition?: Point.Point;
   private secondPointerDownPosition?: Point.Point;
 
-  private doubleTapTimer?: number;
-  private longPressTimer?: number;
+  private doubleTapTimer?: any;
+  private longPressTimer?: any;
 
   public constructor(private getConfig: ConfigProvider) {
     this.handleMouseDown = this.handleMouseDown.bind(this);
@@ -45,6 +45,9 @@ export class TapInteractionHandler implements InteractionHandler {
     this.element?.removeEventListener('mousedown', this.handleMouseDown);
     this.element?.removeEventListener('touchstart', this.handleTouchStart);
     this.element = undefined;
+
+    this.clearDoubleTapTimer();
+    this.clearLongPressTimer();
   }
 
   public initialize(element: HTMLElement, api: InteractionApi): void {
@@ -61,13 +64,7 @@ export class TapInteractionHandler implements InteractionHandler {
         Point.create(event.touches[0].clientX, event.touches[0].clientY)
       );
 
-      const eventKeys = {
-        altKey: event.altKey,
-        ctrlKey: event.ctrlKey,
-        metaKey: event.metaKey,
-        shiftKey: event.shiftKey,
-      };
-      this.restartLongPressTimer(eventKeys);
+      this.restartLongPressTimer();
 
       window.addEventListener('touchend', this.handleTouchEnd);
       window.addEventListener('touchmove', this.handleTouchMove);
@@ -77,7 +74,13 @@ export class TapInteractionHandler implements InteractionHandler {
   private handleMouseDown(event: MouseEvent): void {
     this.setPointerPositions(Point.create(event.clientX, event.clientY));
 
-    this.restartLongPressTimer();
+    const eventKeys = {
+      altKey: event.altKey,
+      ctrlKey: event.ctrlKey,
+      metaKey: event.metaKey,
+      shiftKey: event.shiftKey,
+    };
+    this.restartLongPressTimer(eventKeys);
 
     window.addEventListener('mouseup', this.handleMouseUp);
     window.addEventListener('mousemove', this.handleMouseMove);
@@ -198,7 +201,7 @@ export class TapInteractionHandler implements InteractionHandler {
 
   private clearDoubleTapTimer(): void {
     if (this.doubleTapTimer != null) {
-      window.clearTimeout(this.doubleTapTimer);
+      clearTimeout(this.doubleTapTimer);
     }
     this.doubleTapTimer = undefined;
     this.firstPointerDownPosition = undefined;
@@ -207,7 +210,7 @@ export class TapInteractionHandler implements InteractionHandler {
 
   private restartDoubleTapTimer(): void {
     this.clearDoubleTapTimer();
-    this.doubleTapTimer = window.setTimeout(
+    this.doubleTapTimer = setTimeout(
       () => this.clearDoubleTapTimer(),
       this.getConfig().events.doubleTapThreshold
     );
@@ -215,14 +218,14 @@ export class TapInteractionHandler implements InteractionHandler {
 
   private clearLongPressTimer(): void {
     if (this.longPressTimer != null) {
-      window.clearTimeout(this.longPressTimer);
+      clearTimeout(this.longPressTimer);
     }
     this.longPressTimer = undefined;
   }
 
   private restartLongPressTimer(eventKeys: Partial<TapEventKeys> = {}): void {
     this.clearLongPressTimer();
-    this.longPressTimer = window.setTimeout(() => {
+    this.longPressTimer = setTimeout(() => {
       if (this.pointerDownPosition) {
         this.emit(this.interactionApi?.longPress)(
           this.pointerDownPosition,

--- a/packages/viewer/src/interactions/touchInteractionHandler.ts
+++ b/packages/viewer/src/interactions/touchInteractionHandler.ts
@@ -6,6 +6,7 @@ export class TouchInteractionHandler implements InteractionHandler {
   private element?: HTMLElement;
   private interactionApi?: InteractionApi;
 
+  private isInteracting?: boolean;
   private currentPosition1?: Point.Point;
   private currentPosition2?: Point.Point;
 
@@ -60,6 +61,8 @@ export class TouchInteractionHandler implements InteractionHandler {
   private handleTouchEnd(event: TouchEvent): void {
     this.interactionApi?.endInteraction();
 
+    this.isInteracting = false;
+
     window.removeEventListener('touchmove', this.handleTouchMove);
     window.removeEventListener('touchend', this.handleTouchEnd);
   }
@@ -70,9 +73,10 @@ export class TouchInteractionHandler implements InteractionHandler {
     if (this.currentPosition1 != null) {
       const delta = Point.subtract(position, this.currentPosition1);
 
-      if (Point.distance(position, this.currentPosition1) >= 2) {
+      if (Point.distance(position, this.currentPosition1) >= 2 || this.isInteracting) {
         this.interactionApi?.beginInteraction();
         this.interactionApi?.rotateCamera(delta);
+        this.isInteracting = true;
       }
     }
 

--- a/packages/viewer/src/interactions/touchInteractionHandler.ts
+++ b/packages/viewer/src/interactions/touchInteractionHandler.ts
@@ -73,7 +73,10 @@ export class TouchInteractionHandler implements InteractionHandler {
     if (this.currentPosition1 != null) {
       const delta = Point.subtract(position, this.currentPosition1);
 
-      if (Point.distance(position, this.currentPosition1) >= 2 || this.isInteracting) {
+      if (
+        Point.distance(position, this.currentPosition1) >= 2 ||
+        this.isInteracting
+      ) {
         this.interactionApi?.beginInteraction();
         this.interactionApi?.rotateCamera(delta);
         this.isInteracting = true;

--- a/packages/viewer/src/types/events.ts
+++ b/packages/viewer/src/types/events.ts
@@ -1,0 +1,18 @@
+export interface EventConfig {
+  /**
+   * The number of milliseconds after a single tap where a second tap will
+   * trigger the "doubletap" event.
+   */
+  doubleTapThreshold: number;
+
+  /**
+   * The number of milliseconds that a tap or click has to be held down
+   * before triggering the "longpress" event.
+   */
+  longPressThreshold: number;
+}
+
+export const defaultEventConfig: EventConfig = {
+  doubleTapThreshold: 500,
+  longPressThreshold: 500,
+};

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -1,4 +1,5 @@
 import * as Flags from './flags';
+import * as Events from './events';
 import * as FrameCamera from './frameCamera';
 import * as Frame from './frame';
 import * as LoadableResource from './loadableResource';
@@ -7,4 +8,4 @@ export * from './synchronizedClock';
 
 export * from './typeGuards';
 
-export { Flags, Frame, FrameCamera, LoadableResource };
+export { Events, Flags, Frame, FrameCamera, LoadableResource };


### PR DESCRIPTION
## What

Adds support for a `doubletap` and `longpress` event. These both default to allowing a second tap to trigger a `doubletap` if it occurs within 500ms, and triggering a `longpress` if a mousedown/touchstart occur and 500ms pass before a mouseup/touchend are received. These durations are configurable through the `viewer.config` property by passing:
```javascript
viewer.config = {
  events: {
    longPressThreshold: {ms},
    doubleTapThreshold: {ms}
  }
}
```

Also made a small adjustment to the touch interaction handler for rotating the camera to allow for single pixel movements after you've initiated a rotation (by moving a distance >= 2 pixels). This allows for more fine-tuned movements of the camera during a touch-based camera interaction.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1147

## Test Plan

- Test adding a listener for a `doubletap` event
  - When a double tap occurs an event containing the position of the tap should be emitted
- Test adding a listener for a `longpress` event
  - When a long press (mouse/touch held down for 500ms) an event containing the position of the longpress should be emitted
- Test `tap` events
  - Tap events should fire for every tap/click (currently even when a doubletap fires)
- Test configuring the threshold for a `doubletap` event
  - Verify that the double tap can occur during this new threshold
- Test configuring the threshold for a `longpress` event
  - Verify that the long press can occur during this new threshold
- Test touch-based camera manipulation
  - After the initial 2 pixel movement, single pixel movements should manipulate the camera

## Areas of Possible Regression

Tap events, touch-based camera manipulation

## Out of scope changes made in PR

As mentioned above, the logic for when to manipulate the camera on touch events has been slightly adjusted

## Dependencies

N/A

@Vertexvis/sdk 
PTAL
