### PR TITLE
[API-1978] Fix RTE when setting stream attributes and changing scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ web platform.
 | [@vertexvis/stream-api]    | ![npm](https://img.shields.io/npm/v/@vertexvis/stream-api)   | The API client for streaming 3D images. |
 | [@vertexvis/utils]         | ![npm](https://img.shields.io/npm/v/@vertexvis/utils)        | General Node and Web utilities used within Vertex. |
 | [@vertexvis/viewer]        | ![npm](https://img.shields.io/npm/v/@vertexvis/viewer)       | The Web SDK containing web components to view 3D models. |
-| [@vertexvis/viewer-core]   | ![npm](https://img.shields.io/npm/v/@vertexvis/viewer-core)  | The core libraries for the Web SDK |
 | [@vertexvis/viewer-react]  | ![npm](https://img.shields.io/npm/v/@vertexvis/viewer-react) | Contains React bindings for Vertex's Web SDK. |
 
 ## Documentation

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -583,9 +583,12 @@ export class Viewer {
           frameType: 'final',
         },
       };
-      this.stream.updateStream({
-        streamAttributes: toProtoStreamAttributes(this.getStreamAttributes()),
-      });
+
+      if (this.isStreamStarted) {
+        this.stream.updateStream({
+          streamAttributes: toProtoStreamAttributes(this.getStreamAttributes()),
+        });
+      }
     }
   }
 
@@ -628,6 +631,7 @@ export class Viewer {
   @Method()
   public async unload(): Promise<void> {
     if (this.streamDisposable != null) {
+      this.isStreamStarted = false;
       this.streamId = undefined;
       this.streamDisposable.dispose();
       this.lastFrame = undefined;
@@ -703,6 +707,7 @@ export class Viewer {
    */
   public async handleWebSocketClose(): Promise<void> {
     if (this.isStreamStarted) {
+      console.log('handle ws closed');
       this.isStreamStarted = false;
 
       if (

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -707,7 +707,6 @@ export class Viewer {
    */
   public async handleWebSocketClose(): Promise<void> {
     if (this.isStreamStarted) {
-      console.log('handle ws closed');
       this.isStreamStarted = false;
 
       if (


### PR DESCRIPTION
## What

This is a potential fix for https://vertexvis.atlassian.net/browse/API-1878, which may be caused when quickly assigning stream attributes and changing the src of the stream, as might happen in React applications. This will eagerly disable the connection flag when `unload` is called which should prevent sending a message over a disconnecting websocket when `streamAttributes` is assigned.

## Ticket

https://vertexvis.atlassian.net/browse/API-1878

