### PR TITLE
[SDK-1300] Support View All visible parts

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.3.17",
+    "@vertexvis/frame-streaming-protos": "^0.3.18",
     "@vertexvis/utils": "0.9.18"
   },
   "devDependencies": {

--- a/packages/stream-api/yarn.lock
+++ b/packages/stream-api/yarn.lock
@@ -659,10 +659,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.17":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.17.tgz#dd7a71dc7b6b3e6c481818fad8203ebb80cfd7a9"
-  integrity sha512-1f+HizaTr2Q1qlLDhGjGJTZ++QdPJ+FXRYCZ2X+N+2pDrCEAzPVT4c6T5sry7Uf7FXVFAWHWY+wwGGyj9D0fXg==
+"@vertexvis/frame-streaming-protos@^0.3.18":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.18.tgz#948c588c7daca0fa35732d7270e9c3390a67fd79"
+  integrity sha512-NL+WJUqtIT8qO/n5lvHPLosG7AOzYesX5OwkH9lumM3MOsbLs5CTJ3qT/zPxP/zXh6Kau7Vt1BDGUstSUU/7wA==
 
 "@vertexvis/jest-config-vertexvis@^0.5.0":
   version "0.5.0"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/classnames": "2.2.3",
-    "@vertexvis/frame-streaming-protos": "^0.3.17",
+    "@vertexvis/frame-streaming-protos": "^0.3.18",
     "@vertexvis/geometry": "0.9.18",
     "@vertexvis/stream-api": "0.9.18",
     "@vertexvis/utils": "0.9.18",

--- a/packages/viewer/src/scenes/camera.ts
+++ b/packages/viewer/src/scenes/camera.ts
@@ -78,7 +78,8 @@ export class Camera implements FrameCamera.FrameCamera {
   public constructor(
     private renderer: RemoteRenderer,
     private aspect: number,
-    private data: FrameCamera.FrameCamera
+    private data: FrameCamera.FrameCamera,
+    private boundingBox: BoundingBox.BoundingBox
   ) {}
 
   /**
@@ -131,6 +132,10 @@ export class Camera implements FrameCamera.FrameCamera {
       position: Vector3.add(this.position, delta),
       lookAt: Vector3.add(this.lookAt, delta),
     });
+  }
+
+  public viewAll(): Camera {
+    return this.fitToBoundingBox(this.boundingBox);
   }
 
   /**
@@ -190,10 +195,15 @@ export class Camera implements FrameCamera.FrameCamera {
    * @param camera The values to update the camera to.
    */
   public update(camera: Partial<FrameCamera.FrameCamera>): Camera {
-    return new Camera(this.renderer, this.aspectRatio, {
-      ...this.data,
-      ...camera,
-    });
+    return new Camera(
+      this.renderer,
+      this.aspectRatio,
+      {
+        ...this.data,
+        ...camera,
+      },
+      this.boundingBox
+    );
   }
 
   /**

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -212,7 +212,8 @@ export class Scene {
     return new Camera(
       this.renderer,
       Dimensions.aspectRatio(this.viewport()),
-      this.frame.sceneAttributes.camera
+      this.frame.sceneAttributes.camera,
+      this.frame.sceneAttributes.visibleBoundingBox
     );
   }
 

--- a/packages/viewer/src/types/__fixtures__/index.ts
+++ b/packages/viewer/src/types/__fixtures__/index.ts
@@ -1,6 +1,11 @@
 import * as Frame from '../frame';
 import * as FrameCamera from '../frameCamera';
-import { Dimensions, Rectangle } from '@vertexvis/geometry';
+import {
+  Dimensions,
+  Rectangle,
+  BoundingBox,
+  Vector3,
+} from '@vertexvis/geometry';
 
 export const frame: Frame.Frame = {
   correlationIds: [],
@@ -9,7 +14,10 @@ export const frame: Frame.Frame = {
     imageRect: Rectangle.create(0, 0, 100, 50),
     scaleFactor: 1,
   },
-  sceneAttributes: { camera: FrameCamera.create() },
+  sceneAttributes: {
+    camera: FrameCamera.create(),
+    visibleBoundingBox: BoundingBox.create(Vector3.create(), Vector3.create()),
+  },
   sequenceNumber: 1,
   image: new Uint8Array(),
 };

--- a/packages/viewer/src/types/frame.ts
+++ b/packages/viewer/src/types/frame.ts
@@ -1,4 +1,9 @@
-import { Dimensions, Vector3, Rectangle } from '@vertexvis/geometry';
+import {
+  Dimensions,
+  Vector3,
+  Rectangle,
+  BoundingBox,
+} from '@vertexvis/geometry';
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import * as FrameCamera from './frameCamera';
 
@@ -18,6 +23,7 @@ export interface ImageAttributes {
 
 export interface SceneAttributes {
   camera: FrameCamera.FrameCamera;
+  visibleBoundingBox: BoundingBox.BoundingBox;
 }
 
 export const fromProto = (
@@ -82,6 +88,18 @@ export const fromProto = (
           z: sceneAttributes.camera.up?.z || undefined,
         }),
       }),
+      visibleBoundingBox: BoundingBox.create(
+        Vector3.create({
+          x: sceneAttributes.visibleBoundingBox?.xmin || undefined,
+          y: sceneAttributes.visibleBoundingBox?.ymin || undefined,
+          z: sceneAttributes.visibleBoundingBox?.zmin || undefined,
+        }),
+        Vector3.create({
+          x: sceneAttributes.visibleBoundingBox?.xmax || undefined,
+          y: sceneAttributes.visibleBoundingBox?.ymax || undefined,
+          z: sceneAttributes.visibleBoundingBox?.zmax || undefined,
+        })
+      ),
     },
     sequenceNumber: sequenceNumber,
     image: image,

--- a/packages/viewer/yarn.lock
+++ b/packages/viewer/yarn.lock
@@ -641,10 +641,10 @@
     eslint-plugin-prettier "^3.1.0"
     prettier "^1.19.1"
 
-"@vertexvis/frame-streaming-protos@^0.3.17":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.17.tgz#dd7a71dc7b6b3e6c481818fad8203ebb80cfd7a9"
-  integrity sha512-1f+HizaTr2Q1qlLDhGjGJTZ++QdPJ+FXRYCZ2X+N+2pDrCEAzPVT4c6T5sry7Uf7FXVFAWHWY+wwGGyj9D0fXg==
+"@vertexvis/frame-streaming-protos@^0.3.18":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.3.18.tgz#948c588c7daca0fa35732d7270e9c3390a67fd79"
+  integrity sha512-NL+WJUqtIT8qO/n5lvHPLosG7AOzYesX5OwkH9lumM3MOsbLs5CTJ3qT/zPxP/zXh6Kau7Vt1BDGUstSUU/7wA==
 
 "@vertexvis/rollup-plugin-vertexvis-copyright@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
These changes introduce adding the visible bounding box as present on the scene attributes on the frame. The ticket called for `.viewAll` to be a promise with an executable, and I'm proposing a slightly different direction here to allow for consistent behavior with automations as well as having one executable. 

Pivoting back to have `viewAll` be an executable would not be a big change if we choose to go that route. I thought this approach was a little cleaner and more consistent with the patterns in our SDK.

A developer would perform a `viewAll` operation by doing the following:

```
await scene.camera().viewAll().render()
```

Alternatively, you can animate to the view all position by doing the following:

```
await scene.camera().viewAll().render({ animation: { milliseconds: 1500 }})
```

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-1300

## Test Plan

<!-- Describe how your changes should be tested. -->
Attempt to do these commands. It should go to a full view of all visible parts:


```
await scene.camera().viewAll().render()
```

```
await scene.camera().viewAll().render({ animation: { milliseconds: 1500 }})
```

To ensure functionality, it would also be a good test to hide parts and then do a fit all to ensure the bounding box is accurate. 

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->
N/A

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->
N/A

## Dependencies

<!-- Link to other PRs or tickets. -->

https://github.com/Vertexvis/frame-streaming-service/pull/150
