### PR TITLE
[SDK-1332] Support bounding box on hits

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.3.13",
+    "@vertexvis/frame-streaming-protos": "^0.3.15",
     "@vertexvis/utils": "0.9.18"
   },
   "devDependencies": {

--- a/packages/stream-api/src/types.ts
+++ b/packages/stream-api/src/types.ts
@@ -35,7 +35,7 @@ export type UpdateDimensionsPayload = DeepRequired<
 
 export type HitItemsPayload = DeepRequired<
   vertexvis.protobuf.stream.IHitItemsPayload,
-  []
+  ['includeBoundingBox']
 >;
 
 export type DrawFramePayload = DeepRequired<

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -659,10 +659,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.13":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.14.tgz#156de55954b45494ec2e1e43acf3a5129aa6b778"
-  integrity sha512-D9osgtsL5AXIbgjrYdmIqK+21DHtZnvmjIVMhHZHfoPf3i5nhlXVtXVIoZ/Tlry9sGxTM+N7cW3xoneZIfLlWA==
+"@vertexvis/frame-streaming-protos@^0.3.15":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.15.tgz#79285b967c1921cc3a21cab157d2c459b2500bef"
+  integrity sha512-JlrHdrzWzOUnUTD6Gg3ojCMY17XbHmi2HHGATLlwLvRkmk/syIm63Y3cEBEw7izN8JMd8jlufvcLX8nnuXYCnw==
 
 "@vertexvis/jest-config-vertexvis@^0.5.0":
   version "0.5.0"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.3.13",
+    "@vertexvis/frame-streaming-protos": "^0.3.15",
     "@vertexvis/geometry": "0.9.18",
     "@vertexvis/stream-api": "0.9.18",
     "@vertexvis/utils": "0.9.18",

--- a/packages/viewer/src/scenes/__tests__/raycaster.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/raycaster.spec.ts
@@ -21,5 +21,15 @@ describe(Raycaster, () => {
         true
       );
     });
+
+    it('maps included fields', () => {
+      raycaster.hitItems(Point.create(10, 10), ['bounding-box']);
+      expect(api.hitItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          includeBoundingBox: true,
+        }),
+        true
+      );
+    });
   });
 });

--- a/packages/viewer/src/scenes/raycaster.ts
+++ b/packages/viewer/src/scenes/raycaster.ts
@@ -3,6 +3,11 @@ import { Point } from '@vertexvis/geometry';
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
 
 /**
+ * Additional fields that can be included with hit results.
+ */
+export type HitResultInclude = 'bounding-box';
+
+/**
  * The `Raycaster` class is here.
  */
 export class Raycaster {
@@ -13,11 +18,20 @@ export class Raycaster {
    * the given point.
    *
    * @param point The point to cast from looking for intersections.
+   * @param include (optional) Additional fields to be returned with each hit item.
+   * See the `HitResultInclude` type for available fields.
    */
   public async hitItems(
-    point: Point.Point
+    point: Point.Point,
+    include?: HitResultInclude[]
   ): Promise<vertexvis.protobuf.stream.IHitItemsResult | undefined> {
-    const res = await this.stream.hitItems({ point }, true);
+    const res = await this.stream.hitItems(
+      {
+        point,
+        includeBoundingBox: include && include.includes('bounding-box'),
+      },
+      true
+    );
     return res.hitItems || undefined;
   }
 }

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -641,10 +641,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.13":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.13.tgz#89111cbd6f41265b103e85d8c403c4a403a528d7"
-  integrity sha512-H2cAHJMQw5T55wSM5WdGbdUk72lI/bIjbb76LE+osFvs6kg4pekVaLLX8qS8w2fQrvudu0fPchK13IOZmsuDzw==
+"@vertexvis/frame-streaming-protos@^0.3.15":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.15.tgz#79285b967c1921cc3a21cab157d2c459b2500bef"
+  integrity sha512-JlrHdrzWzOUnUTD6Gg3ojCMY17XbHmi2HHGATLlwLvRkmk/syIm63Y3cEBEw7izN8JMd8jlufvcLX8nnuXYCnw==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What

Adds support to include bounding boxes with hit results.

```
const resultsWithBounds = await scene.raycaster().hitItems(event.detail.position, ['bounding-box']);
```

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1332

## Test Plan

- Test retrieving a bounding box for a hit item properly returns a bounding box
- Test retrieving hit items without passing `['bounding-box']` for the `include` property
  - Should return undefined for all hit items' bounding boxes

## Areas of Possible Regression

Hit requests

## Out of scope changes made in PR

N/A

## Dependencies

https://github.com/Vertexvis/frame-streaming-service/pull/144
