### PR TITLE
[SDK-1321] Support starting from scene view state

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -519,15 +519,15 @@ export class Viewer {
   @Method()
   public async load(urn: string): Promise<void> {
     if (this.commands != null && this.dimensions != null) {
-      const loadableResource = LoadableResource.fromUrn(urn);
+      const { resource, query } = LoadableResource.fromUrn(urn);
       const isSameResource =
         this.resource != null &&
-        this.resource.type === loadableResource.type &&
-        this.resource.id === loadableResource.id;
+        this.resource.type === resource.type &&
+        this.resource.id === resource.id;
       if (!isSameResource) {
         this.unload();
-        this.resource = loadableResource;
-        await this.connectStreamingClient(this.resource);
+        this.resource = resource;
+        await this.connectStreamingClient(this.resource, query);
       }
     } else {
       throw new ViewerInitializationError(
@@ -617,7 +617,8 @@ export class Viewer {
   }
 
   private async connectStreamingClient(
-    resource: LoadableResource.LoadableResource
+    resource: LoadableResource.LoadableResource,
+    queryResource?: LoadableResource.QueryResource
   ): Promise<void> {
     if (this.resource == null) {
       this.errorMessage =
@@ -636,6 +637,9 @@ export class Viewer {
         dimensions: this.dimensions,
         frameBackgroundColor: this.getBackgroundColor(),
         streamAttributes: this.getStreamAttributes(),
+        ...(queryResource?.type === 'scene-view-state' && {
+          sceneViewStateId: { hex: queryResource.id },
+        }),
       });
 
       this.jwt = result.startStream?.jwt || undefined;

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -519,7 +519,7 @@ export class Viewer {
   @Method()
   public async load(urn: string): Promise<void> {
     if (this.commands != null && this.dimensions != null) {
-      const { resource, query } = LoadableResource.fromUrn(urn);
+      const { resource, queries } = LoadableResource.fromUrn(urn);
       const isSameResource =
         this.resource != null &&
         this.resource.type === resource.type &&
@@ -527,7 +527,10 @@ export class Viewer {
       if (!isSameResource) {
         this.unload();
         this.resource = resource;
-        await this.connectStreamingClient(this.resource, query);
+        await this.connectStreamingClient(
+          this.resource,
+          queries != null && queries.length > 0 ? queries[0] : undefined
+        );
       }
     } else {
       throw new ViewerInitializationError(

--- a/packages/viewer/src/types/__tests__/loadableResource.spec.ts
+++ b/packages/viewer/src/types/__tests__/loadableResource.spec.ts
@@ -15,7 +15,14 @@ describe(LoadableResource.fromUrn, () => {
 
   it('parses URN for a stream key', () => {
     const urn = 'urn:vertexvis:stream-key:123';
-    const scene = LoadableResource.fromUrn(urn);
-    expect(scene).toEqual({ type: 'stream-key', id: '123' });
+    const { resource } = LoadableResource.fromUrn(urn);
+    expect(resource).toEqual({ type: 'stream-key', id: '123' });
+  });
+
+  it('parses query param for a URN', () => {
+    const urn = 'urn:vertexvis:stream-key:123?scene-view-state=234';
+    const { resource, query } = LoadableResource.fromUrn(urn);
+    expect(resource).toEqual({ type: 'stream-key', id: '123' });
+    expect(query).toEqual({ type: 'scene-view-state', id: '234' });
   });
 });

--- a/packages/viewer/src/types/__tests__/loadableResource.spec.ts
+++ b/packages/viewer/src/types/__tests__/loadableResource.spec.ts
@@ -21,8 +21,18 @@ describe(LoadableResource.fromUrn, () => {
 
   it('parses query param for a URN', () => {
     const urn = 'urn:vertexvis:stream-key:123?scene-view-state=234';
-    const { resource, query } = LoadableResource.fromUrn(urn);
+    const { resource, queries } = LoadableResource.fromUrn(urn);
     expect(resource).toEqual({ type: 'stream-key', id: '123' });
-    expect(query).toEqual({ type: 'scene-view-state', id: '234' });
+    expect(queries![0]).toEqual({ type: 'scene-view-state', id: '234' });
+  });
+
+  it('parses multiple query params for a URN', () => {
+    const urn =
+      'urn:vertexvis:stream-key:123?scene-view-state=234&scene-view-state=345&scene-view-state=456';
+    const { resource, queries } = LoadableResource.fromUrn(urn);
+    expect(resource).toEqual({ type: 'stream-key', id: '123' });
+    expect(queries![0]).toEqual({ type: 'scene-view-state', id: '234' });
+    expect(queries![1]).toEqual({ type: 'scene-view-state', id: '345' });
+    expect(queries![2]).toEqual({ type: 'scene-view-state', id: '456' });
   });
 });

--- a/packages/viewer/src/types/loadableResource.ts
+++ b/packages/viewer/src/types/loadableResource.ts
@@ -9,7 +9,7 @@ export type LoadableResource = StreamKeyResource;
 
 export interface Resource {
   resource: LoadableResource;
-  query?: QueryResource;
+  queries?: QueryResource[];
 }
 
 export function fromUrn(urn: string): Resource {
@@ -29,7 +29,7 @@ export function fromUrn(urn: string): Resource {
     case 'stream-key':
       return {
         resource: { type: 'stream-key', id: resourceId },
-        query: fromQuery(uri.query),
+        queries: fromQuery(uri.query),
       };
     default:
       throw new Error('Invalid URN. Unknown resource type');
@@ -43,15 +43,17 @@ export interface SceneViewStateResource {
 
 export type QueryResource = SceneViewStateResource;
 
-function fromQuery(query?: string): QueryResource | undefined {
+function fromQuery(query?: string): QueryResource[] | undefined {
   if (query != null) {
-    const [resourceType, resourceId] = query.split('=');
+    return query.split('&').map(queryFragment => {
+      const [resourceType, resourceId] = queryFragment.split('=');
 
-    switch (resourceType) {
-      case 'scene-view-state':
-        return { type: 'scene-view-state', id: resourceId };
-      default:
-        throw new Error('Invalid URN. Unknown query resource type');
-    }
+      switch (resourceType) {
+        case 'scene-view-state':
+          return { type: 'scene-view-state', id: resourceId };
+        default:
+          throw new Error('Invalid URN. Unknown query resource type');
+      }
+    });
   }
 }

--- a/packages/viewer/src/types/loadableResource.ts
+++ b/packages/viewer/src/types/loadableResource.ts
@@ -7,14 +7,20 @@ interface StreamKeyResource {
 
 export type LoadableResource = StreamKeyResource;
 
-export function fromUrn(urn: string): LoadableResource {
+export interface Resource {
+  resource: LoadableResource;
+  query?: QueryResource;
+}
+
+export function fromUrn(urn: string): Resource {
   const uri = Uri.parse(urn);
 
   if (uri.scheme !== 'urn' || uri.path == null) {
     throw new Error('Invalid URN. Expected URN scheme.');
   }
 
-  const [nid, resourceType, resourceId] = uri.path.split(':');
+  const [nid, resourceType, resource] = uri.path.split(':');
+  const [resourceId, query] = resource.split('?');
 
   if (nid !== 'vertexvis') {
     throw new Error('Invalid URN. Expected URN to be vertexvis namespace');
@@ -22,8 +28,31 @@ export function fromUrn(urn: string): LoadableResource {
 
   switch (resourceType) {
     case 'stream-key':
-      return { type: 'stream-key', id: resourceId };
+      return {
+        resource: { type: 'stream-key', id: resourceId },
+        query: fromQuery(query),
+      };
     default:
       throw new Error('Invalid URN. Unknown resource type');
+  }
+}
+
+export interface SceneViewStateResource {
+  type: 'scene-view-state';
+  id: string;
+}
+
+export type QueryResource = SceneViewStateResource;
+
+function fromQuery(query?: string): QueryResource | undefined {
+  if (query != null) {
+    const [resourceType, resourceId] = query.split('=');
+
+    switch (resourceType) {
+      case 'scene-view-state':
+        return { type: 'scene-view-state', id: resourceId };
+      default:
+        throw new Error('Invalid URN. Unknown query resource type');
+    }
   }
 }

--- a/packages/viewer/src/types/loadableResource.ts
+++ b/packages/viewer/src/types/loadableResource.ts
@@ -19,8 +19,7 @@ export function fromUrn(urn: string): Resource {
     throw new Error('Invalid URN. Expected URN scheme.');
   }
 
-  const [nid, resourceType, resource] = uri.path.split(':');
-  const [resourceId, query] = resource.split('?');
+  const [nid, resourceType, resourceId] = uri.path.split(':');
 
   if (nid !== 'vertexvis') {
     throw new Error('Invalid URN. Expected URN to be vertexvis namespace');
@@ -30,7 +29,7 @@ export function fromUrn(urn: string): Resource {
     case 'stream-key':
       return {
         resource: { type: 'stream-key', id: resourceId },
-        query: fromQuery(query),
+        query: fromQuery(uri.query),
       };
     default:
       throw new Error('Invalid URN. Unknown resource type');


### PR DESCRIPTION
## What

Adds support for starting a stream using a scene view state. This is provided using a query param on the `src` urn:

```
urn:vertexvis:stream-key:<key>?scene-view-state=<state-id>
```

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1321

## Test Plan

- Test starting a stream with a scene view state id provided

## Areas of Possible Regression

Loading of stream keys

## Out of scope changes made in PR

N/A

## Dependencies

https://github.com/Vertexvis/frame-streaming-service/pull/153
