### PR TITLE
[APP-2183] Fix zoom interaction interrupting following interactions

### DIFF
--- a/packages/viewer/src/interactions/__tests__/mouseInteractionHandler.spec.ts
+++ b/packages/viewer/src/interactions/__tests__/mouseInteractionHandler.spec.ts
@@ -136,6 +136,18 @@ describe(MouseInteractionHandler, () => {
     expect(zoomInteraction.zoom).toHaveBeenCalled();
   });
 
+  it('ends zoom interaction on drag', async () => {
+    div.dispatchEvent(wheelEvent);
+
+    await delay(50);
+
+    expect(zoomInteraction.zoom).toHaveBeenCalled();
+
+    await simulatePrimaryInteractions(50);
+
+    expect(zoomInteraction.endDrag).toHaveBeenCalled();
+  });
+
   describe(MouseInteractionHandler.prototype.dispose, () => {
     it('removes mouse down event listeners', async () => {
       handler.dispose();

--- a/packages/viewer/src/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/interactions/baseInteractionHandler.ts
@@ -214,6 +214,10 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     }
 
     if (this.draggingInteraction != null && this.interactionApi != null) {
+      // Ensure any scroll wheel interactions have been ended prior to beginning
+      // another interaction to prevent the interaction from being ended early.
+      this.zoomInteraction.endDrag(event, this.interactionApi);
+
       this.draggingInteraction.beginDrag(
         event,
         this.downPositionCanvas || Point.create(event.clientX, event.clientY),

--- a/packages/viewer/src/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/interactions/mouseInteractions.ts
@@ -137,6 +137,8 @@ export class ZoomInteraction extends MouseInteraction {
 
   public endDrag(event: MouseEvent, api: InteractionApi): void {
     super.endDrag(event, api);
+    this.stopInteractionTimer();
+    this.didTransformBegin = false;
   }
 
   public zoom(delta: number, api: InteractionApi): void {


### PR DESCRIPTION
## What

Small fix to address an issue where scrolling to zoom would interrupt any following interaction that began before a final frame was received. 

Opted to go this route since it wound up being a fairly small/straightforward fix with our existing interactions rather than any refactoring, but open to thoughts on whether we should take some time to refactor this now.

## Ticket

https://vertexvis.atlassian.net/browse/APP-2183

## Test Plan

- Test scroll to zoom
- Test drag-based zoom
- Test interactions after scrolling to zoom
  - With this version, the interaction should no longer "freeze" after a couple seconds 

## Areas of Possible Regression

Zoom (drag/scroll)

## Out of scope changes made in PR

N/A

## Dependencies

N/A
