### PR TITLE
[APP-2376] Spin-center math adjustment

### DIFF
--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -30,6 +30,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   protected interactionApi?: InteractionApi;
   protected element?: HTMLElement;
   protected downPosition?: Point.Point;
+  private downPositionCanvas?: Point.Point;
   private primaryInteraction: MouseInteraction = this.rotateInteraction;
   private currentInteraction?: MouseInteraction;
   private draggingInteraction: MouseInteraction | undefined;
@@ -143,6 +144,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
 
     this.interactionTimer = window.setTimeout(() => {
       this.downPosition = Point.create(event.screenX, event.screenY);
+      this.downPositionCanvas = this.getCanvasPosition(event);
       this.interactionTimer = undefined;
 
       // Perform the current movement in the case that the interaction timer elapses
@@ -212,10 +214,11 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     }
 
     if (this.draggingInteraction != null && this.interactionApi != null) {
+      console.log(this.downPositionCanvas, this.getCanvasPosition(event));
+
       this.draggingInteraction.beginDrag(
         event,
-        this.getCanvasPosition(event) ||
-          Point.create(event.clientX, event.clientY),
+        this.downPositionCanvas || Point.create(event.clientX, event.clientY),
         this.interactionApi
       );
     }
@@ -290,6 +293,10 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   }
 
   protected getCanvasPosition(event: BaseEvent): Point.Point | undefined {
+    return this.getCanvasPoint(Point.create(event.clientX, event.clientY));
+  }
+
+  protected getCanvasPoint(point: Point.Point): Point.Point | undefined {
     const canvasBounds = this.element?.getBoundingClientRect();
     const canvasOffset =
       canvasBounds != null
@@ -297,7 +304,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
         : undefined;
 
     return canvasOffset != null
-      ? Point.subtract(Point.create(event.clientX, event.clientY), canvasOffset)
+      ? Point.subtract(point, canvasOffset)
       : undefined;
   }
 

--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -214,8 +214,6 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     }
 
     if (this.draggingInteraction != null && this.interactionApi != null) {
-      console.log(this.downPositionCanvas, this.getCanvasPosition(event));
-
       this.draggingInteraction.beginDrag(
         event,
         this.downPositionCanvas || Point.create(event.clientX, event.clientY),

--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -291,10 +291,6 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   }
 
   protected getCanvasPosition(event: BaseEvent): Point.Point | undefined {
-    return this.getCanvasPoint(Point.create(event.clientX, event.clientY));
-  }
-
-  protected getCanvasPoint(point: Point.Point): Point.Point | undefined {
     const canvasBounds = this.element?.getBoundingClientRect();
     const canvasOffset =
       canvasBounds != null
@@ -302,7 +298,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
         : undefined;
 
     return canvasOffset != null
-      ? Point.subtract(point, canvasOffset)
+      ? Point.subtract(Point.create(event.clientX, event.clientY), canvasOffset)
       : undefined;
   }
 

--- a/packages/viewer/src/interactions/interactionApi.ts
+++ b/packages/viewer/src/interactions/interactionApi.ts
@@ -1,10 +1,4 @@
-import {
-  Angle,
-  Dimensions,
-  Matrix4,
-  Point,
-  Vector3,
-} from '@vertexvis/geometry';
+import { Angle, Dimensions, Point, Vector3 } from '@vertexvis/geometry';
 import { EventEmitter } from '@stencil/core';
 import { TapEventDetails, TapEventKeys } from './tapEventDetails';
 import { StreamApi } from '@vertexvis/stream-api';
@@ -12,12 +6,6 @@ import { Scene, Camera } from '../scenes';
 import { Interactions } from '../types';
 import { DepthProvider } from '../rendering/depth';
 import { computeWorldPosition } from '../rendering/coordinates';
-import {
-  inverseProjectionMatrix,
-  inverseViewMatrix,
-  projectionMatrix,
-  viewMatrix,
-} from '../rendering/matrices';
 
 type SceneProvider = () => Scene;
 
@@ -225,44 +213,6 @@ export class InteractionApi {
         depth
       );
 
-      const p1 = Matrix4.multiplyVector3(
-        viewMatrix(camera),
-        this.worldRotationPoint
-      );
-      const p2 = Matrix4.multiplyVector4(
-        projectionMatrix(
-          camera.near,
-          camera.far,
-          camera.fovY,
-          camera.aspectRatio
-        ),
-        p1
-      );
-      const p3 = Vector3.scale(1 / p2.w, p2);
-      const screen = Point.scale(
-        Point.create(
-          ((p3.x + 1) / 2) * viewport.width,
-          ((-p3.y + 1) / 2) * viewport.height
-        ),
-        1 / scale?.x || 1,
-        1 / scale?.y || 1
-      );
-
-      const div =
-        document.querySelector('#dot') || document.createElement('div');
-      div.setAttribute(
-        'style',
-        `width: 5px; height: 5px; background-color: red; position: fixed; top: ${Math.round(
-          screen.y
-        )}px; left: ${Math.round(screen.x)}px; border: 1px solid black`
-      );
-      if (document.querySelector('#dot') == null) {
-        div.id = 'dot';
-        document.body.appendChild(div);
-      }
-
-      // console.log(this.worldRotationPoint);
-
       if (this.worldRotationPoint != null) {
         const upVector = Vector3.normalize(camera.up);
         const lookAt = Vector3.normalize(
@@ -413,83 +363,11 @@ export class InteractionApi {
     if (this.worldRotationPoint != null) {
       return this.worldRotationPoint;
     } else {
-      const fitAllCamera = camera.viewAll();
       // In the case that the depth is at the near or far plane, or we
       // don't have depth info, use 0.5 to represent a value in the middle.
       const adjustedDepth = depth >= 1 || depth <= 0 ? 0.5 : depth;
 
-      console.log(
-        'near/far values',
-        fitAllCamera.far,
-        fitAllCamera.near,
-        camera.far,
-        camera.near
-      );
-
-      // const wp = computeWorldPosition(
-      //   inverseProjectionMatrix(
-      //     fitAllCamera.near,
-      //     fitAllCamera.far,
-      //     // camera.near,
-      //     // camera.far,
-      //     camera.fovY,
-      //     camera.aspectRatio
-      //   ),
-      //   inverseViewMatrix(fitAllCamera),
-      //   viewport,
-      //   scaledPoint,
-      //   adjustedDepth,
-      //   camera.near,
-      //   camera.far,
-      //   // camera.aspectRatio,
-      //   (camera.distanceToBoundingBoxCenter() /
-      //     fitAllCamera.distanceToBoundingBoxCenter())
-      //   // (fitAllCamera.far) / (camera.far)
-      //   // Vector3.scale(1 / p2.w, p2)
-      //   // Vector3.subtract(camera.position, camera.lookAt)
-      // );
-
-      const upVector = Vector3.normalize(camera.up);
-      const lookAt = Vector3.normalize(
-        Vector3.subtract(camera.lookAt, camera.position)
-      );
-
-      const crossX = Vector3.normalize(Vector3.cross(upVector, lookAt));
-      const crossY = Vector3.normalize(Vector3.cross(lookAt, crossX));
-
-      const wp = computeWorldPosition(
-        inverseProjectionMatrix(
-          fitAllCamera.near,
-          fitAllCamera.far,
-          // camera.near,
-          // camera.far,
-          camera.fovY,
-          camera.aspectRatio
-        ),
-        inverseViewMatrix(fitAllCamera),
-        viewport,
-        scaledPoint,
-        adjustedDepth,
-        camera.near,
-        camera.far,
-        Vector3.subtract(camera.lookAt, camera.position),
-        lookAt,
-        camera.position,
-        crossX,
-        crossY,
-        camera.aspectRatio,
-        camera.fovY
-        // // camera.aspectRatio,
-        // (camera.distanceToBoundingBoxCenter() /
-        //   fitAllCamera.distanceToBoundingBoxCenter())
-        // (fitAllCamera.far) / (camera.far)
-        // Vector3.scale(1 / p2.w, p2)
-        // Vector3.subtract(camera.position, camera.lookAt)
-      );
-
-      console.log(wp);
-
-      return wp;
+      return computeWorldPosition(camera, viewport, scaledPoint, adjustedDepth);
     }
   }
 }

--- a/packages/viewer/src/rendering/__tests__/coordinates.spec.ts
+++ b/packages/viewer/src/rendering/__tests__/coordinates.spec.ts
@@ -22,8 +22,6 @@ describe(computeWorldPosition, () => {
   it('should return correct world position for near-plane depth', () => {
     const depth = 0;
 
-    console.log(camera.near, camera.far);
-
     expect(computeWorldPosition(camera, viewport, point, depth).z).toBe(4);
   });
 

--- a/packages/viewer/src/rendering/__tests__/coordinates.spec.ts
+++ b/packages/viewer/src/rendering/__tests__/coordinates.spec.ts
@@ -1,125 +1,41 @@
-import { Dimensions, Point } from '@vertexvis/geometry';
-import {
-  computeNormalizedDeviceCoordinates,
-  computeWorldPosition,
-} from '../coordinates';
-import {
-  inverseProjectionMatrix,
-  inverseViewMatrix,
-} from '../../rendering/matrices';
+jest.mock('@vertexvis/stream-api');
 
-describe(computeNormalizedDeviceCoordinates, () => {
-  const viewport = Dimensions.create(100, 100);
-  const point1 = Point.create(50, 50);
-  const depth1 = 0;
-  const point2 = Point.create(0, 0);
-  const depth2 = 0.5;
-  const point3 = Point.create(100, 100);
-  const depth3 = 1;
-
-  it('returns correct NDC values', () => {
-    expect(
-      computeNormalizedDeviceCoordinates(viewport, point1, 1, depth1)
-    ).toMatchObject({
-      x: 0,
-      y: 0,
-      z: -1,
-    });
-
-    expect(
-      computeNormalizedDeviceCoordinates(viewport, point2, 1, depth1)
-    ).toMatchObject({
-      x: -1,
-      y: 1,
-      z: -1,
-    });
-
-    expect(
-      computeNormalizedDeviceCoordinates(viewport, point3, 1, depth1)
-    ).toMatchObject({
-      x: 1,
-      y: -1,
-      z: -1,
-    });
-
-    expect(
-      computeNormalizedDeviceCoordinates(viewport, point1, 1, depth2)
-    ).toMatchObject({
-      x: 0,
-      y: 0,
-      z: 0,
-    });
-
-    expect(
-      computeNormalizedDeviceCoordinates(viewport, point1, 1, depth3)
-    ).toMatchObject({
-      x: 0,
-      y: 0,
-      z: 1,
-    });
-  });
-});
+import { BoundingBox, Dimensions, Point, Vector3 } from '@vertexvis/geometry';
+import { computeWorldPosition } from '../coordinates';
+import { Camera } from '../../scenes';
+import { StreamApi } from '@vertexvis/stream-api';
 
 describe(computeWorldPosition, () => {
-  const near = 5;
-  const far = 15;
   const viewport = Dimensions.create(100, 100);
-  const inverseProjection = inverseProjectionMatrix(near, far, 45, 1);
-  const inverseView = inverseViewMatrix({
-    position: { x: 0, y: 0, z: 5 },
-    lookAt: { x: 0, y: 0, z: 0 },
-    up: { x: 0, y: 1, z: 0 },
-  });
+  const camera = new Camera(
+    new StreamApi(),
+    1,
+    {
+      position: { x: 0, y: 0, z: 5 },
+      lookAt: { x: 0, y: 0, z: 0 },
+      up: { x: 0, y: 1, z: 0 },
+    },
+    BoundingBox.create(Vector3.origin(), { x: 0, y: 0, z: 100 })
+  );
   const point = Point.create(50, 50);
 
   it('should return correct world position for near-plane depth', () => {
     const depth = 0;
 
-    expect(
-      computeWorldPosition(
-        inverseProjection,
-        inverseView,
-        viewport,
-        point,
-        depth,
-        near,
-        far,
-        1
-      ).z
-    ).toBe(0);
+    console.log(camera.near, camera.far);
+
+    expect(computeWorldPosition(camera, viewport, point, depth).z).toBe(4);
   });
 
   it('should return correct world position for far-plane depth', () => {
     const depth = 1;
 
-    expect(
-      computeWorldPosition(
-        inverseProjection,
-        inverseView,
-        viewport,
-        point,
-        depth,
-        near,
-        far,
-        1
-      ).z
-    ).toBe(-10);
+    expect(computeWorldPosition(camera, viewport, point, depth).z).toBe(-95);
   });
 
   it('should return correct world position for depths in-between near and far', () => {
     const depth = 0.5;
 
-    expect(
-      computeWorldPosition(
-        inverseProjection,
-        inverseView,
-        viewport,
-        point,
-        depth,
-        near,
-        far,
-        1
-      ).z
-    ).toBe(-5);
+    expect(computeWorldPosition(camera, viewport, point, depth).z).toBe(-45.5);
   });
 });

--- a/packages/viewer/src/rendering/coordinates.ts
+++ b/packages/viewer/src/rendering/coordinates.ts
@@ -1,66 +1,97 @@
-import {
-  Angle,
-  Dimensions,
-  Matrix4,
-  Point,
-  Vector3,
-} from '@vertexvis/geometry';
+import { Angle, Dimensions, Point, Vector3 } from '@vertexvis/geometry';
+import { Camera } from '../scenes';
 
+/**
+ * Computes the world position of a click on screen using
+ * the provided depth. The depth value is expected to be
+ * in the range [0, 1], where 0 represents the near plane
+ * distance, and 1 represents the far plane distance.
+ *
+ * @param camera - The camera of the scene.
+ * @param viewport - The viewport of the scene.
+ * @param point - The screen point.
+ * @param depth - The depth value (between 0 and 1).
+ */
 export function computeWorldPosition(
-  inverseProjection: Matrix4.Matrix4,
-  inverseView: Matrix4.Matrix4,
+  camera: Camera,
   viewport: Dimensions.Dimensions,
   point: Point.Point,
-  depth: number,
-  near: number,
-  far: number,
-  viewVector: Vector3.Vector3,
-  normalizedViewVector: Vector3.Vector3,
-  position: Vector3.Vector3,
-  crossX: Vector3.Vector3,
-  crossY: Vector3.Vector3,
-  aspect: number,
-  fovy: number
+  depth: number
 ): Vector3.Vector3 {
-  const rayDir = Vector3.create(
-    (point.x / viewport.width - 0.5) * aspect,
-    -(point.y / viewport.height) + 0.5,
-    -0.5 / Math.tan(Angle.toRadians(fovy / 2.0))
-  );
+  const viewVector = camera.viewVector();
+  const normalizedRay = normalizedRayFromPoint(camera, viewport, point);
 
-  const normalized = Vector3.normalize(
+  // Computes the world position along the ray at the far plane.
+  // This is used to determine the angle with the view vector.
+  const viewVectorToWorldPosition = Vector3.subtract(
     Vector3.add(
-      Vector3.scale(rayDir.x, Vector3.scale(-1, crossX)),
-      Vector3.scale(rayDir.y, crossY),
-      Vector3.scale(rayDir.z, Vector3.scale(-1, normalizedViewVector))
-    )
-  );
-  const pointAtViewVector = Vector3.subtract(
-    Vector3.add(
-      position,
-      Vector3.scale(linearDepth(depth, near, far), normalized)
+      camera.position,
+      Vector3.scale(linearDepth(1, camera.near, camera.far), normalizedRay)
     ),
-    position
+    camera.position
   );
-
-  const a =
-    Vector3.dot(viewVector, pointAtViewVector) /
-    (Vector3.magnitude(viewVector) * Vector3.magnitude(pointAtViewVector));
 
   const angle =
-    Math.abs((point.x / viewport.width) * fovy - fovy / 2) / aspect +
-    Math.abs((point.y / viewport.height) * fovy - fovy / 2);
-  console.log(a);
-  const relativeDepth = depth / Math.cos(Angle.toRadians(angle));
-  // const relativeDepth = depth / a;
-  console.log(relativeDepth);
-
+    Vector3.dot(viewVector, viewVectorToWorldPosition) /
+    (Vector3.magnitude(viewVector) *
+      Vector3.magnitude(viewVectorToWorldPosition));
   return Vector3.add(
-    position,
-    Vector3.scale(linearDepth(depth, near, far) / a, normalized)
+    camera.position,
+    Vector3.scale(
+      linearDepth(depth, camera.near, camera.far) / angle,
+      normalizedRay
+    )
   );
 }
 
+/**
+ * Creates a normalized ray at the screen point, pointing
+ * away from the camera. This can then be used to find a point
+ * at a specific depth along the ray.
+ *
+ * @param camera - The camera of the scene.
+ * @param viewport - The viewport of the scene.
+ * @param point - The screen point.
+ */
+export function normalizedRayFromPoint(
+  camera: Camera,
+  viewport: Dimensions.Dimensions,
+  point: Point.Point
+): Vector3.Vector3 {
+  const viewVector = camera.viewVector();
+  const normalizedUpVector = Vector3.normalize(camera.up);
+  const normalizedViewVector = Vector3.normalize(viewVector);
+  const crossX = Vector3.normalize(
+    Vector3.cross(normalizedUpVector, normalizedViewVector)
+  );
+  const crossY = Vector3.normalize(Vector3.cross(normalizedViewVector, crossX));
+
+  const direction = Vector3.create(
+    (point.x / viewport.width - 0.5) * camera.aspectRatio,
+    -(point.y / viewport.height) + 0.5,
+    -0.5 / Math.tan(Angle.toRadians(camera.fovY / 2.0))
+  );
+
+  return Vector3.normalize(
+    Vector3.add(
+      Vector3.scale(direction.x, Vector3.scale(-1, crossX)),
+      Vector3.scale(direction.y, crossY),
+      Vector3.scale(
+        direction.z,
+        Vector3.scale(-1, Vector3.normalize(viewVector))
+      )
+    )
+  );
+}
+
+/**
+ * Returns the distance the provided depth represents
+ * between the near and far plane.
+ *
+ * @param depth - The depth value (between 0 and 1).
+ * @param near - The near plane value.
+ * @param far - The far plane value.
+ */
 export function linearDepth(depth: number, near: number, far: number): number {
   return depth * (far - near) + near;
 }


### PR DESCRIPTION
## What

Adjusts the calculation of the world position when using spin-center. This approach uses similar logic to compute a ray to our rendering pipeline, and uses that in combination with the depth buffer value to determine a world position instead of using the camera matrices.

This resolves a couple issues related to camera zoom levels and click position.

## Ticket

https://vertexvis.atlassian.net/browse/APP-2376

## Test Plan

- Test spin-center behavior
  - Test at different zoom levels, and picking parts at the edge/corner of the screen
  - Test when clicking in whitespace

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
