### PR TITLE
[API-2009] Don't show distance anchor labels by default

### DIFF
--- a/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement-components.tsx
+++ b/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement-components.tsx
@@ -68,7 +68,7 @@ export const DistanceMeasurementRenderer: FunctionalComponent<DistanceMeasuremen
           class="anchor-label anchor-label-start"
           style={{ transform: cssTransformCenterAt(startLabelPt) }}
         >
-          <div class="anchor-label-placeholder">A</div>
+          <slot name="start-label" />
         </div>
       )}
 
@@ -90,9 +90,7 @@ export const DistanceMeasurementRenderer: FunctionalComponent<DistanceMeasuremen
           class="anchor-label anchor-label-end"
           style={{ transform: cssTransformCenterAt(endLabelPt) }}
         >
-          <slot name="end-label">
-            <div class="anchor-label-placeholder">B</div>
-          </slot>
+          <slot name="end-label" />
         </div>
       )}
 

--- a/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement.css
+++ b/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement.css
@@ -133,17 +133,6 @@
   display: block;
 }
 
-.anchor-label-placeholder {
-  color: var(--viewer-distance-measurement-contrast-color);
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--viewer-distance-measurement-accent-color);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 :host([mode='edit']) .anchor {
   cursor: move;
 }

--- a/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement.spec.tsx
+++ b/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement.spec.tsx
@@ -26,6 +26,8 @@ describe('vertex-viewer-distance-measurement', () => {
   const endNdc = Vector3.transformMatrix(end, projectionViewMatrix);
   const centerNdc = Line3.center(Line3.create({ start, end }));
 
+  const depthBuffer = Fixtures.createDepthBuffer(100, 50, 0);
+
   (getElementBoundingClientRect as jest.Mock).mockReturnValue({
     left: 0,
     top: 0,
@@ -193,23 +195,29 @@ describe('vertex-viewer-distance-measurement', () => {
   it('positions anchor labels with distance property', async () => {
     const page = await newSpecPage({
       components: [ViewerDistanceMeasurement],
-      html: `
-        <vertex-viewer-distance-measurement anchor-label-offset="50" start-json="[0, 0, 0]" end-json="[0, 0, 0]">
+      template: () => (
+        <vertex-viewer-distance-measurement
+          anchorLabelOffset={25}
+          startJson="[0, 0, 0]"
+          endJson="[0, 0, 0]"
+          projectionViewMatrix={projectionViewMatrix}
+          depthBuffer={depthBuffer}
+        >
           <div id="start-label" slot="start-label"></div>
           <div id="end-label" slot="end-label"></div>
         </vertex-viewer-distance-measurement>
-      `,
+      ),
     });
 
     const startLabelEl = page.root?.shadowRoot?.querySelector(
       '.anchor-label-start'
-    );
+    ) as HTMLElement | undefined;
     const endLabelEl = page.root?.shadowRoot?.querySelector(
       '.anchor-label-end'
-    );
+    ) as HTMLElement | undefined;
 
-    expect(startLabelEl).toBeDefined();
-    expect(endLabelEl).toBeDefined();
+    expect(startLabelEl?.style.transform).toContain('translate(25px, 50px)');
+    expect(endLabelEl?.style.transform).toContain('translate(75px, 50px)');
   });
 
   it('is empty if start and end points cant be calculated', async () => {

--- a/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement.spec.tsx
+++ b/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement.spec.tsx
@@ -172,6 +172,46 @@ describe('vertex-viewer-distance-measurement', () => {
     );
   });
 
+  it('supports slots for anchor labels', async () => {
+    const page = await newSpecPage({
+      components: [ViewerDistanceMeasurement],
+      html: `
+        <vertex-viewer-distance-measurement>
+          <div id="start-label" slot="start-label"></div>
+          <div id="end-label" slot="end-label"></div>
+        </vertex-viewer-distance-measurement>
+      `,
+    });
+
+    const startLabelEl = page.root?.querySelector('#start-label');
+    const endLabelEl = page.root?.querySelector('#end-label');
+
+    expect(startLabelEl).toBeDefined();
+    expect(endLabelEl).toBeDefined();
+  });
+
+  it('positions anchor labels with distance property', async () => {
+    const page = await newSpecPage({
+      components: [ViewerDistanceMeasurement],
+      html: `
+        <vertex-viewer-distance-measurement anchor-label-offset="50" start-json="[0, 0, 0]" end-json="[0, 0, 0]">
+          <div id="start-label" slot="start-label"></div>
+          <div id="end-label" slot="end-label"></div>
+        </vertex-viewer-distance-measurement>
+      `,
+    });
+
+    const startLabelEl = page.root?.shadowRoot?.querySelector(
+      '.anchor-label-start'
+    );
+    const endLabelEl = page.root?.shadowRoot?.querySelector(
+      '.anchor-label-end'
+    );
+
+    expect(startLabelEl).toBeDefined();
+    expect(endLabelEl).toBeDefined();
+  });
+
   it('is empty if start and end points cant be calculated', async () => {
     const page = await newSpecPage({
       components: [ViewerDistanceMeasurement],


### PR DESCRIPTION
## What

This change makes it so the distance anchor labels are not included by default. This is to decouple the SDK styling from what is used in Connect. To include distance labels, create a template like so:

```html
<html>
<body>
  <div>
    <template id="distance-measurement">
      <vertex-viewer-distance-measurement class="measurement">
        <div slot="start-label" class="anchor-label">A</div>
        <div slot="end-label" class="anchor-label">B</div>
      </vertex-viewer-distance-measurement>
    </template>

    <vertex-viewer id="viewer" depth-buffers="all">
      <vertex-viewer-measurements
        distance-template-id="distance-measurement"
      >
        <vertex-viewer-measurement-tool></vertex-viewer-measurement-tool>
      </vertex-viewer-measurements>
    </vertex-viewer>
  </div>
</body>
</html>
```

## Ticket

https://vertexvis.atlassian.net/browse/API-2009
