### PR TITLE
[API-1847] Fix incorrect conversion of send to receive duration

### DIFF
--- a/packages/stream-api/src/__tests__/time.spec.ts
+++ b/packages/stream-api/src/__tests__/time.spec.ts
@@ -30,6 +30,16 @@ describe(toProtoDuration, () => {
     const duration = toProtoDuration(millis);
     expect(duration).toMatchObject({ seconds: 1, nanos: 0 });
   });
+
+  it('returns correct duration if negative', () => {
+    const duration = toProtoDuration(-1);
+    expect(duration).toMatchObject({ seconds: -0, nanos: -1000000 });
+  });
+
+  it('returns correct duration if negative', () => {
+    const duration = toProtoDuration(-1000);
+    expect(duration).toMatchObject({ seconds: -1, nanos: -0 });
+  });
 });
 
 describe(protoToDate, () => {

--- a/packages/stream-api/src/time.ts
+++ b/packages/stream-api/src/time.ts
@@ -83,7 +83,7 @@ export function protoToDate(
 /* eslint-enable padding-line-between-statements */
 
 function parseEpochMillis(millis: number): DefinedTimestampOrDuration {
-  const seconds = Math.floor(millis / 1000);
+  const seconds = Math.floor(Math.abs(millis) / 1000);
   const nanos = (millis % 1000) * 1000000;
-  return { seconds, nanos };
+  return { seconds: seconds * (millis < 0 ? -1 : 1), nanos };
 }


### PR DESCRIPTION
## What

Should help with reducing the number of logs for `"Possible erroneous send to receive timing"`. We were not adjusting the time offsets with the server. Note, this fix may still produce these logs but should hopefully be reported less.

## Ticket

https://vertexvis.atlassian.net/browse/API-1847
