### PR TITLE
[API-1771] Display error message if scene tree not enabled

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -11,6 +11,7 @@ import {
 } from './components/scene-tree/scene-tree';
 import { Config } from './config/config';
 import { Environment } from './config/environment';
+import { SceneTreeErrorDetails } from './components/scene-tree/lib/errors';
 import { Row } from './components/scene-tree/lib/row';
 import { SelectItemOptions } from './components/scene-tree/lib/viewer-ops';
 import { StreamAttributes } from '@vertexvis/stream-api';
@@ -414,6 +415,7 @@ declare namespace LocalJSX {
      * A JWT token to make authenticated API calls. This is normally automatically assigned from the viewer, and shouldn't be assigned manually.
      */
     jwt?: string | undefined;
+    onError?: (event: CustomEvent<SceneTreeErrorDetails>) => void;
     /**
      * The number of offscreen rows above and below the viewport to render. Having a higher number reduces the chance of the browser not displaying a row while scrolling.
      */

--- a/packages/viewer/src/components/scene-tree/lib/dom.ts
+++ b/packages/viewer/src/components/scene-tree/lib/dom.ts
@@ -7,8 +7,8 @@ export function getSceneTreeOffsetTop(el: HTMLElement): number {
 }
 
 export function getSceneTreeContainsElement(
-  el: HTMLElement,
-  other: HTMLElement
+  el: Element,
+  other: Element
 ): boolean {
   return el.contains(other);
 }

--- a/packages/viewer/src/components/scene-tree/lib/errors.ts
+++ b/packages/viewer/src/components/scene-tree/lib/errors.ts
@@ -1,0 +1,24 @@
+export enum SceneTreeErrorCode {
+  UNKNOWN = 0,
+  SCENE_TREE_DISABLED = 1,
+}
+
+export class SceneTreeErrorDetails {
+  public readonly message: string;
+
+  public constructor(
+    public readonly code: SceneTreeErrorCode,
+    public readonly link?: string
+  ) {
+    this.message = getSceneTreeErrorMessage(code);
+  }
+}
+
+function getSceneTreeErrorMessage(code: SceneTreeErrorCode): string {
+  switch (code) {
+    case SceneTreeErrorCode.UNKNOWN:
+      return 'An unknown error occurred.';
+    case SceneTreeErrorCode.SCENE_TREE_DISABLED:
+      return 'The tree for this scene cannot be loaded, because this feature is disabled.';
+  }
+}

--- a/packages/viewer/src/components/scene-tree/lib/grpc.ts
+++ b/packages/viewer/src/components/scene-tree/lib/grpc.ts
@@ -1,0 +1,5 @@
+import { ServiceError } from '@vertexvis/scene-tree-protos/scenetree/protos/scene_tree_api_pb_service';
+
+export function isGrpcServiceError(err: any): err is ServiceError {
+  return typeof err.code === 'number' && err.hasOwnProperty('metadata');
+}

--- a/packages/viewer/src/components/scene-tree/lib/testing.ts
+++ b/packages/viewer/src/components/scene-tree/lib/testing.ts
@@ -1,6 +1,7 @@
 import { EventDispatcher } from '@vertexvis/utils';
 import type {
   ResponseStream,
+  ServiceError,
   Status,
 } from '@vertexvis/scene-tree-protos/scenetree/protos/scene_tree_api_pb_service';
 import { GetTreeResponse } from '@vertexvis/scene-tree-protos/scenetree/protos/scene_tree_api_pb';
@@ -56,7 +57,9 @@ export function mockGrpcUnaryResult(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function mockGrpcUnaryError(error: Error): (...args: any[]) => unknown {
+export function mockGrpcUnaryError(
+  error: Error | ServiceError
+): (...args: any[]) => unknown {
   return (_, __, handler) => {
     setTimeout(() => {
       handler(error);

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -19,6 +19,13 @@
 | `viewerSelector`    | `viewer-selector`    | A CSS selector that points to a `<vertex-viewer>` element. Either this property or `viewer` must be set.                                                            | `string \| undefined`                                  | `undefined`  |
 
 
+## Events
+
+| Event   | Description | Type                                 |
+| ------- | ----------- | ------------------------------------ |
+| `error` |             | `CustomEvent<SceneTreeErrorDetails>` |
+
+
 ## Methods
 
 ### `collapseAll() => Promise<void>`

--- a/packages/viewer/src/components/scene-tree/scene-tree.css
+++ b/packages/viewer/src/components/scene-tree/scene-tree.css
@@ -77,3 +77,14 @@
 .row:hover .visibility-btn {
   visibility: visible;
 }
+
+.error {
+  display: flex;
+  align-items: center;
+  font-size: 0.875rem;
+  width: 100%;
+  height: 100%;
+  padding: 0.25rem;
+  box-sizing: border-box;
+  text-align: center;
+}


### PR DESCRIPTION
## What

If the scene tree fails to load, we'll display an error message in the UI. Currently displays a custom message if the the scene tree has not been enabled for a scene. Will also emit on `error` event with details of why the tree did not load.

## Ticket

https://vertexvis.atlassian.net/browse/API-1771
