### PR TITLE
[API-2011] Only update measurement validty on user interaction

### DIFF
--- a/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement.tsx
+++ b/packages/viewer/src/components/viewer-distance-measurement/viewer-distance-measurement.tsx
@@ -383,7 +383,6 @@ export class ViewerDistanceMeasurement {
     this.updateProjectionViewMatrix();
     this.updateDepthBuffer();
     this.updateLineFromProps();
-    this.updateInvalid();
     this.updateDistance();
   }
 
@@ -605,6 +604,7 @@ export class ViewerDistanceMeasurement {
         } else {
           this.end = worldPt;
         }
+        this.updateLineFromProps();
         this.updateInvalid();
       }
     };


### PR DESCRIPTION
## What

Fixes a bug where measurements would show as invalid when rotating the model. This happened because we were checking validity on every prop change. We now only update validity when moving an anchor through user interaction.

## Ticket

https://vertexvis.atlassian.net/browse/API-2011
