### PR TITLE
[APP-2368] Adjust spin center whitespace behavior

### DIFF
--- a/packages/viewer/src/interactions/interactionApi.ts
+++ b/packages/viewer/src/interactions/interactionApi.ts
@@ -370,8 +370,7 @@ export class InteractionApi {
       const fitAllCamera = camera.viewAll();
       // In the case that the depth is at the near or far plane, or we
       // don't have depth info, use 0.5 to represent a value in the middle.
-      const adjustedDepth =
-        depth === 0 || depth === 1 || depth === -1 ? 0.5 : depth;
+      const adjustedDepth = depth >= 1 || depth <= 0 ? 0.5 : depth;
 
       return computeWorldPosition(
         inverseProjectionMatrix(


### PR DESCRIPTION
## What

Adjusts spin-center behavior when a mouse down occurs in whitespace.

This changes the previous default of rotating about the lookAt, which could be in an unexpected location after performing a number of spin-center rotations, to rotate about a point halfway between the near/far plane.

## Ticket

https://vertexvis.atlassian.net/browse/APP-2368

## Test Plan

- Test spin-center when mouse down occurs in whitespace
- Test spin-center when mouse down occurs on the model

## Areas of Possible Regression

Spin center when mouse down occurs on the model

## Out of scope changes made in PR

N/A

## Dependencies

N/A
