### PR TITLE
[SDK-1513] Perform drag when beginning interaction

### DIFF
--- a/packages/viewer/src/interactions/__tests__/mouseInteractionHandler.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/mouseInteractionHandler.spec.ts
@@ -29,27 +29,15 @@ describe(MouseInteractionHandler, () => {
     buttons: 1,
     bubbles: true,
   });
-  const mouseMovePrimaryButton1 = new MouseEvent('mousemove', {
+  const mouseMovePrimaryButton = new MouseEvent('mousemove', {
     screenX: 110,
     screenY: 60,
     buttons: 1,
     bubbles: true,
   });
-  const mouseMovePrimaryButton2 = new MouseEvent('mousemove', {
-    screenX: 115,
-    screenY: 65,
-    buttons: 1,
-    bubbles: true,
-  });
-  const mouseMoveSecondaryButton1 = new MouseEvent('mousemove', {
+  const mouseMoveSecondaryButton = new MouseEvent('mousemove', {
     screenX: 110,
     screenY: 60,
-    buttons: 2,
-    bubbles: true,
-  });
-  const mouseMoveSecondaryButton2 = new MouseEvent('mousemove', {
-    screenX: 115,
-    screenY: 65,
     buttons: 2,
     bubbles: true,
   });
@@ -84,7 +72,7 @@ describe(MouseInteractionHandler, () => {
     handler.dispose();
   });
 
-  it('begins a drag of primary interaction if the primary mouse has moved more than 2 pixels', () => {
+  it('begins a drag of primary interaction if the primary mouse has moved 2 pixels', () => {
     simulatePrimaryInteractions();
 
     expect(rotateInteraction.beginDrag).toHaveBeenCalledTimes(1);
@@ -92,7 +80,7 @@ describe(MouseInteractionHandler, () => {
     expect(rotateInteraction.endDrag).toHaveBeenCalledTimes(1);
   });
 
-  it('begins a drag of pan interaction if the secondary mouse has moved more than 2 pixels', () => {
+  it('begins a drag of pan interaction if the secondary mouse has moved 2 pixels', () => {
     simulateSecondaryInteractions();
 
     expect(panInteraction.beginDrag).toHaveBeenCalledTimes(1);
@@ -102,7 +90,7 @@ describe(MouseInteractionHandler, () => {
 
   it('removes window listeners on mouse up', () => {
     simulatePrimaryInteractions();
-    window.dispatchEvent(mouseMovePrimaryButton2);
+    window.dispatchEvent(mouseMovePrimaryButton);
 
     expect(rotateInteraction.drag).toHaveBeenCalledTimes(1);
   });
@@ -163,15 +151,13 @@ describe(MouseInteractionHandler, () => {
 
   function simulatePrimaryInteractions(): void {
     div.dispatchEvent(mouseDown);
-    window.dispatchEvent(mouseMovePrimaryButton1);
-    window.dispatchEvent(mouseMovePrimaryButton2);
+    window.dispatchEvent(mouseMovePrimaryButton);
     window.dispatchEvent(mouseUp);
   }
 
   function simulateSecondaryInteractions(): void {
     div.dispatchEvent(mouseDown);
-    window.dispatchEvent(mouseMoveSecondaryButton1);
-    window.dispatchEvent(mouseMoveSecondaryButton2);
+    window.dispatchEvent(mouseMoveSecondaryButton);
     window.dispatchEvent(mouseUp);
   }
 

--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -130,7 +130,6 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     }
 
     const position = Point.create(event.screenX, event.screenY);
-    let didBeginDrag = false;
     const pixelThreshold =
       this.interactionApi != null
         ? this.interactionApi.pixelThreshold(this.isTouch(event))
@@ -141,13 +140,10 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
       !this.isDragging
     ) {
       this.beginDrag(event);
-      didBeginDrag = true;
       this.isDragging = true;
     }
 
-    // We only invoke drag interactions for mouse events after a beginDrag has
-    // been invoked.
-    if (!didBeginDrag && this.isDragging) {
+    if (this.isDragging) {
       this.drag(event);
     }
   }

--- a/packages/viewer/src/interactions/tapInteractionHandler.ts
+++ b/packages/viewer/src/interactions/tapInteractionHandler.ts
@@ -152,6 +152,10 @@ export class TapInteractionHandler implements InteractionHandler {
     isTouch = false
   ): void {
     if (position != null && this.pointerDownPosition != null) {
+      if (this.longPressTimer != null) {
+        this.emit(this.interactionApi?.tap)(position, keyDetails);
+      }
+
       if (
         this.doubleTapTimer != null &&
         this.secondPointerDownPosition != null
@@ -162,10 +166,6 @@ export class TapInteractionHandler implements InteractionHandler {
           this.secondPointerDownPosition
         );
         this.clearDoubleTapTimer();
-      }
-
-      if (this.longPressTimer != null) {
-        this.emit(this.interactionApi?.tap)(position, keyDetails);
       }
     }
 


### PR DESCRIPTION
## What

Corrects a couple behaviors from the SDK that were resulting in seemingly lost `tap` events:
- Performs a drag immediately after beginning an interaction since we will have moved the threshold amount
- Emits a tap when a longpress occurred, and adds both a `longPress` and `doubleTap` property to the tap event info to indicate whether it was part of either interaction

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1513

## Test Plan

- Test tap events (longpress, doubletap, tap)
- Test interactions, there should no longer be a "dead zone" where a tap is not emitted and an interaction doesn't begin visually

## Areas of Possible Regression

Tap events, interactions

## Out of scope changes made in PR

N/A

## Dependencies

N/A
