### PR TITLE
[API-1853] Omit React bindings for vertex-scene-tree-row

### DIFF
--- a/packages/viewer/stencil.config.ts
+++ b/packages/viewer/stencil.config.ts
@@ -13,6 +13,11 @@ export const config: Config = {
     reactOutputTarget({
       componentCorePackage: '@vertexvis/viewer',
       proxiesFile: '../viewer-react/src/generated/components.ts',
+      excludeComponents: [
+        // Omitted because the React scene tree component doesn't support
+        // rendering a row as a React element.
+        'vertex-scene-tree-row',
+      ],
     }),
     {
       type: 'dist',


### PR DESCRIPTION
## What

Removes the React bindings for `vertex-scene-tree-row`. This component doesn't work as a React element when passed as a child to the scene tree, and is causing some confusion.

## Ticket

https://vertexvis.atlassian.net/browse/API-1853