### PR TITLE
[SDK-1388] Fly to tweaks

### DIFF
--- a/packages/viewer/src/components/viewer/readme.md
+++ b/packages/viewer/src/components/viewer/readme.md
@@ -11,6 +11,7 @@
 | `clientId`         | `client-id`         | The Client ID associated with your Vertex Application.                                                                                                                           | `string \| undefined`                      | `undefined`  |
 | `config`           | `config`            | An object or JSON encoded string that defines configuration settings for the viewer.                                                                                             | `Config \| string \| undefined`            | `undefined`  |
 | `configEnv`        | `config-env`        | Sets the default environment for the viewer. This setting is used for auto-configuring network hosts.  Use the `config` property for manually setting hosts.                     | `"platdev" \| "platprod"`                  | `'platprod'` |
+| `keyboardControls` | `keyboard-controls` | Enables or disables the default keyboard shortcut interactions provided by the viewer. Enabled by default, requires `cameraControls` being enabled.                              | `boolean`                                  | `true`       |
 | `sessionId`        | `session-id`        | Property used for internals or testing.                                                                                                                                          | `string \| undefined`                      | `undefined`  |
 | `src`              | `src`               | A URN of the scene resource to load when the component is mounted in the DOM tree. The specified resource is a URN in the following format:    * `urn:vertexvis:scene:<sceneid>` | `string \| undefined`                      | `undefined`  |
 | `streamAttributes` | `stream-attributes` | An object or JSON encoded string that defines configuration settings for the viewer.                                                                                             | `IStreamAttributes \| string \| undefined` | `undefined`  |
@@ -100,6 +101,22 @@ the default camera controls provided by the viewer.
 #### Returns
 
 Type: `Promise<Disposable>`
+
+
+
+### `registerTapKeyInteraction(keyInteraction: KeyInteraction<TapEventDetails>) => Promise<void>`
+
+Registers a key interaction to be invoked when a specific set of
+keys are pressed during a `tap` event.
+
+`KeyInteraction`s are used to build custom keyboard shortcuts for the
+viewer using the current state of they keyboard to determine whether
+the `fn` should be invoked. Use `<vertex-viewer keyboard-controls="false" />`
+to disable the default keyboard shortcuts provided by the viewer.
+
+#### Returns
+
+Type: `Promise<void>`
 
 
 

--- a/packages/viewer/src/interactions/__tests__/flyToPartKeyInteraction.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/flyToPartKeyInteraction.spec.ts
@@ -16,9 +16,9 @@ describe(FlyToPartKeyInteraction, () => {
   );
 
   it('Returns true for its predicate with Command or Control pressed', () => {
-    expect(flyToPartKeyInteraction.predicate({ Control: true })).toBeTruthy();
-    expect(flyToPartKeyInteraction.predicate({ Meta: true })).toBeTruthy();
-    expect(flyToPartKeyInteraction.predicate({ Alt: true })).toBeFalsy();
+    expect(flyToPartKeyInteraction.predicate({ Control: true })).toBe(false);
+    expect(flyToPartKeyInteraction.predicate({ Meta: true })).toBe(false);
+    expect(flyToPartKeyInteraction.predicate({ Alt: true })).toBe(true);
   });
 
   it('Queries for hit results and fits to the item if present', async () => {

--- a/packages/viewer/src/interactions/flyToPartKeyInteraction.ts
+++ b/packages/viewer/src/interactions/flyToPartKeyInteraction.ts
@@ -11,7 +11,7 @@ export class FlyToPartKeyInteraction
   ) {}
 
   public predicate(keyState: KeyState): boolean {
-    return keyState['Alt'];
+    return keyState['Alt'] === true;
   }
 
   public async fn(e: TapEventDetails): Promise<void> {

--- a/packages/viewer/src/interactions/flyToPartKeyInteraction.ts
+++ b/packages/viewer/src/interactions/flyToPartKeyInteraction.ts
@@ -11,7 +11,7 @@ export class FlyToPartKeyInteraction
   ) {}
 
   public predicate(keyState: KeyState): boolean {
-    return keyState['Meta'] || keyState['Control'];
+    return keyState['Alt'];
   }
 
   public async fn(e: TapEventDetails): Promise<void> {

--- a/packages/viewer/src/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/camera.spec.ts
@@ -177,10 +177,7 @@ describe(Camera, () => {
             position: Vector3.forward(),
           }),
           flyToOptions: {
-            flyTo: {
-              type: 'internal',
-              data: id,
-            },
+            flyTo: { type: 'internal', data: id },
           },
         })
       );
@@ -204,11 +201,59 @@ describe(Camera, () => {
             milliseconds: 500,
           },
           flyToOptions: {
-            flyTo: {
-              data: 'suppliedId',
-              type: 'supplied',
-            },
+            flyTo: { data: 'suppliedId', type: 'supplied' },
           },
+        })
+      );
+    });
+
+    it('renders with fly to item id param', async () => {
+      camera.flyTo({ itemId: 'item-id' }).render();
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flyToOptions: {
+            flyTo: { type: 'internal', data: 'item-id' },
+          },
+        })
+      );
+    });
+
+    it('renders with fly to item id param', async () => {
+      camera.flyTo({ itemSuppliedId: 'supplied-id' }).render();
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flyToOptions: {
+            flyTo: { type: 'supplied', data: 'supplied-id' },
+          },
+        })
+      );
+    });
+
+    it('renders with fly to bounding box param', async () => {
+      const boundingBox = BoundingBox.create(
+        Vector3.create(-1, -1, -1),
+        Vector3.create(1, 1, 1)
+      );
+      camera.flyTo({ boundingBox }).render();
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flyToOptions: {
+            flyTo: { type: 'bounding-box', data: boundingBox },
+          },
+        })
+      );
+    });
+
+    it('renders with fly to camera param', async () => {
+      const data = FrameCamera.create();
+      camera.flyTo({ camera: data }).render();
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flyToOptions: { flyTo: { type: 'camera', data } },
         })
       );
     });


### PR DESCRIPTION
## What

Making some small tweaks to our fly-to operation:

* Use Alt+Click to fly to part. This is inline with the keyboard shortcut in connect and should reduce key conflicts in Mac OS.
* Add a simpler object params to specify fly to part arguments.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1388

## Test Plan

<!-- Describe how your changes should be tested. -->

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->
