### PR TITLE
[API-2019] Fix parsing of cross section

### DIFF
--- a/packages/stream-api/src/encoder.ts
+++ b/packages/stream-api/src/encoder.ts
@@ -13,5 +13,8 @@ export function decode(
     bufferOrBytes instanceof ArrayBuffer
       ? new Uint8Array(bufferOrBytes)
       : bufferOrBytes;
-  return vertexvis.protobuf.stream.StreamMessage.decode(bytes);
+  const message = vertexvis.protobuf.stream.StreamMessage.decode(bytes);
+  return vertexvis.protobuf.stream.StreamMessage.toObject(message, {
+    defaults: true,
+  });
 }

--- a/packages/viewer/src/lib/mappers.ts
+++ b/packages/viewer/src/lib/mappers.ts
@@ -17,16 +17,11 @@ import {
 } from './types';
 
 export const mapRGBi: M.Func<
-  vertexvis.protobuf.core.IRGBAi,
+  vertexvis.protobuf.core.IRGBi,
   Color.Color
 > = M.defineMapper(
-  M.read(
-    M.requiredProp('r'),
-    M.requiredProp('g'),
-    M.requiredProp('b'),
-    M.requiredProp('a')
-  ),
-  ([r, g, b, a]) => Color.create(r, g, b, a)
+  M.read(M.requiredProp('r'), M.requiredProp('g'), M.requiredProp('b')),
+  ([r, g, b]) => Color.create(r, g, b)
 );
 
 export const mapVector3f: M.Func<


### PR DESCRIPTION
## What

pbjs doesn't default scalar values during decoding, which was causing our mapper to throw an RTE. calling `toObject` will apply defaults to scalars.

## Ticket

https://vertexvis.atlassian.net/browse/API-2019

