### PR TITLE
[SDK-1335][SDK-1052][SDK-1355] Animations on Camera Render, and support for fly to

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.3.12",
+    "@vertexvis/frame-streaming-protos": "^0.3.14",
     "@vertexvis/utils": "0.9.18"
   },
   "devDependencies": {

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.3.14",
+    "@vertexvis/frame-streaming-protos": "^0.3.17",
     "@vertexvis/utils": "0.9.18"
   },
   "devDependencies": {

--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -179,6 +179,28 @@ export class StreamApi {
   }
 
   /**
+   * Sends a request to update the position of the scene's camera as a fly operation
+   *
+   * The payload accepts an optional `frameCorrelationId` that will be sent
+   * back on the frame that is associated to this request. Use `onRequest` to
+   * add a callback that'll be invoked when the server sends a request to draw
+   * the frame.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param payload
+   * @param withResponse
+   */
+  public flyTo(
+    payload: vertexvis.protobuf.stream.IFlyToPayload,
+    withResponse = true
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
+    return this.sendRequest({ flyTo: payload }, withResponse);
+  }
+
+  /**
    * Sends a request to update the dimensions of the frame.
    *
    * The payload accepts an optional `frameCorrelationId` that will be sent

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -659,10 +659,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.14":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.14.tgz#156de55954b45494ec2e1e43acf3a5129aa6b778"
-  integrity sha512-D9osgtsL5AXIbgjrYdmIqK+21DHtZnvmjIVMhHZHfoPf3i5nhlXVtXVIoZ/Tlry9sGxTM+N7cW3xoneZIfLlWA==
+"@vertexvis/frame-streaming-protos@^0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.17.tgz#dd7a71dc7b6b3e6c481818fad8203ebb80cfd7a9"
+  integrity sha512-1f+HizaTr2Q1qlLDhGjGJTZ++QdPJ+FXRYCZ2X+N+2pDrCEAzPVT4c6T5sry7Uf7FXVFAWHWY+wwGGyj9D0fXg==
 
 "@vertexvis/jest-config-vertexvis@^0.5.0":
   version "0.5.0"

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -659,10 +659,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.12":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.12.tgz#62f16a14f41a8a66ce33669a76cc76fb3ee6deac"
-  integrity sha512-RTQEsroAP7WmJjQ40PHfZYIypmLqgZ8+FqlS2nEJbSchtA4V5ZEHaYvOLBfaZpZZo2RhW4Dr9FWpaav5Wnd7ag==
+"@vertexvis/frame-streaming-protos@^0.3.14":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.14.tgz#156de55954b45494ec2e1e43acf3a5129aa6b778"
+  integrity sha512-D9osgtsL5AXIbgjrYdmIqK+21DHtZnvmjIVMhHZHfoPf3i5nhlXVtXVIoZ/Tlry9sGxTM+N7cW3xoneZIfLlWA==
 
 "@vertexvis/jest-config-vertexvis@^0.5.0":
   version "0.5.0"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.3.14",
+    "@vertexvis/frame-streaming-protos": "^0.3.17",
     "@vertexvis/geometry": "0.9.18",
     "@vertexvis/stream-api": "0.9.18",
     "@vertexvis/utils": "0.9.18",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.3.12",
+    "@vertexvis/frame-streaming-protos": "^0.3.14",
     "@vertexvis/geometry": "0.9.18",
     "@vertexvis/stream-api": "0.9.18",
     "@vertexvis/utils": "0.9.18",

--- a/packages/viewer/src/rendering/__tests__/remote.spec.ts
+++ b/packages/viewer/src/rendering/__tests__/remote.spec.ts
@@ -39,6 +39,31 @@ describe(createStreamApiRenderer, () => {
     expect(resp.frame.sequenceNumber).toBe(1);
   });
 
+  it('should render given an animation and fly to op', async () => {
+    const req = render({
+      correlationId,
+      camera,
+      flyToOptions: {
+        flyTo: {
+          type: 'supplied',
+          data: 'givenId',
+        },
+      },
+      animation: {
+        milliseconds: 500,
+      },
+    });
+    mockWs.receiveMessage(
+      encode(
+        Fixtures.Requests.drawFrame({
+          payload: { frameCorrelationIds: [correlationId] },
+        })
+      )
+    );
+    const resp = await req;
+    expect(resp.frame.sequenceNumber).toBe(1);
+  });
+
   it('throws exception if render times out', async () => {
     const req = render({ correlationId, camera, timeoutInMs: 10 });
     await expect(req).rejects.toThrow();

--- a/packages/viewer/src/rendering/remote.ts
+++ b/packages/viewer/src/rendering/remote.ts
@@ -3,7 +3,6 @@ import { FrameCamera, Frame, Animation } from '../types';
 import { StreamApi, protoToDate, toProtoDuration } from '@vertexvis/stream-api';
 import { ifDrawFrame } from './utils';
 import { FrameRenderer } from './renderer';
-import { vertexvis } from '@vertexvis/frame-streaming-protos';
 
 const DEFAULT_TIMEOUT_IN_MS = 10 * 1000; // 10 seconds
 
@@ -21,20 +20,6 @@ export interface FrameResponse {
 }
 
 export type RemoteRenderer = FrameRenderer<FrameRequest, FrameResponse>;
-
-const easingMap = {
-  linear: vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
-  'ease-out-cubic':
-    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_CUBIC,
-  'ease-out-quad':
-    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_QUAD,
-  'ease-out-quart':
-    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_QUART,
-  'ease-out-sine':
-    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_SINE,
-  'ease-out-expo':
-    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_EXPO,
-};
 
 function requestFrame(api: StreamApi): RemoteRenderer {
   const requests = new Map<string, (resp: FrameResponse) => void>();
@@ -70,7 +55,6 @@ function requestFrame(api: StreamApi): RemoteRenderer {
     const animation = req.animation
       ? {
           duration: toProtoDuration(req.animation.milliseconds),
-          easing: easingMap[req.animation.easing],
         }
       : undefined;
 

--- a/packages/viewer/src/rendering/remote.ts
+++ b/packages/viewer/src/rendering/remote.ts
@@ -23,13 +23,13 @@ export interface FrameResponse {
 export type RemoteRenderer = FrameRenderer<FrameRequest, FrameResponse>;
 
 export const easingMap = {
-  'linear': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
-  'ease-out-cubic' : vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
+  linear: vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
+  'ease-out-cubic': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
   'ease-out-quad': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
   'ease-out-quart': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
   'ease-out-sine': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
   'ease-out-expo': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
-}
+};
 
 function requestFrame(api: StreamApi): RemoteRenderer {
   const requests = new Map<string, (resp: FrameResponse) => void>();
@@ -62,23 +62,27 @@ function requestFrame(api: StreamApi): RemoteRenderer {
   return req => {
     const corrId = req.correlationId || UUID.create();
     const timeout = req.timeoutInMs || DEFAULT_TIMEOUT_IN_MS;
-    const animation = req.animation && req.animation.milliseconds ? {
-      duration: {
-        nanos: (req.animation.milliseconds % 1000) * 1000000,
-        seconds: req.animation.milliseconds / 1000
-      },
-      easing: req.animation?.easing ? easingMap[req.animation.easing] : undefined,
-    }: undefined;
+    const animation =
+      req.animation && req.animation.milliseconds
+        ? {
+            duration: {
+              nanos: (req.animation.milliseconds % 1000) * 1000000,
+              seconds: req.animation.milliseconds / 1000,
+            },
+            easing: req.animation?.easing
+              ? easingMap[req.animation.easing]
+              : undefined,
+          }
+        : undefined;
 
-    console.log('animation', animation);
     const update = new Promise<FrameResponse>(resolve => {
       requests.set(corrId, resolve);
       api.replaceCamera(
-        { 
-          camera: req.camera, 
+        {
+          camera: req.camera,
           frameCorrelationId: { value: corrId },
           animation,
-         },
+        },
         false
       );
     });

--- a/packages/viewer/src/rendering/remote.ts
+++ b/packages/viewer/src/rendering/remote.ts
@@ -24,11 +24,16 @@ export type RemoteRenderer = FrameRenderer<FrameRequest, FrameResponse>;
 
 export const easingMap = {
   linear: vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
-  'ease-out-cubic': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
-  'ease-out-quad': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
-  'ease-out-quart': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
-  'ease-out-sine': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
-  'ease-out-expo': vertexvis.protobuf.stream.EasingType.EASING_TYPE_LINEAR,
+  'ease-out-cubic':
+    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_CUBIC,
+  'ease-out-quad':
+    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_QUAD,
+  'ease-out-quart':
+    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_QUART,
+  'ease-out-sine':
+    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_SINE,
+  'ease-out-expo':
+    vertexvis.protobuf.stream.EasingType.EASING_TYPE_EASE_OUT_EXPO,
 };
 
 function requestFrame(api: StreamApi): RemoteRenderer {

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -97,8 +97,10 @@ describe(Camera, () => {
 
     it('should render using camera with animations', async () => {
       camera.render({
-        milliseconds: 500,
-        easing: 'ease-out-sine',
+        animation: {
+          milliseconds: 500,
+          easing: 'ease-out-sine',
+        },
       });
 
       expect(renderer).toHaveBeenCalledWith(

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -96,20 +96,13 @@ describe(Camera, () => {
     });
 
     it('should render using camera with animations', async () => {
-      camera.render({
-        animation: {
-          milliseconds: 500,
-        },
-      });
+      camera.render();
 
       expect(renderer).toHaveBeenCalledWith(
         expect.objectContaining({
           camera: expect.objectContaining({
             position: Vector3.forward(),
           }),
-          animation: {
-            milliseconds: 500,
-          },
         })
       );
     });

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -88,4 +88,30 @@ describe(Camera, () => {
       );
     });
   });
+
+  describe('render with animations', () => {
+    const camera = new Camera(renderer, 1, {
+      ...data,
+      position: Vector3.forward(),
+    });
+
+    it('should render using camera with animations', async () => {
+      camera.render({
+        milliseconds: 500,
+        easing: 'ease-out-sine',
+      });
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          camera: expect.objectContaining({
+            position: Vector3.forward(),
+          }),
+          animation: {
+            easing: 'ease-out-sine',
+            milliseconds: 500,
+          },
+        })
+      );
+    });
+  });
 });

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -99,7 +99,6 @@ describe(Camera, () => {
       camera.render({
         animation: {
           milliseconds: 500,
-          easing: 'ease-out-sine',
         },
       });
 
@@ -109,7 +108,6 @@ describe(Camera, () => {
             position: Vector3.forward(),
           }),
           animation: {
-            easing: 'ease-out-sine',
             milliseconds: 500,
           },
         })

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -129,11 +129,13 @@ describe(Camera, () => {
         position: Vector3.forward(),
       });
       const id = UUID.create();
-      newCamera.flyToSceneItem(id).render({
-        animation: {
-          milliseconds: 500,
-        },
-      });
+      newCamera
+        .flyTo(q => q.withItemId(id))
+        .render({
+          animation: {
+            milliseconds: 500,
+          },
+        });
 
       expect(renderer).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -154,11 +156,13 @@ describe(Camera, () => {
     });
 
     it('should support fly to suppliedId with animations', async () => {
-      camera.flyToSuppliedId('suppliedId').render({
-        animation: {
-          milliseconds: 500,
-        },
-      });
+      camera
+        .flyTo(q => q.withSuppliedId('suppliedId'))
+        .render({
+          animation: {
+            milliseconds: 500,
+          },
+        });
 
       expect(renderer).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -1,5 +1,6 @@
 import { Camera } from '../camera';
 import { FrameCamera } from '../../types';
+import { UUID } from '@vertexvis/utils';
 import { Vector3, BoundingBox, Angle } from '@vertexvis/geometry';
 
 describe(Camera, () => {
@@ -96,13 +97,83 @@ describe(Camera, () => {
     });
 
     it('should render using camera with animations', async () => {
-      camera.render();
+      camera.render({
+        animation: {
+          milliseconds: 500,
+        },
+      });
 
       expect(renderer).toHaveBeenCalledWith(
         expect.objectContaining({
           camera: expect.objectContaining({
             position: Vector3.forward(),
           }),
+          animation: {
+            milliseconds: 500,
+          },
+          flyToOptions: {
+            flyTo: {
+              data: expect.objectContaining({
+                position: Vector3.forward(),
+              }),
+              type: 'camera',
+            },
+          },
+        })
+      );
+    });
+
+    it('should support fly to with sceneItemId', async () => {
+      const newCamera = new Camera(renderer, 1, {
+        ...data,
+        position: Vector3.forward(),
+      });
+      const id = UUID.create();
+      newCamera.flyToSceneItem(id).render({
+        animation: {
+          milliseconds: 500,
+        },
+      });
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          animation: {
+            milliseconds: 500,
+          },
+          camera: expect.objectContaining({
+            position: Vector3.forward(),
+          }),
+          flyToOptions: {
+            flyTo: {
+              type: 'internal',
+              data: id,
+            },
+          },
+        })
+      );
+    });
+
+    it('should support fly to suppliedId with animations', async () => {
+      camera.flyToSuppliedId('suppliedId').render({
+        animation: {
+          milliseconds: 500,
+        },
+      });
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          camera: expect.objectContaining({
+            position: Vector3.forward(),
+          }),
+          animation: {
+            milliseconds: 500,
+          },
+          flyToOptions: {
+            flyTo: {
+              data: 'suppliedId',
+              type: 'supplied',
+            },
+          },
         })
       );
     });

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -111,7 +111,8 @@ export class Camera implements FrameCamera.FrameCamera {
   }
 
   /**
-   *
+   * fly to accepts a function that contains the type of fly to operation that will be done by the camera operation.
+   * To animate the fly to, pass in animation options into render.
    * @param query
    */
   public flyTo(query: (q: FlyToExecutor) => TerminalFlyToExecutor): Camera {

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -15,7 +15,6 @@ const PI_OVER_360 = 0.008726646259972;
  * a new instance of the class with the updated properties.
  */
 export class Camera implements FrameCamera.FrameCamera {
-
   public constructor(
     private renderer: RemoteRenderer,
     private aspect: number,
@@ -70,7 +69,7 @@ export class Camera implements FrameCamera.FrameCamera {
    */
   public async render(animation?: Animation.Animation): Promise<void> {
     try {
-      await this.renderer({ camera: this.data, animation});
+      await this.renderer({ camera: this.data, animation });
     } catch (e) {
       console.warn('Error when requesting new frame: ', e);
     }

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -107,6 +107,7 @@ export class Camera implements FrameCamera.FrameCamera {
       await this.renderer({
         camera: this.data,
         flyToOptions: this.flyToOptions,
+        animation: renderOptions?.animation,
       });
     } catch (e) {
       console.warn('Error when requesting new frame: ', e);

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -8,6 +8,60 @@ interface CameraRenderOptions {
   animation: Animation.Animation;
 }
 
+export class TerminalFlyToExecutor {
+  public constructor(private flyToOptions?: FlyTo.FlyToOptions) {}
+
+  public build(): FlyTo.FlyToOptions | undefined {
+    return this.flyToOptions;
+  }
+}
+
+export class FlyToExecutor {
+  private flyToOptions?: FlyTo.FlyToOptions;
+
+  public withItemId(id: string): TerminalFlyToExecutor {
+    return new TerminalFlyToExecutor({
+      flyTo: {
+        type: 'internal',
+        data: id,
+      },
+    });
+  }
+
+  public withSuppliedId(id: string): TerminalFlyToExecutor {
+    return new TerminalFlyToExecutor({
+      flyTo: {
+        type: 'supplied',
+        data: id,
+      },
+    });
+  }
+
+  public withCamera(camera: FrameCamera.FrameCamera): TerminalFlyToExecutor {
+    return new TerminalFlyToExecutor({
+      flyTo: {
+        type: 'camera',
+        data: camera,
+      },
+    });
+  }
+
+  public withBoundingBox(
+    boundingBox: BoundingBox.BoundingBox
+  ): TerminalFlyToExecutor {
+    return new TerminalFlyToExecutor({
+      flyTo: {
+        type: 'bounding-box',
+        data: boundingBox,
+      },
+    });
+  }
+
+  public build(): FlyTo.FlyToOptions | undefined {
+    return this.flyToOptions;
+  }
+}
+
 /**
  * The `Camera` class contains properties that reflect a world space position, a
  * view direction (lookAt), and normalized vector representing the up direction.
@@ -56,23 +110,12 @@ export class Camera implements FrameCamera.FrameCamera {
     return this.update({ lookAt, position });
   }
 
-  public flyToSceneItem(sceneItemId: string): Camera {
-    this.flyToOptions = {
-      flyTo: {
-        type: 'internal',
-        data: sceneItemId,
-      },
-    };
-    return this;
-  }
-
-  public flyToSuppliedId(partId: string): Camera {
-    this.flyToOptions = {
-      flyTo: {
-        type: 'supplied',
-        data: partId,
-      },
-    };
+  /**
+   *
+   * @param query
+   */
+  public flyTo(query: (q: FlyToExecutor) => TerminalFlyToExecutor): Camera {
+    this.flyToOptions = query(new FlyToExecutor()).build();
     return this;
   }
 

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -1,4 +1,4 @@
-import { FrameCamera } from '../types';
+import { Animation, FrameCamera } from '../types';
 import { Vector3, BoundingBox } from '@vertexvis/geometry';
 import { RemoteRenderer } from '../rendering';
 
@@ -15,6 +15,7 @@ const PI_OVER_360 = 0.008726646259972;
  * a new instance of the class with the updated properties.
  */
 export class Camera implements FrameCamera.FrameCamera {
+
   public constructor(
     private renderer: RemoteRenderer,
     private aspect: number,
@@ -67,9 +68,9 @@ export class Camera implements FrameCamera.FrameCamera {
    * Queues the rendering for a new frame using this camera. The returned
    * promise will resolve when a frame is received that contains this camera.
    */
-  public async render(): Promise<void> {
+  public async render(animation?: Animation.Animation): Promise<void> {
     try {
-      await this.renderer({ camera: this.data });
+      await this.renderer({ camera: this.data, animation});
     } catch (e) {
       console.warn('Error when requesting new frame: ', e);
     }

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -4,6 +4,9 @@ import { RemoteRenderer } from '../rendering';
 
 const PI_OVER_360 = 0.008726646259972;
 
+interface CameraRenderOptions {
+  animation: Animation.Animation;
+}
 /**
  * The `Camera` class contains properties that reflect a world space position, a
  * view direction (lookAt), and normalized vector representing the up direction.
@@ -67,9 +70,12 @@ export class Camera implements FrameCamera.FrameCamera {
    * Queues the rendering for a new frame using this camera. The returned
    * promise will resolve when a frame is received that contains this camera.
    */
-  public async render(animation?: Animation.Animation): Promise<void> {
+  public async render(renderOptions?: CameraRenderOptions): Promise<void> {
     try {
-      await this.renderer({ camera: this.data, animation });
+      await this.renderer({
+        camera: this.data,
+        animation: renderOptions?.animation,
+      });
     } catch (e) {
       console.warn('Error when requesting new frame: ', e);
     }

--- a/packages/viewer/src/types/animation.ts
+++ b/packages/viewer/src/types/animation.ts
@@ -1,6 +1,6 @@
 export interface Animation {
-  milliseconds?: number;
-  easing?:
+  milliseconds: number;
+  easing:
     | 'linear'
     | 'ease-out-cubic'
     | 'ease-out-quad'
@@ -11,7 +11,7 @@ export interface Animation {
 
 export function create(data: Partial<Animation> = {}): Animation {
   return {
-    milliseconds: data.milliseconds || undefined,
-    easing: data.easing || undefined,
+    milliseconds: data.milliseconds || 2000,
+    easing: data.easing || 'linear',
   };
 }

--- a/packages/viewer/src/types/animation.ts
+++ b/packages/viewer/src/types/animation.ts
@@ -1,17 +1,9 @@
 export interface Animation {
   milliseconds: number;
-  easing:
-    | 'linear'
-    | 'ease-out-cubic'
-    | 'ease-out-quad'
-    | 'ease-out-quart'
-    | 'ease-out-sine'
-    | 'ease-out-expo';
 }
 
 export function create(data: Partial<Animation> = {}): Animation {
   return {
     milliseconds: data.milliseconds || 2000,
-    easing: data.easing || 'linear',
   };
 }

--- a/packages/viewer/src/types/animation.ts
+++ b/packages/viewer/src/types/animation.ts
@@ -1,11 +1,17 @@
 export interface Animation {
   milliseconds?: number;
-  easing?: 'linear' | 'ease-out-cubic' | 'ease-out-quad' | 'ease-out-quart' | 'ease-out-sine' | 'ease-out-expo'
+  easing?:
+    | 'linear'
+    | 'ease-out-cubic'
+    | 'ease-out-quad'
+    | 'ease-out-quart'
+    | 'ease-out-sine'
+    | 'ease-out-expo';
 }
 
 export function create(data: Partial<Animation> = {}): Animation {
   return {
     milliseconds: data.milliseconds || undefined,
-    easing: data.easing || undefined
+    easing: data.easing || undefined,
   };
 }

--- a/packages/viewer/src/types/animation.ts
+++ b/packages/viewer/src/types/animation.ts
@@ -1,0 +1,11 @@
+export interface Animation {
+  milliseconds?: number;
+  easing?: 'linear' | 'ease-out-cubic' | 'ease-out-quad' | 'ease-out-quart' | 'ease-out-sine' | 'ease-out-expo'
+}
+
+export function create(data: Partial<Animation> = {}): Animation {
+  return {
+    milliseconds: data.milliseconds || undefined,
+    easing: data.easing || undefined
+  };
+}

--- a/packages/viewer/src/types/flyToOptions.ts
+++ b/packages/viewer/src/types/flyToOptions.ts
@@ -1,0 +1,40 @@
+import { BoundingBox } from '@vertexvis/geometry';
+import { FrameCamera } from './frameCamera';
+
+interface FlyToSuppliedId {
+  type: 'supplied';
+  data: string;
+}
+
+interface FlyToItemId {
+  type: 'internal';
+  data: string;
+}
+
+interface FlyToBoundingBox {
+  type: 'bounding-box';
+  data: BoundingBox.BoundingBox;
+}
+
+interface FlyToCamera {
+  type: 'camera';
+  data: FrameCamera;
+}
+export type FlyToType =
+  | FlyToSuppliedId
+  | FlyToItemId
+  | FlyToBoundingBox
+  | FlyToCamera;
+
+export interface FlyToOptions {
+  flyTo: FlyToType;
+}
+
+export function create(data: Partial<FlyToOptions> = {}): FlyToOptions {
+  return {
+    flyTo: data.flyTo || {
+      type: 'internal',
+      data: '',
+    },
+  };
+}

--- a/packages/viewer/src/types/flyToOptions.ts
+++ b/packages/viewer/src/types/flyToOptions.ts
@@ -18,7 +18,7 @@ interface FlyToBoundingBox {
 
 interface FlyToCamera {
   type: 'camera';
-  data: FrameCamera;
+  data: Partial<FrameCamera>;
 }
 export type FlyToType =
   | FlyToSuppliedId

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -4,9 +4,18 @@ import * as FrameCamera from './frameCamera';
 import * as Frame from './frame';
 import * as LoadableResource from './loadableResource';
 import * as Animation from './animation';
+import * as FlyTo from './flyToOptions';
 
 export * from './synchronizedClock';
 
 export * from './typeGuards';
 
-export { Events, Flags, Frame, FrameCamera, LoadableResource, Animation };
+export {
+  Events,
+  Flags,
+  Frame,
+  FrameCamera,
+  LoadableResource,
+  Animation,
+  FlyTo,
+};

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -3,9 +3,9 @@ import * as Events from './events';
 import * as FrameCamera from './frameCamera';
 import * as Frame from './frame';
 import * as LoadableResource from './loadableResource';
-
+import * as Animation from './animation';
 export * from './synchronizedClock';
 
 export * from './typeGuards';
 
-export { Events, Flags, Frame, FrameCamera, LoadableResource };
+export { Events, Flags, Frame, FrameCamera, LoadableResource, Animation };

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -4,6 +4,7 @@ import * as FrameCamera from './frameCamera';
 import * as Frame from './frame';
 import * as LoadableResource from './loadableResource';
 import * as Animation from './animation';
+
 export * from './synchronizedClock';
 
 export * from './typeGuards';

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -641,10 +641,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.14":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.14.tgz#156de55954b45494ec2e1e43acf3a5129aa6b778"
-  integrity sha512-D9osgtsL5AXIbgjrYdmIqK+21DHtZnvmjIVMhHZHfoPf3i5nhlXVtXVIoZ/Tlry9sGxTM+N7cW3xoneZIfLlWA==
+"@vertexvis/frame-streaming-protos@^0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.17.tgz#dd7a71dc7b6b3e6c481818fad8203ebb80cfd7a9"
+  integrity sha512-1f+HizaTr2Q1qlLDhGjGJTZ++QdPJ+FXRYCZ2X+N+2pDrCEAzPVT4c6T5sry7Uf7FXVFAWHWY+wwGGyj9D0fXg==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.2.0":
   version "0.2.0"

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -641,10 +641,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.12":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.12.tgz#62f16a14f41a8a66ce33669a76cc76fb3ee6deac"
-  integrity sha512-RTQEsroAP7WmJjQ40PHfZYIypmLqgZ8+FqlS2nEJbSchtA4V5ZEHaYvOLBfaZpZZo2RhW4Dr9FWpaav5Wnd7ag==
+"@vertexvis/frame-streaming-protos@^0.3.14":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.14.tgz#156de55954b45494ec2e1e43acf3a5129aa6b778"
+  integrity sha512-D9osgtsL5AXIbgjrYdmIqK+21DHtZnvmjIVMhHZHfoPf3i5nhlXVtXVIoZ/Tlry9sGxTM+N7cW3xoneZIfLlWA==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
Changes to support animations on render.

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-1335
https://vertexvis.atlassian.net/browse/SDK-1052

## Test Plan

<!-- Describe how your changes should be tested. -->
See test plan on FSS pr for comprehensive test plan:
https://github.com/Vertexvis/frame-streaming-service/pull/143

Can be tested in the viewer by adding a duration in ms in the camera render func:
```
      await scene.camera().update(updateCamera).render({
               animation: {
                   milliseconds: 500
               }
          });
```

I also added the support for the fly to operation that supports either a bounding box, item id, suppliedId or camera.

```
      camera
        .flyTo(q => q.withSuppliedId('suppliedId'))
        .render({
          animation: {
            milliseconds: 500,
          },
        });
```

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->

https://github.com/Vertexvis/frame-streaming-service/pull/143
