### PR TITLE
[SDK-1249] Omit alpha from color in hex string converter

### DIFF
--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -119,7 +119,7 @@ export const isOpaque = (color: Color): boolean => {
  * Converts a `Color` to a hex string. The returned string will be prefixed with
  * `#`.
  */
-export const toHexString = (color: Color): string => {
+export const toHexString = (color: Omit<Color, 'a'>): string => {
   return `#${componentToHex(color.r)}${componentToHex(color.g)}${componentToHex(
     color.b
   )}`;


### PR DESCRIPTION
## What

The alpha component isn't used when converting color to a hex code. Omit it from the type.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1249

## Test Plan

<!-- Describe how your changes should be tested. -->

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->
