### PR TITLE
[SDK-1025] Update reference to wait for custom element to be defined

### DIFF
--- a/packages/viewer/readme.md
+++ b/packages/viewer/readme.md
@@ -43,6 +43,28 @@ file that references our published JS bundles from a CDN.
 </html>
 ```
 
+If you want to interact with the web component via JavaScript, you'll need to ensure the browser has registered the custom elements prior to use. 
+
+One option is to call this prior to any method calls on the viewer:
+```js
+  await window.customElements.whenDefined('vertex-viewer');
+```
+
+Another option is to import `defineCustomElements`, and this will register all custom elements in your DOM.
+```js
+import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
+
+async function main() {
+  const viewer = document.querySelector('#viewer');
+  viewer.load(...)
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  defineCustomElements(window).then(() => main());
+});
+
+```
+
 ### NPM Dependency
 
 Our components can also be installed as an NPM dependency and imported through a

--- a/packages/viewer/readme.md
+++ b/packages/viewer/readme.md
@@ -45,18 +45,13 @@ file that references our published JS bundles from a CDN.
 
 If you want to interact with the web component via JavaScript, you'll need to ensure the browser has registered the custom elements prior to use. 
 
-One option is to call this prior to any method calls on the viewer:
-```js
-  await window.customElements.whenDefined('vertex-viewer');
-```
-
-Another option is to import `defineCustomElements`, and this will register all custom elements in your DOM.
+Import `defineCustomElements`, and this will register all custom elements in your DOM.
 ```js
 import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
 
 async function main() {
   const viewer = document.querySelector('#viewer');
-  viewer.load(...)
+  viewer.load("urn:vertexvis:stream-key:123")
 }
 
 window.addEventListener('DOMContentLoaded', () => {

--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -28,7 +28,8 @@
     </style>
 
     <script type="module">
-      window.addEventListener('DOMContentLoaded', () => {
+      window.addEventListener('DOMContentLoaded', async () => {
+        await window.customElements.whenDefined('vertex-viewer');
         main();
       });
 

--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -28,13 +28,13 @@
     </style>
 
     <script type="module">
-      import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
-      
+
       window.addEventListener('DOMContentLoaded', () => {
-        defineCustomElements(window).then(() => main());
+        main();
       });
 
       async function main() {
+        await window.customElements.whenDefined('vertex-viewer');
         const viewer = document.querySelector('#viewer');
       }
     </script>

--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -35,7 +35,6 @@
       });
 
       async function main() {
-        await window.customElements.whenDefined('vertex-viewer');
         const viewer = document.querySelector('#viewer');
       }
     </script>

--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -28,12 +28,12 @@
     </style>
 
     <script type="module">
-      window.addEventListener('DOMContentLoaded', async () => {
-        await window.customElements.whenDefined('vertex-viewer');
+      window.addEventListener('DOMContentLoaded', () => {
         main();
       });
 
       async function main() {
+        await window.customElements.whenDefined('vertex-viewer');
         const viewer = document.querySelector('#viewer');
       }
     </script>

--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -28,8 +28,10 @@
     </style>
 
     <script type="module">
+      import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
+      
       window.addEventListener('DOMContentLoaded', () => {
-        main();
+        defineCustomElements(window).then(() => main());
       });
 
       async function main() {


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
In some browsers the custom elements are not yet defined. We will want to wait for those prior to trying to access any custom elements on our web component. 

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-1025

## Test Plan

<!-- Describe how your changes should be tested. -->
Ensure the regression steps on SDK-1025 do not happen any more with this change. Note, you'll need to update the html in the ticket with the code referenced in the example to get this to work. 

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->
N/A

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->
N/a

## Dependencies

<!-- Link to other PRs or tickets. -->
N/A
