### PR TITLE
[SDK-1391] Run publish-release after publish-canary is run

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,7 +39,21 @@ jobs:
             packages/*/dist
             packages/viewer/loader
 
-  publish:
+  detect-publish-release:
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.detect-publish.outputs.publish }}
+    steps:
+      - name: "Checkout changes"
+        uses: actions/checkout@v2
+      - name: "Detect publish"
+        id: "detect-publish"
+        run: |
+          result=`./scripts/detect_release.sh`
+          echo $result
+          echo ::set-output name=publish::$result
+
+  publish-canary:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -68,7 +82,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: "Install"
         run: "yarn install"
-      - name: "Publish canary to NPM"
+      - name: "Publish Canary to NPM"
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPMJS_ACCESS_TOKEN }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,16 +91,40 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           ./scripts/publish_canary.sh
-      - name: "Detect publish"
-        id: "detect-publish"
-        run: |
-          result=`./scripts/detect_release.sh`
-          echo $result
-          echo ::set-output name=publish::$result
-      - name: "Publish release to NPM"
-        if: steps.detect-publish.outputs.publish == 1
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: [build, detect-publish-release, publish-canary]
+    if: needs.detect-publish-release.outputs.publish == 1
+    steps:
+      - name: "Checkout changes"
+        uses: actions/checkout@v2
+      - name: "Download build artifacts"
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifact
+          path: packages
+      - name: Set Node Version
+        id: nvm
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+      - name: Setup NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          registry-url: https://registry.npmjs.org
+          scope: "@vertexvis"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: "Install"
+        run: "yarn install"
+      - name: "Publish Release to NPM"
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPMJS_ACCESS_TOKEN }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-        run: ./scripts/publish_release.sh
+        run: "./scripts/publish_release.sh"


### PR DESCRIPTION
## What

This sequences the publishing of release versions to NPM after canary deploys are run.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1391