### PR TITLE
Change return type of hit items to use undefined

### DIFF
--- a/packages/viewer/src/scenes/raycaster.ts
+++ b/packages/viewer/src/scenes/raycaster.ts
@@ -16,9 +16,8 @@ export class Raycaster {
    */
   public async hitItems(
     point: Point.Point
-  ): Promise<vertexvis.protobuf.stream.IHitItemsResult | void> {
-    return this.stream.hitItems({ point }, true).then(resp => {
-      return resp.hitItems != null ? resp.hitItems : undefined;
-    });
+  ): Promise<vertexvis.protobuf.stream.IHitItemsResult | undefined> {
+    const res = await this.stream.hitItems({ point }, true);
+    return res.hitItems || undefined;
   }
 }


### PR DESCRIPTION
## What

Return type was incorrect. Should be `IHitItemsResult | undefined`. If `void` is used, then you need to provide a type guard to see if a `IHitItemsResult` is returned.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1249

## Test Plan

<!-- Describe how your changes should be tested. -->

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->
