### PR TITLE
[API-2048] Disable parsing of depth buffers in Node environments

### DIFF
--- a/packages/viewer/src/components/scene-tree-toolbar/readme.md
+++ b/packages/viewer/src/components/scene-tree-toolbar/readme.md
@@ -44,9 +44,9 @@ the group with a fractional gap size of this component.
 
 ## CSS Custom Properties
 
-| Name                       | Description                                                   |
-| -------------------------- | ------------------------------------------------------------- |
-| `--scene-tree-toolbar-gap` | A CSS length that specifies the horizontal gap between slots. |
+| Name                               | Description                                                   |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `--scene-tree-toolbar-content-gap` | A CSS length that specifies the horizontal gap between slots. |
 
 
 ## Dependencies

--- a/packages/viewer/src/lib/workers.ts
+++ b/packages/viewer/src/lib/workers.ts
@@ -1,0 +1,33 @@
+/**
+ * Checks if the code is running in a browser environment, and if so calls
+ * `module()` which is expected to load a module via a dynamic import.
+ *
+ * @example
+ *
+ * ```ts
+ * // module.ts
+ * export function hi(): string {
+ *   return 'hi';
+ * }
+ *
+ * // loader.ts
+ * async function main(): Promise<void> {
+ *   const { hi } = await loadWorker(() => import('./module'));
+ * 	 console.log(hi()); // hi
+ * }
+ * ```
+ *
+ * @param module A function that will load the module via dynamic imports.
+ * @returns A promise that resolves with the loaded module.
+ */
+export async function loadWorker<T>(module: () => Promise<T>): Promise<T> {
+  if (isBrowserEnv()) {
+    return await module();
+  } else {
+    throw new Error('Worker is not supported in non-browser environments.');
+  }
+}
+
+function isBrowserEnv(): boolean {
+  return typeof window !== 'undefined';
+}


### PR DESCRIPTION
## What

This disables parsing of depth buffers when running in a Node environment. This should fix a build error when using the SDK in a NextJS app.

## Ticket

https://vertexvis.atlassian.net/browse/API-2048