### PR TITLE
[SDK-1517] [SDK-963] Prevent window scroll when zooming and fix zoom on firefox

### DIFF
--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -208,20 +208,23 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
 
     const defaultLineHeight =
       this.computedBodyStyle.fontSize != null &&
-      this.computedBodyStyle.fontSize !== ''
+      this.computedBodyStyle.fontSize !== '' &&
+      !isNaN(parseFloat(this.computedBodyStyle.fontSize))
         ? parseFloat(this.computedBodyStyle.fontSize) * DEFAULT_LINE_HEIGHT
         : DEFAULT_FONT_SIZE * DEFAULT_LINE_HEIGHT;
 
     if (deltaMode === 1) {
       // deltaMode 1 corresponds to DOM_DELTA_LINE, which computes deltas in lines
       return this.computedBodyStyle.lineHeight != null &&
-        this.computedBodyStyle.lineHeight !== ''
+        this.computedBodyStyle.lineHeight !== '' &&
+        !isNaN(parseFloat(this.computedBodyStyle.lineHeight))
         ? deltaY * parseFloat(this.computedBodyStyle.lineHeight)
         : deltaY * defaultLineHeight;
     } else if (deltaMode === 2) {
       // deltaMode 2 corresponds to DOM_DELTA_PAGE, which computes deltas in pages
       return this.computedBodyStyle.height != null &&
-        this.computedBodyStyle.height !== ''
+        this.computedBodyStyle.height !== '' &&
+        !isNaN(parseFloat(this.computedBodyStyle.height))
         ? deltaY * parseFloat(this.computedBodyStyle.height)
         : deltaY * window.innerHeight;
     }

--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -189,6 +189,8 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   }
 
   protected handleMouseWheel(event: WheelEvent): void {
+    event.preventDefault();
+
     SCROLL_WHEEL_DELTA_PERCENTAGES.forEach((percentage, index) => {
       const delta =
         -this.wheelDeltaToPixels(event.deltaY, event.deltaMode) / 10;


### PR DESCRIPTION
## What

Prevent default on wheel events and fix scrolling for firefox.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-963
https://vertexvis.atlassian.net/browse/SDK-1517

## Test Plan

- Test scrolling in the viewer with a page that's larger than the browser window
  - Page should not scroll, and model should zoom
- Test scrolling on Firefox

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
