### PR TITLE
[SDK-1429] Stencil 2.0 support for Edge <= 18

### DIFF
--- a/packages/viewer/stencil.config.ts
+++ b/packages/viewer/stencil.config.ts
@@ -34,4 +34,9 @@ export const config: Config = {
     },
     roots: ['<rootDir>/src/'],
   },
+  extras: {
+    cssVarsShim: true,
+    dynamicImportShim: true,
+    shadowDomShim: true,
+  },
 };

--- a/packages/viewer/stencil.config.ts
+++ b/packages/viewer/stencil.config.ts
@@ -35,7 +35,6 @@ export const config: Config = {
     roots: ['<rootDir>/src/'],
   },
   extras: {
-    cssVarsShim: true,
     dynamicImportShim: true,
     shadowDomShim: true,
   },


### PR DESCRIPTION
## What

Adds `extras` corresponding to necessary polyfills for Edge <= 18 to allow for usage in the Xamarin SDK.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1429

## Test Plan

- Test on Windows with EdgeHTML <= 18 replacing the `DOMContentLoaded` listener with the following
```typescript
import { applyPolyfills } from '/dist/esm/polyfills/index.js';
import { defineCustomElements } from '/dist/esm/loader.js';

window.addEventListener('DOMContentLoaded', () => {
  applyPolyfills().then(() => defineCustomElements(window).then(() => main()))
});
```

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
