### PR TITLE
[API-2083] Scene tree UI tweaks

### DIFF
--- a/packages/viewer/src/components/scene-tree-search/scene-tree-search.css
+++ b/packages/viewer/src/components/scene-tree-search/scene-tree-search.css
@@ -70,7 +70,7 @@
   width: 100%;
 }
 
-.input.focused {
+.input.background {
   background: var(--scene-tree-search-focused-input-background);
   outline: var(--scene-tree-search-focused-input-outline);
 }
@@ -95,13 +95,13 @@
 }
 
 .icon {
-  pointer-events: none;
-  color: var(--neutral-800);
+  color: var(--neutral-700);
 }
 
 .icon-search {
   position: absolute;
   left: var(--scene-tree-search-search-icon-offset);
+  pointer-events: none;
 }
 
 .clear-btn {
@@ -111,7 +111,9 @@
   pointer-events: initial;
   cursor: pointer;
 }
-
+.clear-btn:hover {
+  color: var(--neutral-800);
+}
 .clear-btn:disabled {
   pointer-events: none;
   opacity: 0.5;

--- a/packages/viewer/src/components/scene-tree-search/scene-tree-search.spec.tsx
+++ b/packages/viewer/src/components/scene-tree-search/scene-tree-search.spec.tsx
@@ -68,10 +68,10 @@ describe('vertex-scene-tree-search', () => {
     expect(input).toHaveClass('show');
   });
 
-  it('shows focused state when input has focus', async () => {
+  it('shows textfield background when input has focus', async () => {
     const page = await newSpecPage({
       components: [SceneTreeSearch],
-      html: `<vertex-scene-tree-search value="text"></vertex-scene-tree-search>`,
+      html: `<vertex-scene-tree-search></vertex-scene-tree-search>`,
     });
 
     const input = page.root?.shadowRoot?.querySelector(
@@ -81,7 +81,20 @@ describe('vertex-scene-tree-search', () => {
 
     await page.waitForChanges();
 
-    expect(input).toHaveClass('focused');
+    expect(input).toHaveClass('background');
+  });
+
+  it('shows textfield background when value is non-empty', async () => {
+    const page = await newSpecPage({
+      components: [SceneTreeSearch],
+      html: `<vertex-scene-tree-search value="text"></vertex-scene-tree-search>`,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector(
+      '.input'
+    ) as HTMLInputElement;
+
+    expect(input).toHaveClass('background');
   });
 
   it('shows blurred state when input blurs', async () => {

--- a/packages/viewer/src/components/scene-tree-search/scene-tree-search.tsx
+++ b/packages/viewer/src/components/scene-tree-search/scene-tree-search.tsx
@@ -91,7 +91,9 @@ export class SceneTreeSearch {
           </div>
 
           <input
-            class={classNames('input', { focused: this.focused })}
+            class={classNames('input', {
+              background: this.focused || this.value.length > 0,
+            })}
             type="text"
             ref={(ref) => (this.inputEl = ref)}
             placeholder={this.placeholder}

--- a/packages/viewer/src/components/scene-tree-toolbar/scene-tree-toolbar.css
+++ b/packages/viewer/src/components/scene-tree-toolbar/scene-tree-toolbar.css
@@ -7,7 +7,6 @@
 
   display: flex;
   padding: 0.5rem;
-  border-color: var(--neutral-300);
 }
 
 .content {

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -143,7 +143,7 @@ work for an attribute, but not for a property binding.
 ### Camel Cased Properties and Events
 
 The DOM lowercases property names and events that you assign in your templates
-HTML. Bind to a camel cased property or event by separating words with a dash.
+HTML. Bind to a camel-cased property or event by separating words with a dash.
 The binding syntax will convert dash case to camel case for properties and
 events.
 
@@ -180,6 +180,42 @@ replace the header and want search behavior, your header slot should include a
         </vertex-scene-tree-toolbar-group>
       </vertex-scene-tree-toolbar>
 
+      <vertex-scene-tree-toolbar slot="footer">
+        <button slot="before">A</button>
+        <div>Footer Text</div>
+        <button slot="after">A</button>
+      </vertex-scene-tree-toolbar>
+    </vertex-scene-tree>
+    <vertex-viewer id="viewer" src="urn:vertexvis:stream-key:my-key"></vertex-viewer>
+  </body>
+</html>
+```
+
+**Example:** Stacking headers and footers.
+
+Pass multiple elements with a slot name of `header` or `footer` to vertically
+stack toolbars.
+
+```html
+<html>
+  <body>
+    <vertex-scene-tree viewer-selector="#viewer">
+      <!-- Main header toolbar -->
+      <vertex-scene-tree-toolbar slot="header">
+        <vertex-scene-tree-search></vertex-scene-tree-search>
+      </vertex-scene-tree-toolbar>
+      <!-- Secondary header toolbar -->
+      <vertex-scene-tree-toolbar slot="header">
+        <button>A</button>
+        <button>B</button>
+      </vertex-scene-tree-toolbar>
+
+      <!-- Main footer toolbar -->
+      <vertex-scene-tree-toolbar slot="footer">
+        <button>A</button>
+        <button>B</button>
+      </vertex-scene-tree-toolbar>
+      <!-- Secondary footer toolbar -->
       <vertex-scene-tree-toolbar slot="footer">
         <button slot="before">A</button>
         <div>Footer Text</div>
@@ -415,10 +451,17 @@ Type: `Promise<void>`
 
 ## Slots
 
-| Slot       | Description                                                                                                      |
-| ---------- | ---------------------------------------------------------------------------------------------------------------- |
-| `"footer"` | A slot that places content below the rows in the tree.                                                           |
-| `"header"` | A slot that places content above the rows in the tree. By default, a search toolbar will be placed in this slot. |
+| Slot       | Description                                                                                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"footer"` | A slot that places content below the rows in the tree. Elements can be stacked by assigning multiple elements to this slot.                                                           |
+| `"header"` | A slot that places content above the rows in the tree. By default, a search toolbar will be placed in this slot. Elements can be stacked by assigning multiple elements to this slot. |
+
+
+## CSS Custom Properties
+
+| Name                             | Description                                                               |
+| -------------------------------- | ------------------------------------------------------------------------- |
+| `--scene-tree-toolbar-separator` | A CSS border value that specifies the border between scene tree toolbars. |
 
 
 ## Dependencies

--- a/packages/viewer/src/components/scene-tree/scene-tree.css
+++ b/packages/viewer/src/components/scene-tree/scene-tree.css
@@ -1,4 +1,10 @@
 :host {
+  /**
+   * @prop --scene-tree-toolbar-separator: A CSS border value that specifies the
+   * border between scene tree toolbars.
+   */
+  --scene-tree-toolbar-separator: 1px solid var(--neutral-300);
+
   width: 300px;
   height: 100%;
   user-select: none;
@@ -73,12 +79,20 @@
 }
 
 .search-toolbar,
-slot[name='header']::slotted(vertex-scene-tree-toolbar) {
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
+slot[name='header']::slotted(*) {
+  border-bottom: var(--scene-tree-toolbar-separator);
 }
 
-slot[name='footer']::slotted(vertex-scene-tree-toolbar) {
-  border-top-width: 1px;
-  border-top-style: solid;
+slot[name='footer']::slotted(:not(:last-child)) {
+  border-top: var(--scene-tree-toolbar-separator);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
 }

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -115,8 +115,10 @@ export interface SelectItemOptions extends ViewerSelectItemOptions {
 
 /**
  * @slot header - A slot that places content above the rows in the tree. By
- *  default, a search toolbar will be placed in this slot.
+ *  default, a search toolbar will be placed in this slot. Elements can be
+ *  stacked by assigning multiple elements to this slot.
  * @slot footer - A slot that places content below the rows in the tree.
+ * Elements can be stacked by assigning multiple elements to this slot.
  */
 @Component({
   tag: 'vertex-scene-tree',


### PR DESCRIPTION
## What

Supports stacking toolbars to create headers and sub-headers in the scene tree. Also tweak the UI for the search bar.

**Example:** Stacking toolbars.

```html
<html>
  <body>
    <vertex-scene-tree viewer-selector="#viewer">
      <!-- Main header toolbar -->
      <vertex-scene-tree-toolbar slot="header">
        <vertex-scene-tree-search></vertex-scene-tree-search>
      </vertex-scene-tree-toolbar>
      <!-- Secondary header toolbar -->
      <vertex-scene-tree-toolbar slot="header">
        <button>A</button>
        <button>B</button>
      </vertex-scene-tree-toolbar>

      <!-- Main footer toolbar -->
      <vertex-scene-tree-toolbar slot="footer">
        <button>A</button>
        <button>B</button>
      </vertex-scene-tree-toolbar>
      <!-- Secondary footer toolbar -->
      <vertex-scene-tree-toolbar slot="footer">
        <button slot="before">A</button>
        <div>Footer Text</div>
        <button slot="after">A</button>
      </vertex-scene-tree-toolbar>
    </vertex-scene-tree>
    <vertex-viewer id="viewer" src="urn:vertexvis:stream-key:my-key"></vertex-viewer>
  </body>
</html>
```

![Screen Shot 2021-08-05 at 12 53 50 PM](https://user-images.githubusercontent.com/37429/128405514-6409554a-757d-4def-a04a-967e2d4c1a9e.png)

## Ticket

https://vertexvis.atlassian.net/browse/API-2083

## Test Plan

<!-- Describe how your changes should be tested. -->

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->
