### PR TITLE
[SDK-1232] Bumping version of protos to support returning part ids on a hit result

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.3.3",
+    "@vertexvis/frame-streaming-protos": "^0.3.10",
     "@vertexvis/utils": "0.9.14"
   },
   "devDependencies": {

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -659,10 +659,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.3.tgz#2a975af4a2b8bdea0c004c0c329d0ebb2adee530"
-  integrity sha512-s5byzxCr2xTJCFPky1dXxx55J+6wVTD29rGHpphnO1fFND3iWvNldh+iLLYQOdzEycvqTU/+FD3whu1rHaguLQ==
+"@vertexvis/frame-streaming-protos@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.10.tgz#68e4aa5029008ec3637a3900406243c76dcaeb07"
+  integrity sha512-IFHmZww1MA7HREnv2pd/uvUtNXyar3kAXT9O0YoLwKJkzatrT3yII59YgPEAQ7HNj6jurQjrSkynbD79MW7f5g==
 
 "@vertexvis/jest-config-vertexvis@^0.5.0":
   version "0.5.0"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.3.3",
+    "@vertexvis/frame-streaming-protos": "^0.3.10",
     "@vertexvis/geometry": "0.9.14",
     "@vertexvis/stream-api": "0.9.14",
     "@vertexvis/utils": "0.9.14",

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -641,10 +641,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.3.tgz#2a975af4a2b8bdea0c004c0c329d0ebb2adee530"
-  integrity sha512-s5byzxCr2xTJCFPky1dXxx55J+6wVTD29rGHpphnO1fFND3iWvNldh+iLLYQOdzEycvqTU/+FD3whu1rHaguLQ==
+"@vertexvis/frame-streaming-protos@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.10.tgz#68e4aa5029008ec3637a3900406243c76dcaeb07"
+  integrity sha512-IFHmZww1MA7HREnv2pd/uvUtNXyar3kAXT9O0YoLwKJkzatrT3yII59YgPEAQ7HNj6jurQjrSkynbD79MW7f5g==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
When a part revision is associated to a scene, you will now see the revision, part, and supplied revision Id on the hit result. 

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-1232

## Test Plan

<!-- Describe how your changes should be tested. -->
- on a hit response for a scene created with part revisions, do a console.log of the hit result. You should see the part id, part revision and supplied part revision if the data is present on the entity. 

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->
