### PR TITLE
[API-2016] Fix bug with incorrect measurement validity

### DIFF
--- a/packages/viewer/src/components/viewer-measurements/viewer-measurements.spec.tsx
+++ b/packages/viewer/src/components/viewer-measurements/viewer-measurements.spec.tsx
@@ -40,6 +40,7 @@ describe('vertex-viewer-measurements', () => {
       expect(measurementEl.id).toEqual(measurement1.id);
       expect(measurementEl.start).toEqual(measurement1.start);
       expect(measurementEl.end).toEqual(measurement1.end);
+      expect(measurementEl.invalid).toEqual(measurement1.invalid);
     });
 
     it('adds a measurement element with distance template', async () => {

--- a/packages/viewer/src/components/viewer-measurements/viewer-measurements.tsx
+++ b/packages/viewer/src/components/viewer-measurements/viewer-measurements.tsx
@@ -86,12 +86,13 @@ export class ViewerMeasurements {
     measurement: Measurement
   ): Promise<HTMLVertexViewerDistanceMeasurementElement> {
     if (measurement instanceof DistanceMeasurement) {
-      const { start, end, id } = measurement;
+      const { start, end, invalid, id } = measurement;
 
       const measurementEl = this.createDistanceMeasurementElement();
       measurementEl.id = id;
       measurementEl.start = start;
       measurementEl.end = end;
+      measurementEl.invalid = invalid;
       measurementEl.viewer = this.viewer;
       measurementEl.classList.add('viewer-measurements__measurement');
 


### PR DESCRIPTION
## What

Fixes issue where a measurement will appear "valid" when adding a measurement where an anchor is off the model.

## Ticket

https://vertexvis.atlassian.net/browse/API-2016

