### PR TITLE
[SDK-1512] Support quick tap events

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -298,7 +298,7 @@ export class Viewer {
           'pointermove',
           () => this.getConfig()
         );
-        this.baseInteractionHandler = new PointerInteractionHandler();
+        this.baseInteractionHandler = new PointerInteractionHandler(() => this.getConfig());
         this.registerInteractionHandler(this.baseInteractionHandler);
         this.registerInteractionHandler(new MultiPointerInteractionHandler());
         this.registerInteractionHandler(tapInteractionHandler);
@@ -311,7 +311,7 @@ export class Viewer {
         );
 
         // fallback to touch events and mouse events as a default
-        this.baseInteractionHandler = new MouseInteractionHandler();
+        this.baseInteractionHandler = new MouseInteractionHandler(() => this.getConfig());
         this.registerInteractionHandler(this.baseInteractionHandler);
         this.registerInteractionHandler(new TouchInteractionHandler());
         this.registerInteractionHandler(tapInteractionHandler);

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -298,7 +298,9 @@ export class Viewer {
           'pointermove',
           () => this.getConfig()
         );
-        this.baseInteractionHandler = new PointerInteractionHandler(() => this.getConfig());
+        this.baseInteractionHandler = new PointerInteractionHandler(() =>
+          this.getConfig()
+        );
         this.registerInteractionHandler(this.baseInteractionHandler);
         this.registerInteractionHandler(new MultiPointerInteractionHandler());
         this.registerInteractionHandler(tapInteractionHandler);
@@ -311,7 +313,9 @@ export class Viewer {
         );
 
         // fallback to touch events and mouse events as a default
-        this.baseInteractionHandler = new MouseInteractionHandler(() => this.getConfig());
+        this.baseInteractionHandler = new MouseInteractionHandler(() =>
+          this.getConfig()
+        );
         this.registerInteractionHandler(this.baseInteractionHandler);
         this.registerInteractionHandler(new TouchInteractionHandler());
         this.registerInteractionHandler(tapInteractionHandler);

--- a/packages/viewer/src/interactions/__tests__/mouseInteractionHandler.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/mouseInteractionHandler.spec.ts
@@ -72,8 +72,6 @@ describe(MouseInteractionHandler, () => {
       interactions: {
         ...config.interactions,
         interactionDelay: 10,
-        finePointerThreshold: 1,
-        coarsePointerThreshold: 1,
       },
     }),
     rotateInteraction,
@@ -95,7 +93,7 @@ describe(MouseInteractionHandler, () => {
     handler.dispose();
   });
 
-  it.only('begins a drag of primary interaction if the primary mouse has moved more than 2 pixels', async () => {
+  it('begins a drag of primary interaction if the primary mouse has moved more than 2 pixels', async () => {
     await simulatePrimaryInteractions(50);
 
     expect(rotateInteraction.beginDrag).toHaveBeenCalledTimes(1);

--- a/packages/viewer/src/interactions/__tests__/tapInteractionHandler.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/tapInteractionHandler.spec.ts
@@ -169,7 +169,7 @@ describe(TapInteractionHandler, () => {
     window.dispatchEvent(touchMove1);
     window.dispatchEvent(touchEnd);
 
-    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {}, {});
+    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {});
   });
 
   it('should emit a double tap if a touch move has occurred < 2 pixels away from the touch start', () => {

--- a/packages/viewer/src/interactions/__tests__/tapInteractionHandler.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/tapInteractionHandler.spec.ts
@@ -51,11 +51,23 @@ describe(TapInteractionHandler, () => {
     touches: [{ clientX: 11, clientY: 10, identifier: 1 }],
   } as any);
 
+  const config = parseConfig('platdev');
   const handler = new TapInteractionHandler(
     'mousedown',
     'mouseup',
     'mousemove',
-    () => parseConfig('platdev')
+    () => ({
+      ...config,
+      events: {
+        ...config.events,
+        doubleTapThreshold: 15,
+        longPressThreshold: 15,
+      },
+      interactions: {
+        ...config.interactions,
+        interactionDelay: 10,
+      },
+    })
   );
 
   beforeEach(() => {
@@ -71,22 +83,25 @@ describe(TapInteractionHandler, () => {
     handler.dispose();
   });
 
-  it('should invoke the tap method of the interaction api provided on mouseup', () => {
+  it('should invoke the tap method of the interaction api provided on mouseup', async () => {
     div.dispatchEvent(mouseDown);
+    await delay(5);
     window.dispatchEvent(mouseUp1);
 
     expect(api.tap).toHaveBeenCalledWith(Point.create(10, 10), keyDetails);
   });
 
-  it('should invoke the tap method of the interaction api provided on touchend', () => {
+  it('should invoke the tap method of the interaction api provided on touchend', async () => {
     div.dispatchEvent(touchStart);
+    await delay(5);
     window.dispatchEvent(touchEnd);
 
     expect(api.tap).toHaveBeenCalledWith(Point.create(10, 10), {});
   });
 
-  it('should not emit a tap if the ending location is more than 1 pixel away from the starting location', () => {
+  it('should not emit a tap if the ending location is more than 1 pixel away from the starting location', async () => {
     div.dispatchEvent(mouseDown);
+    await delay(5);
     window.dispatchEvent(mouseUp2);
 
     expect(api.tap).not.toHaveBeenCalledWith(Point.create(15, 15), keyDetails);
@@ -101,11 +116,10 @@ describe(TapInteractionHandler, () => {
     expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {});
   });
 
-  it('should not emit a double tap if the second tap occurs after the time period', () => {
-    jest.useFakeTimers();
+  it('should not emit a double tap if the second tap occurs after the time period', async () => {
     div.dispatchEvent(touchStart);
     window.dispatchEvent(touchEnd);
-    jest.advanceTimersByTime(5000);
+    await delay(50);
     div.dispatchEvent(touchStart);
     window.dispatchEvent(touchEnd);
 
@@ -124,11 +138,10 @@ describe(TapInteractionHandler, () => {
     );
   });
 
-  it('should not emit a double tap if the second click occurs after the time period', () => {
-    jest.useFakeTimers();
+  it('should not emit a double tap if the second click occurs after the time period', async () => {
     div.dispatchEvent(mouseDown);
     window.dispatchEvent(mouseUp1);
-    jest.advanceTimersByTime(5000);
+    await delay(50);
     div.dispatchEvent(mouseDown);
     window.dispatchEvent(mouseUp1);
 
@@ -138,14 +151,25 @@ describe(TapInteractionHandler, () => {
     );
   });
 
-  it('should not emit a double tap if a touch move has occurred >= 2 pixels away from the touch start', () => {
+  it('should not emit a double tap if a touch move has occurred >= 2 pixels away from the touch start and the interaction has begun', async () => {
+    div.dispatchEvent(touchStart);
+    window.dispatchEvent(touchEnd);
+    div.dispatchEvent(touchStart);
+    await delay(50);
+    window.dispatchEvent(touchMove1);
+    window.dispatchEvent(touchEnd);
+
+    expect(api.doubleTap).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+  });
+
+  it('should emit a double tap at the start location if a touch move has occurred >= 2 pixels away from the touch start and the interaction has not begun', async () => {
     div.dispatchEvent(touchStart);
     window.dispatchEvent(touchEnd);
     div.dispatchEvent(touchStart);
     window.dispatchEvent(touchMove1);
     window.dispatchEvent(touchEnd);
 
-    expect(api.doubleTap).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {}, {});
   });
 
   it('should emit a double tap if a touch move has occurred < 2 pixels away from the touch start', () => {
@@ -158,10 +182,11 @@ describe(TapInteractionHandler, () => {
     expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {});
   });
 
-  it('should not emit a double tap if a mouse move has occurred >= 2 pixels away from the mouse down', () => {
+  it('should not emit a double tap if a mouse move has occurred >= 2 pixels away from the mouse down and the interaction has begun', async () => {
     div.dispatchEvent(mouseDown);
     window.dispatchEvent(mouseUp1);
     div.dispatchEvent(mouseDown);
+    await delay(50);
     window.dispatchEvent(mouseMove1);
     window.dispatchEvent(mouseUp1);
 
@@ -171,7 +196,7 @@ describe(TapInteractionHandler, () => {
     );
   });
 
-  it('should emit a double tap if a mouse move has occurred < 2 pixels away from the mouse down', () => {
+  it('should emit a double tap if a mouse move has occurred < 2 pixels away from the mouse down', async () => {
     div.dispatchEvent(mouseDown);
     window.dispatchEvent(mouseUp1);
     div.dispatchEvent(mouseDown);
@@ -184,28 +209,25 @@ describe(TapInteractionHandler, () => {
     );
   });
 
-  it('should emit a long press if a touch start occurs and a touch end does not occur within the configured time threshold', () => {
-    jest.useFakeTimers();
+  it('should emit a long press if a touch start occurs and a touch end does not occur within the configured time threshold', async () => {
     div.dispatchEvent(touchStart);
-    jest.advanceTimersByTime(5000);
+    await delay(50);
     window.dispatchEvent(touchEnd);
 
     expect(api.longPress).toHaveBeenCalledWith(Point.create(10, 10), {});
   });
 
-  it('should not emit a long press if a touch start occurs and a touch end occurs within the configured time threshold', () => {
-    jest.useFakeTimers();
+  it('should not emit a long press if a touch start occurs and a touch end occurs within the configured time threshold', async () => {
     div.dispatchEvent(touchStart);
-    jest.advanceTimersByTime(200);
+    await delay(5);
     window.dispatchEvent(touchEnd);
 
     expect(api.longPress).not.toHaveBeenCalledWith(Point.create(10, 10), {});
   });
 
-  it('should emit a long press if a mouse down occurs and a mouse up does not occur within the configured time threshold', () => {
-    jest.useFakeTimers();
+  it('should emit a long press if a mouse down occurs and a mouse up does not occur within the configured time threshold', async () => {
     div.dispatchEvent(mouseDown);
-    jest.advanceTimersByTime(5000);
+    await delay(50);
     window.dispatchEvent(mouseUp1);
 
     expect(api.longPress).toHaveBeenCalledWith(
@@ -214,10 +236,9 @@ describe(TapInteractionHandler, () => {
     );
   });
 
-  it('should not emit a long press if a mouse down occurs and a mouse up occurs within the configured time threshold', () => {
-    jest.useFakeTimers();
+  it('should not emit a long press if a mouse down occurs and a mouse up occurs within the configured time threshold', async () => {
     div.dispatchEvent(mouseDown);
-    jest.advanceTimersByTime(200);
+    await delay(5);
     window.dispatchEvent(mouseUp1);
 
     expect(api.longPress).not.toHaveBeenCalledWith(
@@ -226,31 +247,29 @@ describe(TapInteractionHandler, () => {
     );
   });
 
-  it('should not emit a long press if a touch move has occurred >= 2 pixels away from the touch start', () => {
-    jest.useFakeTimers();
+  it('should not emit a long press if a touch move has occurred >= 2 pixels away from the touch start and the interaction has begun', async () => {
     div.dispatchEvent(touchStart);
+    await delay(10);
     window.dispatchEvent(touchMove1);
-    jest.advanceTimersByTime(5000);
+    await delay(50);
     window.dispatchEvent(touchEnd);
 
     expect(api.longPress).not.toHaveBeenCalledWith(Point.create(10, 10), {});
   });
 
-  it('should emit a long press if a touch move has occurred < 2 pixels away from the touch start', () => {
-    jest.useFakeTimers();
+  it('should emit a long press if a touch move has occurred < 2 pixels away from the touch start', async () => {
     div.dispatchEvent(touchStart);
     window.dispatchEvent(touchMove2);
-    jest.advanceTimersByTime(5000);
+    await delay(50);
     window.dispatchEvent(touchEnd);
 
     expect(api.longPress).toHaveBeenCalledWith(Point.create(10, 10), {});
   });
 
-  it('should not emit a long press if a mouse move has occurred >= 2 pixels away from the mouse down', () => {
-    jest.useFakeTimers();
+  it('should not emit a long press if a mouse move has occurred >= 2 pixels away from the mouse down', async () => {
     div.dispatchEvent(mouseDown);
+    await delay(10);
     window.dispatchEvent(mouseMove1);
-    jest.advanceTimersByTime(5000);
     window.dispatchEvent(mouseUp1);
 
     expect(api.longPress).not.toHaveBeenCalledWith(
@@ -259,10 +278,9 @@ describe(TapInteractionHandler, () => {
     );
   });
 
-  it('should emit a long press if a mouse move has occurred < 2 pixels away from the mouse down', () => {
-    jest.useFakeTimers();
+  it('should emit a long press if a mouse move has occurred < 2 pixels away from the mouse down', async () => {
     div.dispatchEvent(mouseDown);
-    jest.advanceTimersByTime(5000);
+    await delay(50);
     window.dispatchEvent(mouseMove2);
     window.dispatchEvent(mouseUp1);
 
@@ -271,4 +289,8 @@ describe(TapInteractionHandler, () => {
       keyDetails
     );
   });
+
+  function delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+  }
 });

--- a/packages/viewer/src/interactions/__tests__/twistInteractionHandler.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/twistInteractionHandler.spec.ts
@@ -1,8 +1,11 @@
 import { TwistInteractionHandler } from '../twistInteractionHandler';
 import { PointerInteractionHandler } from '../pointerInteractionHandler';
+import { parseConfig } from '../../config/config';
 
 describe(TwistInteractionHandler, () => {
-  const baseInteractionHandler = new PointerInteractionHandler();
+  const baseInteractionHandler = new PointerInteractionHandler(() =>
+    parseConfig('platdev')
+  );
 
   const twistInteractionHandler = new TwistInteractionHandler(
     baseInteractionHandler

--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -29,7 +29,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   private draggingInteraction: MouseInteraction | undefined;
   private isDragging = false;
   private lastMoveEvent?: BaseEvent;
-  private interactionTimer?: any;
+  private interactionTimer?: number;
 
   protected disableIndividualInteractions = false;
 
@@ -123,7 +123,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   protected handleDownEvent(event: BaseEvent): void {
     event.preventDefault();
 
-    this.interactionTimer = setTimeout(() => {
+    this.interactionTimer = window.setTimeout(() => {
       this.downPosition = Point.create(event.screenX, event.screenY);
       this.interactionTimer = undefined;
 
@@ -172,7 +172,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     }
 
     if (this.interactionTimer != null) {
-      clearTimeout(this.interactionTimer);
+      window.clearTimeout(this.interactionTimer);
       this.interactionTimer = undefined;
     }
 

--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -28,7 +28,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   private currentInteraction?: MouseInteraction;
   private draggingInteraction: MouseInteraction | undefined;
   private isDragging = false;
-  private lastMouseEvent?: BaseEvent;
+  private lastMoveEvent?: BaseEvent;
   private interactionTimer: number | undefined;
 
   protected disableIndividualInteractions = false;
@@ -127,8 +127,9 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
       this.downPosition = Point.create(event.screenX, event.screenY);
       this.interactionTimer = undefined;
 
-      if (this.lastMouseEvent != null) {
-        this.handleWindowMove(this.lastMouseEvent);
+      // Perform the current movement in the case that the interaction timer elapses
+      if (this.lastMoveEvent != null) {
+        this.handleWindowMove(this.lastMoveEvent);
       }
     }, this.getConfig().interactions.interactionDelay);
 
@@ -161,7 +162,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
       }
     }
 
-    this.lastMouseEvent = event;
+    this.lastMoveEvent = event;
   }
 
   protected async handleWindowUp(event: BaseEvent): Promise<void> {
@@ -173,11 +174,11 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     if (this.interactionTimer != null) {
       window.clearTimeout(this.interactionTimer);
       this.interactionTimer = undefined;
-      this.lastMouseEvent = undefined;
     }
 
     window.removeEventListener(this.moveEvent, this.handleWindowMove);
     window.removeEventListener(this.upEvent, this.handleWindowUp);
+    this.lastMoveEvent = undefined;
   }
 
   protected beginDrag(event: BaseEvent): void {

--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -29,7 +29,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   private draggingInteraction: MouseInteraction | undefined;
   private isDragging = false;
   private lastMoveEvent?: BaseEvent;
-  private interactionTimer: number | undefined;
+  private interactionTimer?: any;
 
   protected disableIndividualInteractions = false;
 
@@ -123,7 +123,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   protected handleDownEvent(event: BaseEvent): void {
     event.preventDefault();
 
-    this.interactionTimer = window.setTimeout(() => {
+    this.interactionTimer = setTimeout(() => {
       this.downPosition = Point.create(event.screenX, event.screenY);
       this.interactionTimer = undefined;
 
@@ -172,7 +172,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     }
 
     if (this.interactionTimer != null) {
-      window.clearTimeout(this.interactionTimer);
+      clearTimeout(this.interactionTimer);
       this.interactionTimer = undefined;
     }
 

--- a/packages/viewer/src/interactions/mouseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/mouseInteractionHandler.ts
@@ -1,3 +1,4 @@
+import { ConfigProvider } from '../config/config';
 import { BaseInteractionHandler } from './baseInteractionHandler';
 import {
   RotateInteraction,
@@ -8,6 +9,7 @@ import {
 
 export class MouseInteractionHandler extends BaseInteractionHandler {
   public constructor(
+    getConfig: ConfigProvider,
     rotateInteraction = new RotateInteraction(),
     zoomInteraction = new ZoomInteraction(),
     panInteraction = new PanInteraction(),
@@ -20,7 +22,8 @@ export class MouseInteractionHandler extends BaseInteractionHandler {
       rotateInteraction,
       zoomInteraction,
       panInteraction,
-      twistInteraction
+      twistInteraction,
+      getConfig
     );
   }
 }

--- a/packages/viewer/src/interactions/pointerInteractionHandler.ts
+++ b/packages/viewer/src/interactions/pointerInteractionHandler.ts
@@ -7,11 +7,12 @@ import {
   TwistInteraction,
 } from './mouseInteractions';
 import { InteractionApi } from './interactionApi';
+import { ConfigProvider } from '../config/config';
 
 export class PointerInteractionHandler extends BaseInteractionHandler {
   private touchPoints: Set<number>;
 
-  public constructor() {
+  public constructor(getConfig: ConfigProvider) {
     super(
       'pointerdown',
       'pointerup',
@@ -19,7 +20,8 @@ export class PointerInteractionHandler extends BaseInteractionHandler {
       new RotateInteraction(),
       new ZoomInteraction(),
       new PanInteraction(),
-      new TwistInteraction()
+      new TwistInteraction(),
+      getConfig
     );
     this.touchPoints = new Set();
     this.handlePointerDown = this.handlePointerDown.bind(this);

--- a/packages/viewer/src/interactions/tapInteractionHandler.ts
+++ b/packages/viewer/src/interactions/tapInteractionHandler.ts
@@ -200,7 +200,7 @@ export class TapInteractionHandler implements InteractionHandler {
         emittedPosition = this.getCanvasPosition(pointerUpPosition);
       }
       if (emittedPosition != null && emitter != null) {
-        emitter(emittedPosition, keyDetails, eventInfo);
+        emitter(emittedPosition, keyDetails);
       }
     };
   }

--- a/packages/viewer/src/interactions/tapInteractionHandler.ts
+++ b/packages/viewer/src/interactions/tapInteractionHandler.ts
@@ -153,7 +153,9 @@ export class TapInteractionHandler implements InteractionHandler {
     keyDetails: Partial<TapEventKeys> = {},
     isTouch = false
   ): void {
-    if (position != null && this.pointerDownPosition != null) {
+    if (position != null) {
+      this.emit(this.interactionApi?.tap)(position, keyDetails);
+
       if (
         this.doubleTapTimer != null &&
         this.secondPointerDownPosition != null
@@ -187,8 +189,10 @@ export class TapInteractionHandler implements InteractionHandler {
       const threshold = this.interactionApi?.pixelThreshold(isTouch) || 1;
 
       let emittedPosition: Point.Point | undefined;
-      if (this.interactionTimer != null && downPosition != null) {
-        emittedPosition = this.getCanvasPosition(downPosition);
+      if (this.interactionTimer != null) {
+        emittedPosition = this.getCanvasPosition(
+          downPosition || pointerUpPosition
+        );
       } else if (
         downPosition != null &&
         Point.distance(downPosition, pointerUpPosition) <= threshold
@@ -220,6 +224,7 @@ export class TapInteractionHandler implements InteractionHandler {
 
     this.clearDoubleTapTimer();
     this.clearLongPressTimer();
+    this.clearInteractionTimer();
   }
 
   private clearDoubleTapTimer(): void {
@@ -275,8 +280,8 @@ export class TapInteractionHandler implements InteractionHandler {
 
   private setPointerPositions(point: Point.Point): void {
     this.pointerDownPosition = point;
+    this.restartInteractionTimer();
     if (this.firstPointerDownPosition == null) {
-      this.restartInteractionTimer();
       this.restartDoubleTapTimer();
       this.firstPointerDownPosition = point;
     } else {

--- a/packages/viewer/src/interactions/tapInteractionHandler.ts
+++ b/packages/viewer/src/interactions/tapInteractionHandler.ts
@@ -186,15 +186,18 @@ export class TapInteractionHandler implements InteractionHandler {
       const downPosition = pointerDownPosition || this.pointerDownPosition;
       const threshold = this.interactionApi?.pixelThreshold(isTouch) || 1;
       console.log(this.interactionTimer);
-      if (
-        this.interactionTimer != null ||
-        (downPosition != null &&
-          Point.distance(downPosition, pointerUpPosition) <= threshold)
+
+      let emittedPosition: Point.Point | undefined;
+      if (this.interactionTimer != null && downPosition != null) {
+        emittedPosition = this.getCanvasPosition(downPosition);
+      } else if (
+        downPosition != null &&
+        Point.distance(downPosition, pointerUpPosition) <= threshold
       ) {
-        const position = this.getCanvasPosition(pointerUpPosition);
-        if (position != null && emitter != null) {
-          emitter(position, keyDetails);
-        }
+        emittedPosition = this.getCanvasPosition(pointerUpPosition);
+      }
+      if (emittedPosition != null && emitter != null) {
+        emitter(emittedPosition, keyDetails, eventInfo);
       }
     };
   }

--- a/packages/viewer/src/interactions/tapInteractionHandler.ts
+++ b/packages/viewer/src/interactions/tapInteractionHandler.ts
@@ -21,8 +21,8 @@ export class TapInteractionHandler implements InteractionHandler {
   private firstPointerDownPosition?: Point.Point;
   private secondPointerDownPosition?: Point.Point;
 
-  private doubleTapTimer?: any;
-  private longPressTimer?: any;
+  private doubleTapTimer?: number;
+  private longPressTimer?: number;
   private interactionTimer?: number;
 
   public constructor(
@@ -185,7 +185,6 @@ export class TapInteractionHandler implements InteractionHandler {
     ): void => {
       const downPosition = pointerDownPosition || this.pointerDownPosition;
       const threshold = this.interactionApi?.pixelThreshold(isTouch) || 1;
-      console.log(this.interactionTimer);
 
       let emittedPosition: Point.Point | undefined;
       if (this.interactionTimer != null && downPosition != null) {
@@ -225,7 +224,7 @@ export class TapInteractionHandler implements InteractionHandler {
 
   private clearDoubleTapTimer(): void {
     if (this.doubleTapTimer != null) {
-      clearTimeout(this.doubleTapTimer);
+      window.clearTimeout(this.doubleTapTimer);
     }
     this.doubleTapTimer = undefined;
     this.firstPointerDownPosition = undefined;
@@ -234,7 +233,7 @@ export class TapInteractionHandler implements InteractionHandler {
 
   private restartDoubleTapTimer(): void {
     this.clearDoubleTapTimer();
-    this.doubleTapTimer = setTimeout(
+    this.doubleTapTimer = window.setTimeout(
       () => this.clearDoubleTapTimer(),
       this.getConfig().events.doubleTapThreshold
     );
@@ -242,14 +241,14 @@ export class TapInteractionHandler implements InteractionHandler {
 
   private clearLongPressTimer(): void {
     if (this.longPressTimer != null) {
-      clearTimeout(this.longPressTimer);
+      window.clearTimeout(this.longPressTimer);
     }
     this.longPressTimer = undefined;
   }
 
   private restartLongPressTimer(eventKeys: Partial<TapEventKeys> = {}): void {
     this.clearLongPressTimer();
-    this.longPressTimer = setTimeout(() => {
+    this.longPressTimer = window.setTimeout(() => {
       if (this.pointerDownPosition) {
         this.emit(this.interactionApi?.longPress)(
           this.pointerDownPosition,

--- a/packages/viewer/src/types/interactions.ts
+++ b/packages/viewer/src/types/interactions.ts
@@ -15,7 +15,7 @@ export interface InteractionConfig {
 
   /**
    * The amount of time before a movement is considered an interaction and will
-   * update the camera. 
+   * update the camera.
    */
   interactionDelay: number;
 }

--- a/packages/viewer/src/types/interactions.ts
+++ b/packages/viewer/src/types/interactions.ts
@@ -12,9 +12,16 @@ export interface InteractionConfig {
    * camera. This threshold is always scaled up based on the device's pixel ratio.
    */
   coarsePointerThreshold: number;
+
+  /**
+   * The amount of time before a movement is considered an interaction and will
+   * update the camera. 
+   */
+  interactionDelay: number;
 }
 
 export const defaultInteractionConfig: InteractionConfig = {
   finePointerThreshold: 1,
   coarsePointerThreshold: 3,
+  interactionDelay: 150,
 };


### PR DESCRIPTION
## What

Introduces a delay before we register a pointer interaction as a camera manipulation (default to 150ms). Within this delay, a pointerdown + pointerup will be considered a tap regardless of the amount of movement, and an interaction will not occur. 

In the case of that the timer elapses and an interaction begins, we will transform the camera to reflect the amount of movement so far to make things feel more responsive.

Here are a couple videos to demonstrate the change:

Before:

https://user-images.githubusercontent.com/5252480/112912600-7faa0680-90bd-11eb-9b3e-f0d6392e65de.mov

After:

https://user-images.githubusercontent.com/5252480/112912605-833d8d80-90bd-11eb-82eb-7630ad060285.mov


## Ticket

https://vertexvis.atlassian.net/browse/SDK-1512

## Test Plan

- Test tap behavior (tap, doubletap, longpress)
- Test interactions
  - Specifically the feel of the changes, whether this experience is noticeably slower than what we currently have

## Areas of Possible Regression

Tap events, interactions

## Out of scope changes made in PR

N/A

## Dependencies

N/A
