### PR TITLE
[SDK-1391] Check NPM if we need to run a release

### DIFF
--- a/scripts/detect_release.sh
+++ b/scripts/detect_release.sh
@@ -6,11 +6,10 @@
 
 set -e
 
-version=v$(get_version)
+version=$(get_version)
+published_version=`npm view @vertexvis/viewer --json versions | jq --arg version "$version" -r '.[] | select(. == $version)'`
 
-git fetch --tags
-
-if test -z `git tag --list $version`
+if test -z "$published_version"
 then
   echo 1
 else


### PR DESCRIPTION
## What

Saw a bug in our detect release script that was using tags to detect if a release needed to be performed. This instead checks if there's a published version in NPM.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1391

