### PR TITLE
[API-1851] Use attributes instead of selectors for row state

### DIFF
--- a/packages/viewer/src/components/scene-tree-row/readme.md
+++ b/packages/viewer/src/components/scene-tree-row/readme.md
@@ -62,15 +62,16 @@ about how data binding.
 </html>
 ```
 
-## CSS Selectors
+## State Attributes
 
-The row will set certain CSS selectors depending on the state of the node. These
-selectors are used to customize the styling of your slots depending on which
-selectors are set. The following is a list of selectors that will be set:
+The row will set certain HTML attributes depending on the state of the node.
+These attributes can be used by CSS selectors to customize the styling of your
+slots. The following is a list of attributes that are set:
 
-* `selected`: Specifies that the row's node has been selected.
-* `expanded`: Specifies that the row's node has been expanded.
-* `hidden`: Specifies that the row's node has been hidden.
+* `is-selected`: Specifies that the row's node has been selected.
+* `is-expanded`: Specifies that the row's node has been expanded.
+* `is-hidden`: Specifies that the row's node has been hidden.
+* `is-leaf`: Specifies if the row is a leaf node or not.
 
 **Example:** Using selectors to customize appearance.
 
@@ -78,7 +79,7 @@ selectors are set. The following is a list of selectors that will be set:
 <html>
   <head>
     <style>
-      .row.selected .label {
+      .row[is-selected] .label {
         text-decoration: underline;
       }
     </style>
@@ -86,7 +87,7 @@ selectors are set. The following is a list of selectors that will be set:
   <body>
     <vertex-scene-tree>
       <template>
-        <vertex-scene-tree-row class="row" prop:node={{row.node}}>
+        <vertex-scene-tree-row class="row" prop:node="{{row.node}}">
           <div slot="label" class="label">{{row.node.name}}</div>
         </vertex-scene-tree-row>
       </template>
@@ -118,8 +119,7 @@ custom behavior through bindings and the `rowData` callback.
   <body>
     <vertex-scene-tree>
       <template>
-        <vertex-scene-tree-row class="row" event:expandToggled={{row.data.handleExpand}}>
-        </vertex-scene-tree-row>
+        <vertex-scene-tree-row class="row" event:expandToggled="{{row.data.handleExpand}}"></vertex-scene-tree-row>
       </template>
     </vertex-scene-tree>
 
@@ -145,7 +145,7 @@ You can also bind events from your template to callbacks that are returned by
   <body>
     <vertex-scene-tree class="tree">
       <template>
-        <vertex-scene-tree-row prop:node={{row.node}}>
+        <vertex-scene-tree-row prop:node="{{row.node}}">
           <button slot="right-gutter" event:mousedown="{{row.data.handler}}">
             Hi
           </button>

--- a/packages/viewer/src/components/scene-tree-row/scene-tree-row.css
+++ b/packages/viewer/src/components/scene-tree-row/scene-tree-row.css
@@ -49,7 +49,7 @@
   background: var(--scene-tree-row-background-hover);
 }
 
-:host(.selected) .root {
+:host([is-selected]) .root {
   background: var(--scene-tree-row-background-selected);
 }
 
@@ -73,7 +73,7 @@
   min-height: 24px;
 }
 
-.root.leaf .expand-btn {
+:host([is-leaf]) .expand-btn {
   visibility: hidden;
 }
 
@@ -91,7 +91,7 @@
   visibility: inherit;
 }
 
-:host(.hidden) .visibility-btn {
+:host([is-hidden]) .visibility-btn {
   visibility: inherit;
 }
 

--- a/packages/viewer/src/components/scene-tree-row/scene-tree-row.tsx
+++ b/packages/viewer/src/components/scene-tree-row/scene-tree-row.tsx
@@ -83,13 +83,7 @@ export class SceneTreeRow {
       return <div />;
     } else {
       return (
-        <Host
-          class={classnames({
-            hidden: !this.node.visible,
-            selected: this.node.selected,
-            leaf: this.node.isLeaf,
-          })}
-        >
+        <Host>
           <div class="root" ref={(ref) => (this.rootEl = ref)}>
             <div class="no-shrink">
               <slot name="left-gutter" />
@@ -146,6 +140,15 @@ export class SceneTreeRow {
     );
   }
 
+  protected componentWillRender(): void {
+    this.ifNodeDefined(({ visible, selected, expanded, isLeaf }) => {
+      this.toggleAttribute('is-hidden', !visible);
+      this.toggleAttribute('is-selected', selected);
+      this.toggleAttribute('is-expanded', expanded);
+      this.toggleAttribute('is-leaf', isLeaf);
+    });
+  }
+
   /**
    * @internal
    */
@@ -192,6 +195,14 @@ export class SceneTreeRow {
   private ifNodeDefined(f: (row: Node.AsObject) => void): void {
     if (this.node != null) {
       f(this.node);
+    }
+  }
+
+  private toggleAttribute(attr: string, value: boolean): void {
+    if (value) {
+      this.hostEl.setAttribute(attr, '');
+    } else {
+      this.hostEl.removeAttribute(attr);
     }
   }
 }


### PR DESCRIPTION
## What

Fixes an issue where rows are being hidden if a node is marked is hidden in the scene tree and the application is using Tailwind. This happens because the row was setting a `hidden` css selector which is used in Tailwind. I've updated the implementation to use DOM attributes which can still be used to customize row styling using CSS attribute selectors.

## Ticket

https://vertexvis.atlassian.net/browse/API-1851