### PR TITLE
[SDK-1311] Support selection operations

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.3.12",
+    "@vertexvis/frame-streaming-protos": "^0.3.13",
     "@vertexvis/utils": "0.9.18"
   },
   "devDependencies": {

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -659,10 +659,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.12":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.12.tgz#62f16a14f41a8a66ce33669a76cc76fb3ee6deac"
-  integrity sha512-RTQEsroAP7WmJjQ40PHfZYIypmLqgZ8+FqlS2nEJbSchtA4V5ZEHaYvOLBfaZpZZo2RhW4Dr9FWpaav5Wnd7ag==
+"@vertexvis/frame-streaming-protos@^0.3.13":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.14.tgz#156de55954b45494ec2e1e43acf3a5129aa6b778"
+  integrity sha512-D9osgtsL5AXIbgjrYdmIqK+21DHtZnvmjIVMhHZHfoPf3i5nhlXVtXVIoZ/Tlry9sGxTM+N7cW3xoneZIfLlWA==
 
 "@vertexvis/jest-config-vertexvis@^0.5.0":
   version "0.5.0"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.3.12",
+    "@vertexvis/frame-streaming-protos": "^0.3.13",
     "@vertexvis/geometry": "0.9.18",
     "@vertexvis/stream-api": "0.9.18",
     "@vertexvis/utils": "0.9.18",

--- a/packages/viewer/src/commands/streamCommandsMapper.ts
+++ b/packages/viewer/src/commands/streamCommandsMapper.ts
@@ -96,6 +96,23 @@ function buildOperationTypes(
             visible: true,
           },
         };
+      case 'select':
+        return {
+          changeSelection: {
+            material: {
+              d: op.color.opacity,
+              ns: op.color.glossiness,
+              ka: op.color.ambient,
+              kd: op.color.diffuse,
+              ks: op.color.specular,
+              ke: op.color.emissive,
+            },
+          },
+        };
+      case 'deselect':
+        return {
+          changeSelection: {},
+        };
       default:
         return {};
     }

--- a/packages/viewer/src/scenes/operations.ts
+++ b/packages/viewer/src/scenes/operations.ts
@@ -9,6 +9,15 @@ interface HideItemOperation {
   type: 'hide';
 }
 
+interface SelectItemOperation {
+  type: 'select';
+  color: ColorMaterial;
+}
+
+interface DeselectItemOperation {
+  type: 'deselect';
+}
+
 interface ClearItemOperation {
   type: 'clear-override';
 }
@@ -26,6 +35,8 @@ export interface TransformOperation {
 export type ItemOperation =
   | ShowItemOperation
   | HideItemOperation
+  | SelectItemOperation
+  | DeselectItemOperation
   | ChangeMaterialOperation
   | ClearItemOperation
   | TransformOperation;
@@ -34,6 +45,8 @@ export interface SceneItemOperations<T> {
   materialOverride(color: ColorMaterial): T;
   show(): T;
   hide(): T;
+  select(color: ColorMaterial): T;
+  deselect(): T;
   clearMaterialOverrides(): T;
 }
 
@@ -71,6 +84,18 @@ export class SceneOperationBuilder
   public hide(): SceneOperationBuilder {
     return new SceneOperationBuilder(
       this.operations.concat([{ type: 'hide' }])
+    );
+  }
+
+  public select(color: ColorMaterial): SceneOperationBuilder {
+    return new SceneOperationBuilder(
+      this.operations.concat([{ type: 'select', color }])
+    );
+  }
+
+  public deselect(): SceneOperationBuilder {
+    return new SceneOperationBuilder(
+      this.operations.concat([{ type: 'deselect' }])
     );
   }
 

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -57,6 +57,24 @@ export class SceneItemOperationsBuilder
     return new SceneItemOperationsBuilder(this.query, this.builder.show());
   }
 
+  public select(color: ColorMaterial | string): SceneItemOperationsBuilder {
+    if (typeof color === 'string') {
+      return new SceneItemOperationsBuilder(
+        this.query,
+        this.builder.select(fromHex(color))
+      );
+    } else {
+      return new SceneItemOperationsBuilder(
+        this.query,
+        this.builder.select(color)
+      );
+    }
+  }
+
+  public deselect(): SceneItemOperationsBuilder {
+    return new SceneItemOperationsBuilder(this.query, this.builder.deselect());
+  }
+
   public clearMaterialOverrides(): SceneItemOperationsBuilder {
     return new SceneItemOperationsBuilder(
       this.query,

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -641,10 +641,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.12":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.12.tgz#62f16a14f41a8a66ce33669a76cc76fb3ee6deac"
-  integrity sha512-RTQEsroAP7WmJjQ40PHfZYIypmLqgZ8+FqlS2nEJbSchtA4V5ZEHaYvOLBfaZpZZo2RhW4Dr9FWpaav5Wnd7ag==
+"@vertexvis/frame-streaming-protos@^0.3.13":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.13.tgz#89111cbd6f41265b103e85d8c403c4a403a528d7"
+  integrity sha512-H2cAHJMQw5T55wSM5WdGbdUk72lI/bIjbb76LE+osFvs6kg4pekVaLLX8qS8w2fQrvudu0fPchK13IOZmsuDzw==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What

Adds support for selection operations.

```
const scene = await viewer.scene();

scene.items(op => 
  op.where(q => q.withItemId('id').select('#ff0000'))
);

scene.items(op => 
  op.where(q => q.withItemId('id').deselect())
);
```

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1311

## Test Plan

- Test applying selection through the SDK
- Test deselecting the same item

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
