### PR TITLE
[SDK-1574] Scene tree selection

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -55,7 +55,6 @@
     "@vertexvis/utils": "0.9.25",
     "classnames": "2.2.6",
     "google-protobuf": "^3.15.7",
-    "jwt-decode": "^3.1.2",
     "protobufjs": "^6.9.0",
     "requestidlecallback-polyfill": "^1.0.2",
     "tslib": "^2.1.0",

--- a/packages/viewer/src/commands/streamCommandsMapper.ts
+++ b/packages/viewer/src/commands/streamCommandsMapper.ts
@@ -124,12 +124,12 @@ function buildOperationTypes(
         return {
           changeMaterial: {
             material: {
-              d: op.color.opacity,
-              ns: op.color.glossiness,
-              ka: op.color.ambient,
-              kd: op.color.diffuse,
-              ks: op.color.specular,
-              ke: op.color.emissive,
+              d: op.material.opacity,
+              ns: op.material.glossiness,
+              ka: op.material.ambient,
+              kd: op.material.diffuse,
+              ks: op.material.specular,
+              ke: op.material.emissive,
             },
           },
         };
@@ -159,12 +159,12 @@ function buildOperationTypes(
         return {
           changeSelection: {
             material: {
-              d: op.color.opacity,
-              ns: op.color.glossiness,
-              ka: op.color.ambient,
-              kd: op.color.diffuse,
-              ks: op.color.specular,
-              ke: op.color.emissive,
+              d: op.material.opacity,
+              ns: op.material.glossiness,
+              ka: op.material.ambient,
+              kd: op.material.diffuse,
+              ks: op.material.specular,
+              ke: op.material.emissive,
             },
           },
         };

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -46,6 +46,11 @@ export namespace Components {
          */
         "configEnv": Environment;
         /**
+          * Performs an API call that will deselect the item associated to the given row or row index.
+          * @param rowOrIndex The row or row index to deselect.
+         */
+        "deselectItem": (rowOrIndex: number | Row) => Promise<void>;
+        /**
           * Performs an API call to expand all nodes in the tree.
          */
         "expandAll": () => Promise<void>;
@@ -95,6 +100,18 @@ export namespace Components {
          */
         "rowData"?: RowDataProvider;
         "scrollToIndex": (index: number) => Promise<void>;
+        /**
+          * Performs an API call that will select the item associated to the given row or row index.
+          * @param rowOrIndex The row or row index to select.
+          * @param append `true` if the selection should append to the current selection, or `false` if this should replace the current selection. Defaults to replace.
+         */
+        "selectItem": (rowOrIndex: number | Row, append?: boolean) => Promise<void>;
+        /**
+          * Disables the default selection behavior of the tree. Can be used to implement custom selection behavior via the trees selection methods.
+          * @see SceneTree.selectItem *
+          * @see SceneTree.deselectItem
+         */
+        "selectionDisabled": boolean;
         /**
           * Performs an API call that will show the item associated to the given row or row index.
           * @param rowOrIndex The row or row index to show.
@@ -323,6 +340,12 @@ declare namespace LocalJSX {
           * @example ```html <script>   const tree = document.querySelector('vertex-scene-tree');   tree.rowData = (row) => {     return { func: () => console.log('row', row.name) };   } </script>  <vertex-scene-tree>   <template slot="right">     <button onclick="row.data.func">Hi</button>   </template> </vertex-scene-tree> ```
          */
         "rowData"?: RowDataProvider;
+        /**
+          * Disables the default selection behavior of the tree. Can be used to implement custom selection behavior via the trees selection methods.
+          * @see SceneTree.selectItem *
+          * @see SceneTree.deselectItem
+         */
+        "selectionDisabled"?: boolean;
         /**
           * An instance of a `<vertex-viewer>` element. Either this property or `viewerSelector` must be set.
          */

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -9,7 +9,9 @@ import { RowDataProvider } from "./components/scene-tree/scene-tree";
 import { Config } from "./config/config";
 import { Environment } from "./config/environment";
 import { Row } from "./components/scene-tree/lib/row";
+import { SelectItemOptions } from "./components/scene-tree/lib/viewer-ops";
 import { StreamAttributes } from "@vertexvis/stream-api";
+import { ColorMaterial } from "./scenes/colorMaterial";
 import { TapEventDetails } from "./interactions/tapEventDetails";
 import { Frame } from "./types";
 import { ConnectionStatus } from "./components/viewer/viewer";
@@ -76,7 +78,7 @@ export namespace Components {
           * @param event A mouse or pointer event that originated from this component.
           * @returns A row, or `undefined` if the row hasn't been loaded.
          */
-        "getRowFromEvent": (event: MouseEvent | PointerEvent) => Promise<Row>;
+        "getRowForEvent": (event: MouseEvent | PointerEvent) => Promise<Row>;
         /**
           * Performs an API call that will hide the item associated to the given row or row index.
           * @param rowOrIndex The row or row index to hide.
@@ -105,7 +107,7 @@ export namespace Components {
           * @param rowOrIndex The row or row index to select.
           * @param append `true` if the selection should append to the current selection, or `false` if this should replace the current selection. Defaults to replace.
          */
-        "selectItem": (rowOrIndex: number | Row, append?: boolean) => Promise<void>;
+        "selectItem": (rowOrIndex: number | Row, options: SelectItemOptions) => Promise<void>;
         /**
           * Disables the default selection behavior of the tree. Can be used to implement custom selection behavior via the trees selection methods.
           * @see SceneTree.selectItem *
@@ -201,6 +203,11 @@ export namespace Components {
           * Returns an object that is used to perform operations on the `Scene` that's currently being viewed. These operations include updating items, positioning the camera and performing hit tests.
          */
         "scene": () => Promise<Scene>;
+        /**
+          * The default hex color or material to use when selecting items.
+         */
+        "selectionMaterial": | string
+    | ColorMaterial;
         /**
           * Property used for internals or testing.
           * @private
@@ -415,6 +422,11 @@ declare namespace LocalJSX {
           * Emits an event when a provided oauth2 token is about to expire, or is about to expire, causing issues with establishing a websocket connection, or performing API calls.
          */
         "onTokenExpired"?: (event: CustomEvent<void>) => void;
+        /**
+          * The default hex color or material to use when selecting items.
+         */
+        "selectionMaterial"?: | string
+    | ColorMaterial;
         /**
           * Property used for internals or testing.
           * @private

--- a/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
+++ b/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
@@ -100,31 +100,34 @@ describe(SceneTreeController, () => {
       expect(client.subscribe).toHaveBeenCalledTimes(2);
     });
 
-    it('fetches page when list changes', async (done) => {
+    it('fetches page when list changes', async () => {
       const getTree1 = createGetTreeResponse(10, 20);
-      const getTree2 = createGetTreeResponse(20, 20);
-      let onStateChangeCount = 0;
+      const getTree2 = createGetTreeResponse(10, 20);
 
-      (client.getTree as jest.Mock).mockImplementationOnce(
+      (client.getTree as jest.Mock).mockImplementation(
         mockGrpcUnaryResult(getTree1)
       );
 
-      (client.getTree as jest.Mock).mockImplementationOnce(
+      (client.getTree as jest.Mock).mockImplementation(
         mockGrpcUnaryResult(getTree2)
       );
 
       const controller = new SceneTreeController(client, 10, () => jwt);
       await controller.fetchPage(0);
+      await controller.fetchPage(1);
+      controller.updateActiveRowRange(0, 9);
 
       const stream = new ResponseStreamMock<SubscribeResponse>();
       (client.subscribe as jest.Mock).mockReturnValue(stream);
 
-      controller.onStateChange.on((state) => {
-        onStateChangeCount++;
-        if (onStateChangeCount === 2) {
-          expect(state.rows).toHaveLength(20);
-          done();
-        }
+      const pendingRows = new Promise((resolve) => {
+        let onStateChangeCount = 0;
+        controller.onStateChange.on((state) => {
+          onStateChangeCount++;
+          if (onStateChangeCount === 2) {
+            resolve(state.rows);
+          }
+        });
       });
       controller.subscribe();
 
@@ -135,39 +138,9 @@ describe(SceneTreeController, () => {
       const resp = new SubscribeResponse();
       resp.setChange(changeType);
       stream.invokeOnData(resp);
-    });
 
-    it('invalidates pages after list change', async (done) => {
-      const getTree = createGetTreeResponse(10, 100);
-      let onStateChangeCount = 0;
-
-      (client.getTree as jest.Mock).mockImplementation(
-        mockGrpcUnaryResult(getTree)
-      );
-
-      const controller = new SceneTreeController(client, 10, () => jwt);
-      await controller.fetchPage(0);
-      await controller.fetchRange(0, 100);
-
-      const stream = new ResponseStreamMock<SubscribeResponse>();
-      (client.subscribe as jest.Mock).mockReturnValue(stream);
-
-      controller.onStateChange.on((state) => {
-        onStateChangeCount++;
-        if (onStateChangeCount === 2) {
-          expect(controller.fetchedPageCount).toBe(2);
-          done();
-        }
-      });
-      controller.subscribe();
-
-      const listChange = new ListChange();
-      listChange.setStart(11);
-      const changeType = new TreeChangeType();
-      changeType.setListChange(listChange);
-      const resp = new SubscribeResponse();
-      resp.setChange(changeType);
-      stream.invokeOnData(resp);
+      const rows = await pendingRows;
+      expect(rows).toHaveLength(20);
     });
 
     it('patches data that has been hidden', async () => {
@@ -253,6 +226,92 @@ describe(SceneTreeController, () => {
         { ...rows[0], visible: true },
         { ...rows[1], visible: true },
         { ...rows[2], visible: false },
+      ]);
+    });
+
+    it('patches data that has been selected', async () => {
+      const getTree = createGetTreeResponse(100, 100, (node) =>
+        node.setSelected(false)
+      );
+
+      (client.getTree as jest.Mock).mockImplementation(
+        mockGrpcUnaryResult(getTree)
+      );
+
+      const controller = new SceneTreeController(client, 100, () => jwt);
+      await controller.fetchPage(0);
+
+      const stream = new ResponseStreamMock<SubscribeResponse>();
+      (client.subscribe as jest.Mock).mockReturnValue(stream);
+
+      controller.subscribe();
+
+      const pendingRows = new Promise<Row[]>((resolve) => {
+        controller.onStateChange.on((state) => {
+          resolve(state.rows);
+        });
+      });
+
+      const range = new Range();
+      range.setStart(0);
+      range.setEnd(1);
+      const stateChange = new StateChange();
+      stateChange.setSelectedList([range]);
+      const changeType = new TreeChangeType();
+      changeType.setRanges(stateChange);
+      const resp = new SubscribeResponse();
+      resp.setChange(changeType);
+      stream.invokeOnData(resp);
+
+      const rows = await pendingRows;
+
+      expect(rows.slice(0, 3)).toMatchObject([
+        { ...rows[0], selected: true },
+        { ...rows[1], selected: true },
+        { ...rows[2], selected: false },
+      ]);
+    });
+
+    it('patches data that has been deselected', async () => {
+      const getTree = createGetTreeResponse(100, 100, (node) =>
+        node.setSelected(true)
+      );
+
+      (client.getTree as jest.Mock).mockImplementation(
+        mockGrpcUnaryResult(getTree)
+      );
+
+      const controller = new SceneTreeController(client, 100, () => jwt);
+      await controller.fetchPage(0);
+
+      const stream = new ResponseStreamMock<SubscribeResponse>();
+      (client.subscribe as jest.Mock).mockReturnValue(stream);
+
+      controller.subscribe();
+
+      const pendingRows = new Promise<Row[]>((resolve) => {
+        controller.onStateChange.on((state) => {
+          resolve(state.rows);
+        });
+      });
+
+      const range = new Range();
+      range.setStart(0);
+      range.setEnd(1);
+      const stateChange = new StateChange();
+      stateChange.setDeselectedList([range]);
+      const changeType = new TreeChangeType();
+      changeType.setRanges(stateChange);
+      const resp = new SubscribeResponse();
+      resp.setChange(changeType);
+      stream.invokeOnData(resp);
+
+      const rows = await pendingRows;
+
+      expect(rows.slice(0, 3)).toMatchObject([
+        { ...rows[0], selected: false },
+        { ...rows[1], selected: false },
+        { ...rows[2], selected: true },
       ]);
     });
   });

--- a/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
+++ b/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
@@ -67,12 +67,7 @@ describe(SceneTreeController, () => {
       const controller = new SceneTreeController(client, 10, () => jwt);
       controller.subscribe();
 
-      const viewId = new Uuid();
-      viewId.setHex(sceneViewId);
-
       const req = new SubscribeRequest();
-      req.setViewId(viewId);
-
       expect(client.subscribe).toHaveBeenCalledWith(req, metadata);
     });
 
@@ -320,14 +315,10 @@ describe(SceneTreeController, () => {
     const controller = new SceneTreeController(client, 100, () => jwt);
 
     it('makes call to collapse node', () => {
-      const viewId = new Uuid();
-      viewId.setHex(sceneViewId);
-
       const nodeId = new Uuid();
       nodeId.setHex(random.guid());
 
       const req = new CollapseNodeRequest();
-      req.setViewId(viewId);
       req.setNodeId(nodeId);
 
       controller.collapseNode(nodeId.getHex());
@@ -363,14 +354,10 @@ describe(SceneTreeController, () => {
     const controller = new SceneTreeController(client, 100, () => jwt);
 
     it('makes call to expand node', () => {
-      const viewId = new Uuid();
-      viewId.setHex(sceneViewId);
-
       const nodeId = new Uuid();
       nodeId.setHex(random.guid());
 
       const req = new ExpandNodeRequest();
-      req.setViewId(viewId);
       req.setNodeId(nodeId);
 
       controller.expandNode(nodeId.getHex());
@@ -438,14 +425,11 @@ describe(SceneTreeController, () => {
       const controller = new SceneTreeController(client, 100, () => jwt);
       await controller.fetchPage(0);
 
-      const viewId = new Uuid();
-      viewId.setHex(sceneViewId);
       const pager = new OffsetPager();
       pager.setOffset(0);
       pager.setLimit(100);
 
       const req = new GetTreeRequest();
-      req.setViewId(viewId);
       req.setPager(pager);
 
       expect(client.getTree).toHaveBeenCalledWith(
@@ -518,14 +502,11 @@ describe(SceneTreeController, () => {
 
       await controller.fetchPageAtOffset(10);
 
-      const viewId = new Uuid();
-      viewId.setHex(sceneViewId);
       const pager = new OffsetPager();
       pager.setOffset(10);
       pager.setLimit(10);
 
       const req = new GetTreeRequest();
-      req.setViewId(viewId);
       req.setPager(pager);
 
       expect(client.getTree).toHaveBeenCalledWith(
@@ -547,9 +528,6 @@ describe(SceneTreeController, () => {
 
       await controller.fetchRange(-1, 101);
 
-      const viewId = new Uuid();
-      viewId.setHex(sceneViewId);
-
       const pager1 = new OffsetPager();
       pager1.setOffset(0);
       pager1.setLimit(10);
@@ -559,12 +537,10 @@ describe(SceneTreeController, () => {
       pager2.setLimit(10);
 
       const req1 = new GetTreeRequest();
-      req1.setViewId(viewId);
       req1.setPager(pager1);
 
       const req2 = new GetTreeRequest();
-      req2.setViewId(viewId);
-      req2.setPager(pager1);
+      req2.setPager(pager2);
 
       expect(client.getTree).toHaveBeenCalledWith(
         req1,

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -103,22 +103,42 @@ export class SceneTreeController {
           this.fetchUnloadedPagesInActiveRows();
         }
 
-        if (change?.ranges?.hiddenList != null) {
-          console.debug(
-            'Received hidden list change',
-            change.ranges.hiddenList
-          );
+        const {
+          hiddenList = [],
+          shownList = [],
+          deselectedList = [],
+          selectedList = [],
+        } = change?.ranges || {};
 
-          change.ranges.hiddenList.forEach(({ start, end }) =>
+        if (hiddenList != null && hiddenList.length > 0) {
+          console.debug('Received hidden list change', hiddenList);
+
+          hiddenList.forEach(({ start, end }) =>
             this.patchRowsInRange(start, end, () => ({ visible: false }))
           );
         }
 
-        if (change?.ranges?.shownList != null) {
-          console.debug('Received shown list change', change.ranges.shownList);
+        if (shownList != null && shownList.length > 0) {
+          console.debug('Received shown list change', shownList);
 
-          change.ranges.shownList.forEach(({ start, end }) =>
+          shownList.forEach(({ start, end }) =>
             this.patchRowsInRange(start, end, () => ({ visible: true }))
+          );
+        }
+
+        if (deselectedList != null && deselectedList.length > 0) {
+          console.debug('Received deselected list change', deselectedList);
+
+          deselectedList.forEach(({ start, end }) =>
+            this.patchRowsInRange(start, end, () => ({ selected: false }))
+          );
+        }
+
+        if (selectedList != null && selectedList.length > 0) {
+          console.debug('Received selected list change', selectedList);
+
+          selectedList.forEach(({ start, end }) =>
+            this.patchRowsInRange(start, end, () => ({ selected: true }))
           );
         }
       });
@@ -348,9 +368,9 @@ export class SceneTreeController {
       this.activeRowRange[1]
     );
 
-    this.getNonLoadedPageIndexes(startPage - 1, endPage + 1).forEach((page) =>
-      this.fetchPage(page)
-    );
+    this.getNonLoadedPageIndexes(startPage - 1, endPage + 1).forEach((page) => {
+      this.fetchPage(page);
+    });
   }
 
   private patchRowsInRange(
@@ -405,19 +425,12 @@ export class SceneTreeController {
 
   private invalidateAfterOffset(offset: number): void {
     const pageIndex = Math.floor(offset / this.rowLimit);
-    const nextPageIndex = pageIndex + 1;
-    const nextPageOffset = nextPageIndex * this.rowLimit;
-
-    const start = this.state.rows.slice(0, nextPageOffset);
-    const end = new Array(this.state.totalRows - start.length);
-    const rows = [...start, ...end];
 
     for (const index of this.pages.keys()) {
       if (index >= pageIndex) {
         this.invalidatePage(index);
       }
     }
-    this.updateState({ ...this.state, rows });
   }
 
   private updateState(newState: SceneTreeState): void {

--- a/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
+++ b/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
@@ -28,8 +28,7 @@ export async function hideItem(
 export async function selectItem(
   viewer: HTMLVertexViewerElement,
   id: string,
-  // TODO(dan): Make color optional.
-  { color = '#FF0000', append = false }: SelectItemOptions
+  { color, append = false }: SelectItemOptions
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene

--- a/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
+++ b/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
@@ -1,7 +1,7 @@
 import { ColorMaterial } from '../../..';
 
 export interface SelectItemOptions {
-  color?: string | ColorMaterial.ColorMaterial;
+  material?: string | ColorMaterial.ColorMaterial;
   append?: boolean;
 }
 
@@ -28,13 +28,13 @@ export async function hideItem(
 export async function selectItem(
   viewer: HTMLVertexViewerElement,
   id: string,
-  { color, append = false }: SelectItemOptions
+  { material, append = false }: SelectItemOptions
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene
     .items((op) => [
       ...(append ? [] : [op.where((q) => q.all()).deselect()]),
-      op.where((q) => q.withItemId(id)).select(color),
+      op.where((q) => q.withItemId(id)).select(material),
     ])
     .execute();
 }

--- a/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
+++ b/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
@@ -1,3 +1,10 @@
+import { ColorMaterial } from '../../..';
+
+export interface SelectItemOptions {
+  color?: string | ColorMaterial.ColorMaterial;
+  append?: boolean;
+}
+
 export async function showItem(
   viewer: HTMLVertexViewerElement,
   id: string
@@ -15,5 +22,30 @@ export async function hideItem(
   const scene = await viewer.scene();
   return scene
     .items((op) => op.where((q) => q.withItemId(id)).hide())
+    .execute();
+}
+
+export async function selectItem(
+  viewer: HTMLVertexViewerElement,
+  id: string,
+  // TODO(dan): Make color optional.
+  { color = '#FF0000', append = false }: SelectItemOptions
+): Promise<void> {
+  const scene = await viewer.scene();
+  return scene
+    .items((op) => [
+      ...(append ? [] : [op.where((q) => q.all()).deselect()]),
+      op.where((q) => q.withItemId(id)).select(color),
+    ])
+    .execute();
+}
+
+export async function deselectItem(
+  viewer: HTMLVertexViewerElement,
+  id: string
+): Promise<void> {
+  const scene = await viewer.scene();
+  return scene
+    .items((op) => op.where((q) => q.withItemId(id)).deselect())
     .execute();
 }

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -42,6 +42,17 @@ Type: `Promise<void>`
 
 
 
+### `deselectItem(rowOrIndex: number | Row) => Promise<void>`
+
+Performs an API call that will deselect the item associated to the given
+row or row index.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `expandAll() => Promise<void>`
 
 Performs an API call to expand all nodes in the tree.
@@ -131,6 +142,17 @@ Type: `Promise<void>`
 
 
 
+### `selectItem(rowOrIndex: number | Row, append?: boolean) => Promise<void>`
+
+Performs an API call that will select the item associated to the given row
+or row index.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `showItem(rowOrIndex: number | Row) => Promise<void>`
 
 Performs an API call that will show the item associated to the given row
@@ -167,10 +189,12 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                       | Description                                |
-| -------------------------- | ------------------------------------------ |
-| `--scene-tree-row-height`  | The height of each row in the scene tree.  |
-| `--scene-tree-row-padding` | The padding of each row in the scene tree. |
+| Name                          | Description                                  |
+| ----------------------------- | -------------------------------------------- |
+| `--scene-tree-hover-color`    | The background color of a row when hovered.  |
+| `--scene-tree-row-height`     | The height of each row in the scene tree.    |
+| `--scene-tree-row-padding`    | The padding of each row in the scene tree.   |
+| `--scene-tree-selected-color` | The background color of a row when selected. |
 
 
 ## Dependencies

--- a/packages/viewer/src/components/scene-tree/scene-tree.css
+++ b/packages/viewer/src/components/scene-tree/scene-tree.css
@@ -11,9 +11,21 @@
    */
   --scene-tree-row-padding: 0 8px;
 
+  /**
+   * @prop --scene-tree-hover-color: The background color of a row when hovered.
+   */
+  --scene-tree-row-hover-color: var(--blue-200);
+
+  /**
+   * @prop --scene-tree-selected-color: The background color of a row when
+   * selected.
+   */
+  --scene-tree-row-selected-color: var(--blue-300);
+
   width: 300px;
   height: 100%;
   overflow-y: auto;
+  user-select: none;
 }
 
 .rows {
@@ -28,6 +40,14 @@
   height: var(--scene-tree-row-height);
   padding: var(--scene-tree-row-padding);
   box-sizing: border-box;
+}
+
+.row:hover {
+  background-color: var(--scene-tree-row-hover-color);
+}
+
+.row.is-selected {
+  background-color: var(--scene-tree-row-selected-color);
 }
 
 .expand-toggle {

--- a/packages/viewer/src/components/scene-tree/scene-tree.spec.ts
+++ b/packages/viewer/src/components/scene-tree/scene-tree.spec.ts
@@ -206,7 +206,7 @@ describe('<vertex-scene-tree />', () => {
     });
   });
 
-  describe(SceneTree.prototype.getRowFromEvent, () => {
+  describe(SceneTree.prototype.getRowForEvent, () => {
     it('returns row for event', async () => {
       const res = mockGetTree({ client });
 
@@ -228,7 +228,7 @@ describe('<vertex-scene-tree />', () => {
       page.root?.dispatchEvent(new MouseEvent('click', { clientY: 30 }));
 
       const event = await pendingEvent;
-      const row = await sceneTree.getRowFromEvent(event);
+      const row = await sceneTree.getRowForEvent(event);
       expect(row?.name).toBe(res.toObject().itemsList[1].name);
     });
 
@@ -246,7 +246,7 @@ describe('<vertex-scene-tree />', () => {
 
       (getSceneTreeContainsElement as jest.Mock).mockReturnValue(true);
 
-      const row = await sceneTree.getRowFromEvent(
+      const row = await sceneTree.getRowForEvent(
         new MouseEvent('click', { clientY: 30 })
       );
       expect(row).not.toBeDefined();
@@ -598,7 +598,7 @@ describe('<vertex-scene-tree />', () => {
       });
 
       const row = await sceneTree.getRowAtIndex(0);
-      await sceneTree.selectItem(0, true);
+      await sceneTree.selectItem(0, { append: true });
       expect(selectItem).toHaveBeenCalledWith(
         expect.anything(),
         row?.id,

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -25,7 +25,7 @@ import {
   getSceneTreeOffsetTop,
   getSceneTreeViewportHeight,
 } from './lib/dom';
-import { hideItem, showItem } from './lib/viewer-ops';
+import { deselectItem, hideItem, selectItem, showItem } from './lib/viewer-ops';
 
 export type RowDataProvider = (row: Row) => Record<string, unknown>;
 
@@ -118,7 +118,8 @@ export class SceneTree {
    *
    * Use the `config` property for manually setting hosts.
    */
-  @Prop() public configEnv: Environment = 'platprod';
+  @Prop()
+  public configEnv: Environment = 'platprod';
 
   /**
    * A JWT token to make authenticated API calls. This is normally automatically
@@ -126,6 +127,16 @@ export class SceneTree {
    */
   @Prop({ reflect: true, mutable: true })
   public jwt: string | undefined;
+
+  /**
+   * Disables the default selection behavior of the tree. Can be used to
+   * implement custom selection behavior via the trees selection methods.
+   *
+   * @see SceneTree.selectItem
+   * @see SceneTree.deselectItem
+   */
+  @Prop()
+  public selectionDisabled = false;
 
   @Element()
   private el!: HTMLElement;
@@ -343,6 +354,40 @@ export class SceneTree {
   }
 
   /**
+   * Performs an API call that will select the item associated to the given row
+   * or row index.
+   *
+   * @param rowOrIndex The row or row index to select.
+   * @param append `true` if the selection should append to the current
+   *  selection, or `false` if this should replace the current selection.
+   *  Defaults to replace.
+   */
+  @Method()
+  public async selectItem(
+    rowOrIndex: number | Row,
+    append = false
+  ): Promise<void> {
+    await this.performRowOperation(rowOrIndex, async ({ viewer, row }) => {
+      await selectItem(viewer, row.id, { append });
+    });
+  }
+
+  /**
+   * Performs an API call that will deselect the item associated to the given
+   * row or row index.
+   *
+   * @param rowOrIndex The row or row index to deselect.
+   */
+  @Method()
+  public async deselectItem(rowOrIndex: number | Row): Promise<void> {
+    await this.performRowOperation(rowOrIndex, async ({ viewer, row }) => {
+      if (row.selected) {
+        await deselectItem(viewer, row.id);
+      }
+    });
+  }
+
+  /**
    * Returns a row at the given index. If the row data has not been loaded,
    * returns `undefined`.
    *
@@ -444,8 +489,9 @@ export class SceneTree {
               } else {
                 return (
                   <div
-                    class="row"
+                    class={classnames('row', { 'is-selected': row.selected })}
                     style={{ top: `${startY + rowHeight * i}px` }}
+                    onMouseDown={(event) => this.handleRowMouseDown(event, row)}
                   >
                     <span
                       ref={(el) => {
@@ -465,7 +511,10 @@ export class SceneTree {
                     />
                     <span
                       class="expand-toggle"
-                      onClick={() => this.toggleExpandItem(row)}
+                      onMouseDown={(event) => {
+                        event.stopPropagation();
+                        this.toggleExpandItem(row);
+                      }}
                     >
                       {!row.isLeaf && row.expanded && '▾'}
                       {!row.isLeaf && !row.expanded && '▸'}
@@ -494,7 +543,8 @@ export class SceneTree {
                         class={classnames('visibility-btn', {
                           'is-hidden': !row.visible,
                         })}
-                        onClick={() => {
+                        onMouseDown={(event) => {
+                          event.stopPropagation();
                           this.toggleItemVisibility(this.startIndex + i);
                         }}
                       >
@@ -549,6 +599,17 @@ export class SceneTree {
   protected handleJwtChanged(): void {
     if (this.controller != null) {
       this.connectController(this.controller);
+    }
+  }
+
+  private handleRowMouseDown(event: MouseEvent, row: LoadedRow): void {
+    if (!this.selectionDisabled && event.button === 0) {
+      // TODO(dan): Check what append selection is on Windows.
+      if (event.metaKey && row.selected) {
+        this.deselectItem(row);
+      } else {
+        this.selectItem(row, event.ctrlKey || event.metaKey);
+      }
     }
   }
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -70,6 +70,11 @@ import { upsertStorageEntry, getStorageEntry } from '../../sessions/storage';
 import { CustomError } from '../../errors/customError';
 import { KeyInteraction } from '../../interactions/keyInteraction';
 import { BaseInteractionHandler } from '../../interactions/baseInteractionHandler';
+import {
+  ColorMaterial,
+  defaultSelectionMaterial,
+  fromHex,
+} from '../../scenes/colorMaterial';
 
 const WS_RECONNECT_DELAYS = [0, 1000, 1000, 5000];
 
@@ -152,6 +157,13 @@ export class Viewer {
    * the viewer.
    */
   @Prop() public streamAttributes?: StreamAttributes | string;
+
+  /**
+   * The default hex color or material to use when selecting items.
+   */
+  @Prop() public selectionMaterial:
+    | string
+    | ColorMaterial = defaultSelectionMaterial;
 
   /**
    * Emits an event whenever the user taps or clicks a location in the viewer.
@@ -999,11 +1011,16 @@ export class Viewer {
         'Cannot create scene. Frame has not been rendered or stream not initialized.'
       );
     } else {
+      const selectionMaterial =
+        typeof this.selectionMaterial === 'string'
+          ? fromHex(this.selectionMaterial)
+          : this.selectionMaterial;
       return new Scene(
         this.stream,
         this.lastFrame,
         () => this.getImageScale(),
-        this.sceneViewId
+        this.sceneViewId,
+        selectionMaterial
       );
     }
   }

--- a/packages/viewer/src/scenes/__tests__/operations.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/operations.spec.ts
@@ -1,10 +1,10 @@
 import { SceneOperationBuilder } from '../operations';
-import { ColorMaterial } from '../colorMaterial';
+import { ColorMaterial, fromHex } from '../colorMaterial';
 import { Color } from '@vertexvis/utils';
 
 describe(SceneOperationBuilder, () => {
   it('creates a hide operation', () => {
-    const builder = new SceneOperationBuilder();
+    const builder = new SceneOperationBuilder([]);
     const definitions = builder.hide().build();
 
     expect(definitions).toEqual([{ type: 'hide' }]);
@@ -39,5 +39,20 @@ describe(SceneOperationBuilder, () => {
     expect(definitions).toEqual([
       { type: 'change-material', color: materialOverride },
     ]);
+  });
+
+  it('create a select operation', () => {
+    const material = fromHex('#ff0000');
+    const builder = new SceneOperationBuilder();
+    const definitions = builder.select(material).build();
+
+    expect(definitions).toEqual([{ type: 'select', color: material }]);
+  });
+
+  it('create a deselect operation', () => {
+    const builder = new SceneOperationBuilder();
+    const definitions = builder.deselect().build();
+
+    expect(definitions).toEqual([{ type: 'deselect' }]);
   });
 });

--- a/packages/viewer/src/scenes/__tests__/operations.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/operations.spec.ts
@@ -37,7 +37,7 @@ describe(SceneOperationBuilder, () => {
     const definitions = builder.materialOverride(materialOverride).build();
 
     expect(definitions).toEqual([
-      { type: 'change-material', color: materialOverride },
+      { type: 'change-material', material: materialOverride },
     ]);
   });
 
@@ -46,7 +46,7 @@ describe(SceneOperationBuilder, () => {
     const builder = new SceneOperationBuilder();
     const definitions = builder.select(material).build();
 
-    expect(definitions).toEqual([{ type: 'select', color: material }]);
+    expect(definitions).toEqual([{ type: 'select', material }]);
   });
 
   it('create a deselect operation', () => {

--- a/packages/viewer/src/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/scenes/__tests__/scene.spec.ts
@@ -6,12 +6,20 @@ import { Dimensions, Point } from '@vertexvis/geometry';
 import { frame } from '../../types/__fixtures__';
 import { UUID } from '@vertexvis/utils';
 import { ColorMaterial } from '../..';
+import { fromHex } from '../colorMaterial';
 
 describe(Scene, () => {
   const sceneViewId: UUID.UUID = UUID.create();
   const streamApi = new StreamApi();
   const imageScaleProvider = (): Point.Point => Point.create(1, 1);
-  const scene = new Scene(streamApi, frame, imageScaleProvider, sceneViewId);
+  const colorMaterial = fromHex('#ff0000');
+  const scene = new Scene(
+    streamApi,
+    frame,
+    imageScaleProvider,
+    sceneViewId,
+    colorMaterial
+  );
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -188,6 +196,101 @@ describe(Scene, () => {
                     },
                     ns: 10,
                   },
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('uses default selection material if color is not specified', () => {
+      const itemId = UUID.create();
+      scene
+        .items((op) => op.where((q) => q.withItemId(itemId)).select())
+        .execute();
+
+      expect(streamApi.createSceneAlteration).toHaveBeenCalledWith({
+        sceneViewId: {
+          hex: sceneViewId,
+        },
+        operations: [
+          {
+            item: {
+              sceneItemQuery: {
+                id: { hex: itemId.toString() },
+              },
+            },
+            operationTypes: [
+              {
+                changeSelection: {
+                  material: expect.objectContaining({
+                    kd: colorMaterial.diffuse,
+                  }),
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('selection uses specified material', () => {
+      const itemId = UUID.create();
+      const material = fromHex('#0000ff');
+      scene
+        .items((op) => op.where((q) => q.withItemId(itemId)).select(material))
+        .execute();
+
+      expect(streamApi.createSceneAlteration).toHaveBeenCalledWith({
+        sceneViewId: {
+          hex: sceneViewId,
+        },
+        operations: [
+          {
+            item: {
+              sceneItemQuery: {
+                id: { hex: itemId.toString() },
+              },
+            },
+            operationTypes: [
+              {
+                changeSelection: {
+                  material: expect.objectContaining({
+                    kd: material.diffuse,
+                  }),
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('selection uses hex color', () => {
+      const itemId = UUID.create();
+      const material = fromHex('#0000ff');
+      scene
+        .items((op) => op.where((q) => q.withItemId(itemId)).select('#0000ff'))
+        .execute();
+
+      expect(streamApi.createSceneAlteration).toHaveBeenCalledWith({
+        sceneViewId: {
+          hex: sceneViewId,
+        },
+        operations: [
+          {
+            item: {
+              sceneItemQuery: {
+                id: { hex: itemId.toString() },
+              },
+            },
+            operationTypes: [
+              {
+                changeSelection: {
+                  material: expect.objectContaining({
+                    kd: material.diffuse,
+                  }),
                 },
               },
             ],

--- a/packages/viewer/src/scenes/colorMaterial.ts
+++ b/packages/viewer/src/scenes/colorMaterial.ts
@@ -81,3 +81,35 @@ export const fromHex = (hex: string, opacity?: number): ColorMaterial => {
     diffuse: color != null ? { ...color } : { ...defaultColor.diffuse },
   };
 };
+
+/**
+ * The default material that is used for selected items.
+ */
+export const defaultSelectionMaterial: ColorMaterial = {
+  opacity: 100,
+  glossiness: 4,
+  diffuse: {
+    r: 255,
+    g: 255,
+    b: 0,
+    a: 0,
+  },
+  ambient: {
+    r: 0,
+    g: 0,
+    b: 0,
+    a: 0,
+  },
+  specular: {
+    r: 255,
+    g: 255,
+    b: 255,
+    a: 0,
+  },
+  emissive: {
+    r: 0,
+    g: 0,
+    b: 0,
+    a: 0,
+  },
+};

--- a/packages/viewer/src/scenes/operations.ts
+++ b/packages/viewer/src/scenes/operations.ts
@@ -11,7 +11,7 @@ interface HideItemOperation {
 
 interface SelectItemOperation {
   type: 'select';
-  color: ColorMaterial;
+  material: ColorMaterial;
 }
 
 interface DeselectItemOperation {
@@ -24,7 +24,7 @@ interface ClearItemOperation {
 
 export interface ChangeMaterialOperation {
   type: 'change-material';
-  color: ColorMaterial;
+  material: ColorMaterial;
 }
 
 export interface TransformOperation {
@@ -65,9 +65,9 @@ export class SceneOperationBuilder
     return this.operations.concat();
   }
 
-  public materialOverride(color: ColorMaterial): SceneOperationBuilder {
+  public materialOverride(material: ColorMaterial): SceneOperationBuilder {
     return new SceneOperationBuilder(
-      this.operations.concat([{ type: 'change-material', color }])
+      this.operations.concat([{ type: 'change-material', material }])
     );
   }
 
@@ -83,9 +83,9 @@ export class SceneOperationBuilder
     );
   }
 
-  public select(color: ColorMaterial): SceneOperationBuilder {
+  public select(material: ColorMaterial): SceneOperationBuilder {
     return new SceneOperationBuilder(
-      this.operations.concat([{ type: 'select', color }])
+      this.operations.concat([{ type: 'select', material }])
     );
   }
 

--- a/packages/viewer/src/scenes/operations.ts
+++ b/packages/viewer/src/scenes/operations.ts
@@ -55,11 +55,7 @@ export interface SceneItemOperations<T> {
  */
 export class SceneOperationBuilder
   implements SceneItemOperations<SceneOperationBuilder> {
-  private operations: ItemOperation[] = [];
-
-  public constructor(operations: ItemOperation[] = []) {
-    this.operations = operations;
-  }
+  public constructor(private operations: ItemOperation[] = []) {}
 
   /**
    * Constructs the scene operations and returns a definition describing each

--- a/packages/viewer/src/scenes/queries.ts
+++ b/packages/viewer/src/scenes/queries.ts
@@ -1,3 +1,4 @@
+import { ColorMaterial } from './colorMaterial';
 import { SceneItemOperationsBuilder } from './scene';
 
 interface AllQueryExpression {
@@ -157,11 +158,16 @@ export class AndQuery implements TerminalQuery, ItemQuery<AndQuery> {
 }
 
 export class SceneItemQueryExecutor {
+  public constructor(private defaultSelectionMaterial: ColorMaterial) {}
+
   public where(
     query: (q: RootQuery) => TerminalQuery
   ): SceneItemOperationsBuilder {
     const expression: QueryExpression = query(new RootQuery()).build();
 
-    return new SceneItemOperationsBuilder(expression);
+    return new SceneItemOperationsBuilder(
+      expression,
+      this.defaultSelectionMaterial
+    );
   }
 }

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -31,6 +31,7 @@ export class SceneItemOperationsBuilder
 
   public constructor(
     private query: QueryExpression,
+    private defaultSelectionMaterial: ColorMaterial,
     givenBuilder?: SceneOperationBuilder
   ) {
     this.builder =
@@ -43,45 +44,62 @@ export class SceneItemOperationsBuilder
     if (typeof color === 'string') {
       return new SceneItemOperationsBuilder(
         this.query,
+        this.defaultSelectionMaterial,
         this.builder.materialOverride(fromHex(color))
       );
     } else {
       return new SceneItemOperationsBuilder(
         this.query,
+        this.defaultSelectionMaterial,
         this.builder.materialOverride(color)
       );
     }
   }
 
   public hide(): SceneItemOperationsBuilder {
-    return new SceneItemOperationsBuilder(this.query, this.builder.hide());
+    return new SceneItemOperationsBuilder(
+      this.query,
+      this.defaultSelectionMaterial,
+      this.builder.hide()
+    );
   }
 
   public show(): SceneItemOperationsBuilder {
-    return new SceneItemOperationsBuilder(this.query, this.builder.show());
+    return new SceneItemOperationsBuilder(
+      this.query,
+      this.defaultSelectionMaterial,
+      this.builder.show()
+    );
   }
 
-  public select(color: ColorMaterial | string): SceneItemOperationsBuilder {
+  public select(color?: ColorMaterial | string): SceneItemOperationsBuilder {
     if (typeof color === 'string') {
       return new SceneItemOperationsBuilder(
         this.query,
+        this.defaultSelectionMaterial,
         this.builder.select(fromHex(color))
       );
     } else {
       return new SceneItemOperationsBuilder(
         this.query,
-        this.builder.select(color)
+        this.defaultSelectionMaterial,
+        this.builder.select(color || this.defaultSelectionMaterial)
       );
     }
   }
 
   public deselect(): SceneItemOperationsBuilder {
-    return new SceneItemOperationsBuilder(this.query, this.builder.deselect());
+    return new SceneItemOperationsBuilder(
+      this.query,
+      this.defaultSelectionMaterial,
+      this.builder.deselect()
+    );
   }
 
   public clearMaterialOverrides(): SceneItemOperationsBuilder {
     return new SceneItemOperationsBuilder(
       this.query,
+      this.defaultSelectionMaterial,
       this.builder.clearMaterialOverrides()
     );
   }
@@ -98,6 +116,7 @@ export class SceneItemOperationsBuilder
 
       return new SceneItemOperationsBuilder(
         this.query,
+        this.defaultSelectionMaterial,
         this.builder.transform({
           r0: {
             x: matrix[0],
@@ -128,6 +147,7 @@ export class SceneItemOperationsBuilder
     } else {
       return new SceneItemOperationsBuilder(
         this.query,
+        this.defaultSelectionMaterial,
         this.builder.transform(matrix)
       );
     }
@@ -193,7 +213,8 @@ export class Scene {
     private stream: StreamApi,
     private frame: Frame.Frame,
     private imageScaleProvider: ImageScaleProvider,
-    public readonly sceneViewId: UUID.UUID
+    public readonly sceneViewId: UUID.UUID,
+    private defaultSelectionMaterial: ColorMaterial
   ) {}
 
   /**
@@ -204,7 +225,9 @@ export class Scene {
   public items(
     operations: (q: SceneItemQueryExecutor) => TerminalItemOperationBuilder
   ): ItemsOperationExecutor {
-    const sceneOperations = operations(new SceneItemQueryExecutor());
+    const sceneOperations = operations(
+      new SceneItemQueryExecutor(this.defaultSelectionMaterial)
+    );
 
     const ops = Array.isArray(sceneOperations)
       ? sceneOperations

--- a/packages/viewer/src/scenes/scene.ts
+++ b/packages/viewer/src/scenes/scene.ts
@@ -72,18 +72,20 @@ export class SceneItemOperationsBuilder
     );
   }
 
-  public select(color?: ColorMaterial | string): SceneItemOperationsBuilder {
-    if (typeof color === 'string') {
+  public select(
+    colorOrMaterial?: ColorMaterial | string
+  ): SceneItemOperationsBuilder {
+    if (typeof colorOrMaterial === 'string') {
       return new SceneItemOperationsBuilder(
         this.query,
         this.defaultSelectionMaterial,
-        this.builder.select(fromHex(color))
+        this.builder.select(fromHex(colorOrMaterial))
       );
     } else {
       return new SceneItemOperationsBuilder(
         this.query,
         this.defaultSelectionMaterial,
-        this.builder.select(color || this.defaultSelectionMaterial)
+        this.builder.select(colorOrMaterial || this.defaultSelectionMaterial)
       );
     }
   }

--- a/packages/viewer/stencil.config.ts
+++ b/packages/viewer/stencil.config.ts
@@ -27,10 +27,10 @@ export const config: Config = {
     coveragePathIgnorePatterns: ['src/testing'],
     coverageThreshold: {
       global: {
-        branches: 60,
-        functions: 70,
-        lines: 80,
-        statements: 78,
+        branches: 65,
+        functions: 77,
+        lines: 83,
+        statements: 83,
       },
     },
     roots: ['<rootDir>/src/'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5009,11 +5009,6 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-jwt-decode@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
-  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
-
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
## What

Adds support for selection in the scene tree. By default, selecting a row in the tree will select the item that it's mapped to. Developers can disable this behavior by doing `<vertex-scene-tree selection-disabled />`. If disabled, you can programmatically perform selection with the following APIs:

* `SceneTree.selectItem(row, { append, color })`
* `SceneTree.deselectItem(row)`

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1574

