### PR TITLE
[SDK-1302] Add logging for frame rate

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -579,6 +579,7 @@ export class Viewer {
     this.canvasRenderer = measureCanvasRenderer(
       Metrics.paintTime,
       createCanvasRenderer(),
+      this.getConfig().flags.logFrameRate,
       timings => this.reportPerformance(timings)
     );
     if (this.containerElement != null) {

--- a/packages/viewer/src/rendering/__tests__/canvas.spec.ts
+++ b/packages/viewer/src/rendering/__tests__/canvas.spec.ts
@@ -82,6 +82,7 @@ describe(measureCanvasRenderer, () => {
     const render = measureCanvasRenderer(
       meter,
       renderer,
+      false,
       callback,
       reportIntervalInMs
     );
@@ -98,6 +99,7 @@ describe(measureCanvasRenderer, () => {
     const render = measureCanvasRenderer(
       meter,
       renderer,
+      false,
       callback,
       reportIntervalInMs
     );

--- a/packages/viewer/src/rendering/canvas.ts
+++ b/packages/viewer/src/rendering/canvas.ts
@@ -61,7 +61,7 @@ export function measureCanvasRenderer(
 ): CanvasRenderer {
   let timer: number | undefined;
   let renderCount = 0;
-  let framesRendered: number | undefined;
+  let fpsFrameCount: number | undefined;
   let fpsHistory: number[] = [];
 
   function start(): void {
@@ -89,18 +89,18 @@ export function measureCanvasRenderer(
 
   if (logFrameRate != null) {
     setInterval(() => {
-      if (framesRendered != null) {
+      if (fpsFrameCount != null) {
         if (fpsHistory.length === 5) {
-          fpsHistory = [...fpsHistory.slice(1), framesRendered];
+          fpsHistory = [...fpsHistory.slice(1), fpsFrameCount];
         } else {
-          fpsHistory.push(framesRendered);
+          fpsHistory.push(fpsFrameCount);
         }
 
         const avgFps =
           fpsHistory.reduce((res, num) => res + num) / fpsHistory.length;
-        console.debug(`Paint rate: ${framesRendered}fps`);
+        console.debug(`Paint rate: ${fpsFrameCount}fps`);
         console.debug(`Paint rate (avg): ${avgFps}`);
-        framesRendered = undefined;
+        fpsFrameCount = undefined;
       }
     }, 1000);
   }
@@ -110,7 +110,7 @@ export function measureCanvasRenderer(
     return meter
       .measure(async () => {
         const frame = await renderer(data);
-        framesRendered = framesRendered == null ? 1 : framesRendered + 1;
+        fpsFrameCount = fpsFrameCount == null ? 1 : fpsFrameCount + 1;
         return frame;
       })
       .finally(() => end());

--- a/packages/viewer/src/rendering/canvas.ts
+++ b/packages/viewer/src/rendering/canvas.ts
@@ -119,7 +119,6 @@ export function measureCanvasRenderer(
 
 export function createCanvasRenderer(): CanvasRenderer {
   let lastFrameNumber: number | undefined;
-  let framesRendered: number | undefined;
 
   return async data => {
     const frameNumber = data.frame.sequenceNumber;
@@ -128,7 +127,6 @@ export function createCanvasRenderer(): CanvasRenderer {
     if (lastFrameNumber == null || frameNumber > lastFrameNumber) {
       lastFrameNumber = frameNumber;
       drawImage(image, data);
-      framesRendered = framesRendered == null ? 1 : framesRendered + 1;
     }
 
     image.dispose();

--- a/packages/viewer/src/types/flags.ts
+++ b/packages/viewer/src/types/flags.ts
@@ -16,7 +16,12 @@ type Flag =
   /**
    * Enables or disables logging of WS message payloads.
    */
-  | 'logWsMessages';
+  | 'logWsMessages'
+
+  /**
+   * Toggles the logging of frame rates.
+   */
+  | 'logFrameRate';
 
 /**
  * A set of experimental features that can be enabled through the viewer's
@@ -28,6 +33,7 @@ export const defaultFlags: Flags = {
   throttleFrameDelivery: true,
   adaptiveRendering: true,
   logWsMessages: false,
+  logFrameRate: false,
 };
 
 export function createFlags(


### PR DESCRIPTION
## What

Adds a flag to log the current and average (5s) frame rate to the console. Enable by:

```ts
viewer.config = {
  flags: { logFrameRate: true }
}
```

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1302

## Test Plan

<!-- Describe how your changes should be tested. -->

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->
