### PR TITLE
[APP-2577] Zoom to cursor on drag

### DIFF
--- a/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
@@ -7,7 +7,7 @@ import {
   TwistInteraction,
 } from '../mouseInteractions';
 import { InteractionApi } from '../interactionApi';
-import { Point } from '@vertexvis/geometry';
+import { Point, Ray } from '@vertexvis/geometry';
 
 const InteractionApiMock = InteractionApi as jest.Mock<InteractionApi>;
 
@@ -167,7 +167,7 @@ describe(ZoomInteraction, () => {
       interaction.beginDrag(event1, canvasPoint, api);
       interaction.drag(event2, api);
 
-      expect(api.zoomCamera).toHaveBeenCalledWith(5);
+      expect(api.zoomCamera).toHaveBeenCalledWith(5, undefined);
     });
 
     it('continuous drags rotate camera using delta between calls', () => {
@@ -176,7 +176,22 @@ describe(ZoomInteraction, () => {
       interaction.drag(event2, api);
       interaction.drag(event3, api);
 
-      expect(api.zoomCamera).toHaveBeenNthCalledWith(2, 10);
+      expect(api.zoomCamera).toHaveBeenNthCalledWith(2, 10, undefined);
+    });
+
+    it.only('uses the starting point ray', () => {
+      const div = document.createElement('div');
+      jest
+        .spyOn(div, 'getBoundingClientRect')
+        .mockReturnValue({ left: 0, top: 0 } as DOMRect);
+      jest.spyOn(api, 'getRayFromPoint').mockReturnValue(Ray.create());
+      const interaction = new ZoomInteraction();
+      interaction.beginDrag(event1, canvasPoint, api, div);
+      interaction.drag(event2, api);
+      interaction.drag(event3, api);
+
+      expect(api.zoomCamera).toBeCalledWith(5, Ray.create());
+      expect(api.zoomCamera).toBeCalledWith(10, Ray.create());
     });
 
     it('does nothing if begin drag has not been called', () => {

--- a/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
@@ -179,7 +179,7 @@ describe(ZoomInteraction, () => {
       expect(api.zoomCamera).toHaveBeenNthCalledWith(2, 10, undefined);
     });
 
-    it.only('uses the starting point ray', () => {
+    it('uses the starting point ray', () => {
       const div = document.createElement('div');
       jest
         .spyOn(div, 'getBoundingClientRect')

--- a/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
@@ -222,7 +222,8 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
       this.draggingInteraction.beginDrag(
         event,
         this.downPositionCanvas || Point.create(event.clientX, event.clientY),
-        this.interactionApi
+        this.interactionApi,
+        this.element
       );
     }
   }

--- a/packages/viewer/src/lib/interactions/interactionApi.ts
+++ b/packages/viewer/src/lib/interactions/interactionApi.ts
@@ -135,7 +135,6 @@ export class InteractionApi {
   public async transformCamera(t: CameraTransform): Promise<void> {
     if (this.isInteracting()) {
       const scene = this.getScene();
-      console.log(this.currentCamera);
       this.currentCamera =
         this.currentCamera != null
           ? t(this.currentCamera, scene.viewport(), scene.scale())

--- a/packages/viewer/src/lib/interactions/interactionApi.ts
+++ b/packages/viewer/src/lib/interactions/interactionApi.ts
@@ -135,6 +135,7 @@ export class InteractionApi {
   public async transformCamera(t: CameraTransform): Promise<void> {
     if (this.isInteracting()) {
       const scene = this.getScene();
+      console.log(this.currentCamera);
       this.currentCamera =
         this.currentCamera != null
           ? t(this.currentCamera, scene.viewport(), scene.scale())
@@ -309,11 +310,10 @@ export class InteractionApi {
       const vv = camera.viewVector();
       const v = Vector3.normalize(vv);
 
-      const lookAtPlane = Plane.create({
+      const vvPlane = Plane.create({
         normal: v,
-        constant: Vector3.dot(camera.lookAt, v),
       });
-      const pt = ray != null ? Ray.intersectPlane(ray, lookAtPlane) : undefined;
+      const pt = ray != null ? Ray.intersectPlane(ray, vvPlane) : undefined;
       const zv = pt != null ? Vector3.subtract(pt, camera.position) : vv;
 
       const direction = Vector3.normalize(zv);
@@ -324,7 +324,7 @@ export class InteractionApi {
         camera.position,
         Vector3.scale(epsilon, direction)
       );
-      const lookAt = Plane.projectPoint(lookAtPlane, position);
+      const lookAt = Plane.projectPoint(vvPlane, position);
       return camera.update({ position, lookAt });
     });
   }


### PR DESCRIPTION
## What

Adds zoom to cursor behavior for drag interactions. Also makes a small adjustment to the `zoomCamera` method in the `InteractionApi` after noticing some flickering behavior when zoomed in close to the lookAt point.

## Ticket

https://vertexvis.atlassian.net/browse/APP-2577

## Test Plan

- Test zoom to cursor with scrolling
- Test zoom to cursor when dragging with `zoom` interaction mode

## Areas of Possible Regression

Zoom to cursor when scrolling

## Out of scope changes made in PR

N/A

## Dependencies

N/A
