### PR TITLE
[APP-2388] Provide buttons on tap events

### DIFF
--- a/packages/viewer/src/interactions/__tests__/interactionApi.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/interactionApi.spec.ts
@@ -167,6 +167,7 @@ describe(InteractionApi, () => {
         ctrlKey: false,
         metaKey: false,
         shiftKey: false,
+        buttons: 0,
       });
     });
 
@@ -183,6 +184,24 @@ describe(InteractionApi, () => {
       expect(emitTap).toHaveBeenCalledWith({
         position: point,
         ...details,
+        buttons: 0,
+      });
+    });
+
+    it('emits a tap event with correct button details', async () => {
+      const point = Point.create();
+      const details = {
+        altKey: true,
+        ctrlKey: true,
+        metaKey: true,
+        shiftKey: true,
+      };
+
+      await api.tap(point, details, 2);
+      expect(emitTap).toHaveBeenCalledWith({
+        position: point,
+        ...details,
+        buttons: 2,
       });
     });
   });

--- a/packages/viewer/src/interactions/__tests__/tapInteractionHandler.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/tapInteractionHandler.spec.ts
@@ -88,7 +88,7 @@ describe(TapInteractionHandler, () => {
     await delay(5);
     window.dispatchEvent(mouseUp1);
 
-    expect(api.tap).toHaveBeenCalledWith(Point.create(10, 10), keyDetails);
+    expect(api.tap).toHaveBeenCalledWith(Point.create(10, 10), keyDetails, 0);
   });
 
   it('should invoke the tap method of the interaction api provided on touchend', async () => {
@@ -96,7 +96,7 @@ describe(TapInteractionHandler, () => {
     await delay(5);
     window.dispatchEvent(touchEnd);
 
-    expect(api.tap).toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.tap).toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should not emit a tap if the ending location is more than 1 pixel away from the starting location', async () => {
@@ -104,7 +104,11 @@ describe(TapInteractionHandler, () => {
     await delay(5);
     window.dispatchEvent(mouseUp2);
 
-    expect(api.tap).not.toHaveBeenCalledWith(Point.create(15, 15), keyDetails);
+    expect(api.tap).not.toHaveBeenCalledWith(
+      Point.create(15, 15),
+      keyDetails,
+      0
+    );
   });
 
   it('should emit a double tap if two taps occur within the configured time period of one another', () => {
@@ -113,7 +117,7 @@ describe(TapInteractionHandler, () => {
     div.dispatchEvent(touchStart);
     window.dispatchEvent(touchEnd);
 
-    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should not emit a double tap if the second tap occurs after the time period', async () => {
@@ -123,7 +127,7 @@ describe(TapInteractionHandler, () => {
     div.dispatchEvent(touchStart);
     window.dispatchEvent(touchEnd);
 
-    expect(api.doubleTap).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.doubleTap).not.toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should emit a double tap if two clicks occur within the configured time period of one another', () => {
@@ -134,7 +138,8 @@ describe(TapInteractionHandler, () => {
 
     expect(api.doubleTap).toHaveBeenCalledWith(
       Point.create(10, 10),
-      keyDetails
+      keyDetails,
+      0
     );
   });
 
@@ -147,7 +152,8 @@ describe(TapInteractionHandler, () => {
 
     expect(api.doubleTap).not.toHaveBeenCalledWith(
       Point.create(10, 10),
-      keyDetails
+      keyDetails,
+      0
     );
   });
 
@@ -159,7 +165,7 @@ describe(TapInteractionHandler, () => {
     window.dispatchEvent(touchMove1);
     window.dispatchEvent(touchEnd);
 
-    expect(api.doubleTap).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.doubleTap).not.toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should emit a double tap at the start location if a touch move has occurred >= 2 pixels away from the touch start and the interaction has not begun', async () => {
@@ -169,7 +175,7 @@ describe(TapInteractionHandler, () => {
     window.dispatchEvent(touchMove1);
     window.dispatchEvent(touchEnd);
 
-    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should emit a double tap if a touch move has occurred < 2 pixels away from the touch start', () => {
@@ -179,7 +185,7 @@ describe(TapInteractionHandler, () => {
     window.dispatchEvent(touchMove2);
     window.dispatchEvent(touchEnd);
 
-    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.doubleTap).toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should not emit a double tap if a mouse move has occurred >= 2 pixels away from the mouse down and the interaction has begun', async () => {
@@ -192,7 +198,8 @@ describe(TapInteractionHandler, () => {
 
     expect(api.doubleTap).not.toHaveBeenCalledWith(
       Point.create(10, 10),
-      keyDetails
+      keyDetails,
+      0
     );
   });
 
@@ -205,7 +212,8 @@ describe(TapInteractionHandler, () => {
 
     expect(api.doubleTap).toHaveBeenCalledWith(
       Point.create(10, 10),
-      keyDetails
+      keyDetails,
+      0
     );
   });
 
@@ -214,7 +222,7 @@ describe(TapInteractionHandler, () => {
     await delay(50);
     window.dispatchEvent(touchEnd);
 
-    expect(api.longPress).toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.longPress).toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should not emit a long press if a touch start occurs and a touch end occurs within the configured time threshold', async () => {
@@ -222,7 +230,7 @@ describe(TapInteractionHandler, () => {
     await delay(5);
     window.dispatchEvent(touchEnd);
 
-    expect(api.longPress).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.longPress).not.toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should emit a long press if a mouse down occurs and a mouse up does not occur within the configured time threshold', async () => {
@@ -232,7 +240,8 @@ describe(TapInteractionHandler, () => {
 
     expect(api.longPress).toHaveBeenCalledWith(
       Point.create(10, 10),
-      keyDetails
+      keyDetails,
+      0
     );
   });
 
@@ -243,7 +252,8 @@ describe(TapInteractionHandler, () => {
 
     expect(api.longPress).not.toHaveBeenCalledWith(
       Point.create(10, 10),
-      keyDetails
+      keyDetails,
+      0
     );
   });
 
@@ -254,7 +264,7 @@ describe(TapInteractionHandler, () => {
     await delay(50);
     window.dispatchEvent(touchEnd);
 
-    expect(api.longPress).not.toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.longPress).not.toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should emit a long press if a touch move has occurred < 2 pixels away from the touch start', async () => {
@@ -263,7 +273,7 @@ describe(TapInteractionHandler, () => {
     await delay(50);
     window.dispatchEvent(touchEnd);
 
-    expect(api.longPress).toHaveBeenCalledWith(Point.create(10, 10), {});
+    expect(api.longPress).toHaveBeenCalledWith(Point.create(10, 10), {}, 0);
   });
 
   it('should not emit a long press if a mouse move has occurred >= 2 pixels away from the mouse down', async () => {
@@ -274,7 +284,8 @@ describe(TapInteractionHandler, () => {
 
     expect(api.longPress).not.toHaveBeenCalledWith(
       Point.create(10, 10),
-      keyDetails
+      keyDetails,
+      0
     );
   });
 
@@ -286,7 +297,8 @@ describe(TapInteractionHandler, () => {
 
     expect(api.longPress).toHaveBeenCalledWith(
       Point.create(10, 10),
-      keyDetails
+      keyDetails,
+      0
     );
   });
 

--- a/packages/viewer/src/interactions/interactionApi.ts
+++ b/packages/viewer/src/interactions/interactionApi.ts
@@ -51,23 +51,36 @@ export class InteractionApi {
    */
   public async tap(
     position: Point.Point,
-    keyDetails: Partial<TapEventKeys> = {}
+    keyDetails: Partial<TapEventKeys> = {},
+    buttons = 0
   ): Promise<void> {
-    this.emitTapEvent(this.tapEmitter.emit, position, keyDetails);
+    this.emitTapEvent(this.tapEmitter.emit, position, keyDetails, buttons);
   }
 
   public async doubleTap(
     position: Point.Point,
-    keyDetails: Partial<TapEventKeys> = {}
+    keyDetails: Partial<TapEventKeys> = {},
+    buttons = 0
   ): Promise<void> {
-    this.emitTapEvent(this.doubleTapEmitter.emit, position, keyDetails);
+    this.emitTapEvent(
+      this.doubleTapEmitter.emit,
+      position,
+      keyDetails,
+      buttons
+    );
   }
 
   public async longPress(
     position: Point.Point,
-    keyDetails: Partial<TapEventKeys> = {}
+    keyDetails: Partial<TapEventKeys> = {},
+    buttons = 0
   ): Promise<void> {
-    this.emitTapEvent(this.longPressEmitter.emit, position, keyDetails);
+    this.emitTapEvent(
+      this.longPressEmitter.emit,
+      position,
+      keyDetails,
+      buttons
+    );
   }
 
   /**
@@ -324,7 +337,8 @@ export class InteractionApi {
   private emitTapEvent(
     emit: (details: TapEventDetails) => void,
     position: Point.Point,
-    keyDetails: Partial<TapEventKeys> = {}
+    keyDetails: Partial<TapEventKeys> = {},
+    buttons = 0
   ): void {
     const {
       altKey = false,
@@ -338,6 +352,7 @@ export class InteractionApi {
       ctrlKey,
       metaKey,
       shiftKey,
+      buttons,
     });
   }
 

--- a/packages/viewer/src/interactions/tapEventDetails.ts
+++ b/packages/viewer/src/interactions/tapEventDetails.ts
@@ -6,7 +6,7 @@ export interface TapEventDetails {
   ctrlKey: boolean;
   metaKey: boolean;
   shiftKey: boolean;
-  buttons?: number;
+  buttons: number;
 }
 
 export type TapEventKeys = Pick<

--- a/packages/viewer/src/interactions/tapEventDetails.ts
+++ b/packages/viewer/src/interactions/tapEventDetails.ts
@@ -6,6 +6,7 @@ export interface TapEventDetails {
   ctrlKey: boolean;
   metaKey: boolean;
   shiftKey: boolean;
+  buttons?: number;
 }
 
 export type TapEventKeys = Pick<


### PR DESCRIPTION
## What

Adds a `buttons` property to `tap` events to allow for determining whether a `tap` is associated with a left-click or right-click. 

## Ticket

https://vertexvis.atlassian.net/browse/APP-2388

## Test Plan

- Test that the `buttons` property appears on tap events as `1` for left-clicks and `2` for right-clicks

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A
