### PR TITLE
[SDK-1388] Fix concurrent error with dist tags and publishing releases

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,21 +39,7 @@ jobs:
             packages/*/dist
             packages/viewer/loader
 
-  detect-publish-release:
-    runs-on: ubuntu-latest
-    outputs:
-      publish: ${{ steps.detect-publish.outputs.publish }}
-    steps:
-      - name: "Checkout changes"
-        uses: actions/checkout@v2
-      - name: "Detect publish"
-        id: "detect-publish"
-        run: |
-          result=`./scripts/detect_release.sh`
-          echo $result
-          echo ::set-output name=publish::$result
-
-  publish-canary:
+  publish:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -82,7 +68,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: "Install"
         run: "yarn install"
-      - name: "Publish Canary to NPM"
+      - name: "Publish canary to NPM"
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPMJS_ACCESS_TOKEN }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,44 +77,16 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           ./scripts/publish_canary.sh
-
-
-  publish-release:
-    runs-on: ubuntu-latest
-    needs: [build, detect-publish-release]
-    if: needs.detect-publish-release.outputs.publish == 1
-    steps:
-      - name: "Checkout changes"
-        uses: actions/checkout@v2
-      - name: "Download build artifacts"
-        uses: actions/download-artifact@v2
-        with:
-          name: build-artifact
-          path: packages
-      - name: Set Node Version
-        id: nvm
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-      - name: Setup NodeJS
-        uses: actions/setup-node@v1
-        with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
-          registry-url: https://registry.npmjs.org
-          scope: "@vertexvis"
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - name: "Install"
-        run: "yarn install"
-      - name: "Publish Release to NPM"
+      - name: "Detect publish"
+        id: "detect-publish"
+        run: |
+          result=`./scripts/detect_release.sh`
+          echo $result
+          echo ::set-output name=publish::$result
+      - name: "Publish release to NPM"
+        if: steps.detect-publish.outputs.publish == 1
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPMJS_ACCESS_TOKEN }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          "./scripts/publish_release.sh"
+        run: ./scripts/publish_release.sh

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -8,19 +8,17 @@ set -e
 
 version="v$(get_version)"
 sha="$(git rev-parse HEAD)"
-body="Automated release for $version"
 
 npx lerna publish from-package --yes
-
-git tag -a "$version" -m "$body"
-git push --tags
 
 curl -s -X POST https://api.github.com/repos/$REPOSITORY/releases \
 -H "Authorization: token $GITHUB_TOKEN" \
 -d @- <<EOF
 {
   "tag_name": "$version",
+  "target_commitish": "$sha",
   "name": "$version",
+  "body": "Automated release for $version\n",
   "draft": false,
   "prelease": false
 }


### PR DESCRIPTION
## What

I'm seeing a couple errors when trying to publish a release. I think there's some concurrency issue between the canary and latest release scripts. This publishing the latest and canary versions into a single job.

* https://github.com/Vertexvis/vertex-web-sdk/runs/1914816212?check_suite_focus=true
* https://github.com/Vertexvis/vertex-web-sdk/runs/1914664953?check_suite_focus=true

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1388

