### PR TITLE
[SDK-1249] Expose the scene view id from the viewer

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -544,6 +544,9 @@ export class Viewer {
       if (result.startStream?.streamId?.hex != null) {
         this.streamId = result.startStream.streamId.hex;
       }
+      console.debug(
+        `Stream connected [stream-id=${this.streamId}, scene-view-id=${this.sceneViewId}]`
+      );
       await this.waitNextDrawnFrame(15 * 1000);
     } catch (e) {
       if (e instanceof CustomError) {
@@ -626,6 +629,9 @@ export class Viewer {
       });
       this.isStreamStarted = true;
       this.isReconnecting = false;
+      console.debug(
+        `Stream reconnected [stream-id=${this.streamId}, scene-view-id=${this.sceneViewId}]`
+      );
     } catch (e) {
       if (e instanceof CustomError) {
         throw e;

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -808,7 +808,6 @@ export class Viewer {
         this.stream,
         this.remoteRenderer,
         this.lastFrame,
-        this.commands,
         this.sceneViewId
       );
     }

--- a/packages/viewer/src/interactions/__tests__/interactionApi.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/interactionApi.spec.ts
@@ -5,21 +5,15 @@ import { Point } from '@vertexvis/geometry';
 import { InteractionApi } from '../interactionApi';
 import { frame } from '../../types/__fixtures__';
 import { StreamApi } from '@vertexvis/stream-api';
-import { CommandRegistry } from '../../commands/commandRegistry';
 
 describe(InteractionApi, () => {
-  const emit = jest.fn();
+  const emitTap = jest.fn();
+  const emitDoubleTap = jest.fn();
+  const emitLongPress = jest.fn();
   const streamApi = new StreamApi();
   const renderer = jest.fn();
-  const config = {
-    network: {
-      apiHost: 'https://testing.io',
-      renderingHost: 'wss://testing.io',
-    },
-  };
   const sceneViewId = 'scene-view-id';
-  const commands = new CommandRegistry(streamApi, () => config);
-  const scene = new Scene(streamApi, renderer, frame, commands, sceneViewId);
+  const scene = new Scene(streamApi, renderer, frame, sceneViewId);
   const sceneProvider = (): Scene => scene;
 
   let api: InteractionApi;
@@ -28,7 +22,13 @@ describe(InteractionApi, () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
 
-    api = new InteractionApi(streamApi, sceneProvider, { emit });
+    api = new InteractionApi(
+      streamApi,
+      sceneProvider,
+      { emit: emitTap },
+      { emit: emitDoubleTap },
+      { emit: emitLongPress }
+    );
   });
 
   describe(InteractionApi.prototype.beginInteraction, () => {
@@ -102,14 +102,14 @@ describe(InteractionApi, () => {
   describe(InteractionApi.prototype.tap, () => {
     beforeEach(() => {
       api = new InteractionApi(streamApi, sceneProvider, {
-        emit,
+        emit: emitTap,
       });
     });
 
     it('emits a tap event', async () => {
       const point = Point.create();
       await api.tap(point);
-      expect(emit).toHaveBeenCalledWith({
+      expect(emitTap).toHaveBeenCalledWith({
         position: point,
         altKey: false,
         ctrlKey: false,
@@ -128,7 +128,7 @@ describe(InteractionApi, () => {
       };
 
       await api.tap(point, details);
-      expect(emit).toHaveBeenCalledWith({
+      expect(emitTap).toHaveBeenCalledWith({
         position: point,
         ...details,
       });

--- a/packages/viewer/src/rendering/canvas.ts
+++ b/packages/viewer/src/rendering/canvas.ts
@@ -87,7 +87,7 @@ export function measureCanvasRenderer(
     }
   }
 
-  if (logFrameRate != null) {
+  if (logFrameRate) {
     setInterval(() => {
       if (fpsFrameCount != null) {
         if (fpsHistory.length === 5) {

--- a/packages/viewer/src/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/scene.spec.ts
@@ -1,32 +1,20 @@
+jest.mock('@vertexvis/stream-api');
+
 import { Scene } from '../scene';
 import { StreamApi } from '@vertexvis/stream-api';
 import { Dimensions } from '@vertexvis/geometry';
 import { frame } from '../../types/__fixtures__';
-import { CommandRegistry } from '../../commands/commandRegistry';
 import { UUID } from '@vertexvis/utils';
 import { ColorMaterial } from '../..';
 
 describe(Scene, () => {
-  const executeMock = jest.fn();
-  const commandRegistry = ({
-    execute: executeMock,
-  } as unknown) as CommandRegistry;
   const renderer = jest.fn();
   const sceneViewId: UUID.UUID = UUID.create();
-  const streamApi = {
-    createSceneAlteration: jest.fn(),
-  };
-  const scene = new Scene(
-    streamApi as StreamApi,
-    renderer,
-    frame,
-    commandRegistry,
-    sceneViewId
-  );
+  const streamApi = new StreamApi();
+  const scene = new Scene(streamApi, renderer, frame, sceneViewId);
 
   afterEach(() => {
-    executeMock.mockReset();
-    streamApi.createSceneAlteration.mockReset();
+    jest.resetAllMocks();
   });
 
   describe(Scene.prototype.camera, () => {

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -112,8 +112,7 @@ export class Scene {
     private stream: StreamApi,
     private renderer: RemoteRenderer,
     private frame: Frame.Frame,
-    private commands: CommandRegistry,
-    private sceneViewId: UUID.UUID
+    public readonly sceneViewId: UUID.UUID
   ) {}
 
   /**

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -10,7 +10,6 @@ import {
   ItemOperation,
 } from './operations';
 import { QueryExpression, SceneItemQueryExecutor } from './queries';
-import { CommandRegistry } from '../commands/commandRegistry';
 import { UUID } from '@vertexvis/utils';
 import { RemoteRenderer } from '../rendering';
 import { buildSceneOperation } from '../commands/streamCommandsMapper';


### PR DESCRIPTION
## What

There wasn't a way to get the loaded scene view id programmatically in the viewer. This adds that + some logging about connections.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1249

## Test Plan

<!-- Describe how your changes should be tested. -->

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->
