### PR TITLE
[API-1852] Fix bug with binding to camel cased events and props

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -53,6 +53,7 @@
     "@vertexvis/scene-tree-protos": "^0.1.0",
     "@vertexvis/stream-api": "0.9.26",
     "@vertexvis/utils": "0.9.26",
+    "camel-case": "^4.1.2",
     "classnames": "2.2.6",
     "google-protobuf": "^3.15.7",
     "jwt-decode": "^3.1.2",

--- a/packages/viewer/src/components/scene-tree-row/readme.md
+++ b/packages/viewer/src/components/scene-tree-row/readme.md
@@ -119,7 +119,7 @@ custom behavior through bindings and the `rowData` callback.
   <body>
     <vertex-scene-tree>
       <template>
-        <vertex-scene-tree-row class="row" event:expandToggled="{{row.data.handleExpand}}"></vertex-scene-tree-row>
+        <vertex-scene-tree-row class="row" event:expand-toggled="{{row.data.handleExpand}}"></vertex-scene-tree-row>
       </template>
     </vertex-scene-tree>
 
@@ -146,7 +146,7 @@ You can also bind events from your template to callbacks that are returned by
     <vertex-scene-tree class="tree">
       <template>
         <vertex-scene-tree-row prop:node="{{row.node}}">
-          <button slot="right-gutter" event:mousedown="{{row.data.handler}}">
+          <button slot="right-gutter" event:mousedown="{{row.data.mouseDown}}">
             Hi
           </button>
         </vertex-scene-tree-row>

--- a/packages/viewer/src/components/scene-tree/lib/__tests__/binding.spec.ts
+++ b/packages/viewer/src/components/scene-tree/lib/__tests__/binding.spec.ts
@@ -175,14 +175,24 @@ describe(generateBindings, () => {
     parent.appendChild(attr);
 
     const event = document.createElement('div');
-    event.innerHTML = '<div event:click="{{data.event}}"></div>';
+    event.innerHTML = '<div event:click="{{data.click}}"></div>';
     attr.appendChild(event);
+
+    const eventCamelCase = document.createElement('div');
+    eventCamelCase.innerHTML = '<div event:click-me="{{data.clickMe}}"></div>';
+    attr.appendChild(eventCamelCase);
 
     const prop = document.createElement('div');
     prop.innerHTML = '<input prop:value="{{data.value}}"></input>';
     parent.appendChild(prop);
 
-    const input = prop.firstElementChild as HTMLInputElement;
+    const propCamelCase = document.createElement('div');
+    propCamelCase.innerHTML =
+      '<input prop:form-action="{{data.value}}"></input>';
+    parent.appendChild(propCamelCase);
+
+    const input1 = prop.firstElementChild as HTMLInputElement;
+    const input2 = propCamelCase.firstElementChild as HTMLInputElement;
 
     const comment = document.createElement('div');
     comment.innerHTML = `<!-- <div/> -->`;
@@ -191,7 +201,8 @@ describe(generateBindings, () => {
     const data = {
       attr: 'attr',
       text: 'text',
-      event: jest.fn(),
+      click: jest.fn(),
+      clickMe: jest.fn(),
       child: { attr: 'attr-child' },
       value: 'foo',
     };
@@ -200,12 +211,15 @@ describe(generateBindings, () => {
     collection.bind(data);
 
     event.firstElementChild?.dispatchEvent(new MouseEvent('click'));
+    eventCamelCase.firstElementChild?.dispatchEvent(new CustomEvent('clickMe'));
 
-    expect(bindings).toHaveLength(5);
+    expect(bindings).toHaveLength(7);
     expect(parent.getAttribute('title')).toBe('attr');
     expect(text.textContent).toBe('text');
     expect(attr.getAttribute('title')).toBe('attr-child');
-    expect(data.event).toHaveBeenCalled();
-    expect(input.value).toBe('foo');
+    expect(data.click).toHaveBeenCalled();
+    expect(data.clickMe).toHaveBeenCalled();
+    expect(input1.value).toBe('foo');
+    expect(input2.formAction).toBe('foo');
   });
 });

--- a/packages/viewer/src/components/scene-tree/lib/binding.ts
+++ b/packages/viewer/src/components/scene-tree/lib/binding.ts
@@ -1,4 +1,5 @@
 import { Disposable } from '@vertexvis/utils';
+import { camelCase } from 'camel-case';
 
 const bindingRegEx = /{{(.+)}}/;
 
@@ -96,21 +97,15 @@ export function generateBindings(node: Node): Binding[] {
 
     bindableAttributes.forEach((attr) => {
       if (attr.name.startsWith('event:')) {
-        bindings.push(
-          new EventHandlerBinding(
-            el,
-            attr.value,
-            attr.name.replace('event:', '')
-          )
-        );
+        const eventName = camelCase(attr.name.replace('event:', ''));
+        bindings.push(new EventHandlerBinding(el, attr.value, eventName));
       } else if (attr.name.startsWith('attr:')) {
         bindings.push(
           new AttributeBinding(el, attr.value, attr.name.replace('attr:', ''))
         );
       } else if (attr.name.startsWith('prop:')) {
-        bindings.push(
-          new PropertyBinding(el, attr.value, attr.name.replace('prop:', ''))
-        );
+        const propName = camelCase(attr.name.replace('prop:', ''));
+        bindings.push(new PropertyBinding(el, attr.value, propName));
       }
     });
   } else if (

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -140,6 +140,21 @@ because attribute bindings are string values, they can support string
 interpolation. So doing `<div attr:title="Hello {{row.data.name}}"></div>` would
 work for an attribute, but not for a property binding.
 
+### Camel Cased Properties and Events
+
+The DOM lowercases property names and events that you assign in your templates
+HTML. Bind to a camel cased property or event by separating words with a dash.
+The binding syntax will convert dash case to camel case for properties and
+events.
+
+```html
+<!-- Bind to a DOM property -->
+<input prop:my-camel-cased-prop="{{row.data.foo}}"></div>
+
+<!-- Bind to a DOM event -->
+<button event:my-camel-cased-event="{{row.data.handler}}"></button>
+```
+
 <!-- Auto Generated Below -->
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,6 +2340,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camel-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
+  dependencies:
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -5245,6 +5253,13 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -5632,6 +5647,14 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 node-fetch@^2.6.1:
   version "2.6.1"
@@ -6187,6 +6210,14 @@ parse5@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -7777,6 +7808,11 @@ tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tslib@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## What

Fixes a bug where binding to a rows `selectionToggled` event wasn't working. This is because the browser treats HTML as case insensitive and will lowercase any attributes you set. To address this, properties and events can use dash case and it'll automatically be converted to camel case.

```html
<vertex-scene-tree class="tree">
  <template>
    <vertex-scene-tree-row prop:node={{row.node}} event:selection-toggled={{row.data.myHandler}}>
    </vertex-scene-tree-row>
  </template>
</vertex-scene-tree>
```

## Ticket

https://vertexvis.atlassian.net/browse/API-1852

