### PR TITLE
[API-2113] Remove prevent default for pointer events

### DIFF
--- a/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
@@ -141,8 +141,6 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   }
 
   protected handleDownEvent(event: BaseEvent): void {
-    event.preventDefault();
-
     this.interactionTimer = window.setTimeout(() => {
       this.downPosition = Point.create(event.screenX, event.screenY);
       this.downPositionCanvas = this.getCanvasPosition(event);

--- a/packages/viewer/src/lib/interactions/multiPointerInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/multiPointerInteractionHandler.ts
@@ -24,7 +24,6 @@ export class MultiPointerInteractionHandler extends MultiTouchInteractionHandler
   }
 
   private handlePointerDown(event: PointerEvent): void {
-    event.preventDefault();
     const point = Point.create(event.screenX, event.screenY);
     this.touchPoints = {
       ...this.touchPoints,
@@ -38,8 +37,6 @@ export class MultiPointerInteractionHandler extends MultiTouchInteractionHandler
   }
 
   private handlePointerMove(event: PointerEvent): void {
-    event.preventDefault();
-
     if (this.touchPoints[event.pointerId] != null) {
       this.touchPoints[event.pointerId] = Point.create(
         event.screenX,

--- a/packages/viewer/src/lib/interactions/pointerInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/pointerInteractionHandler.ts
@@ -37,7 +37,6 @@ export class PointerInteractionHandler extends BaseInteractionHandler {
   }
 
   private handlePointerDown(event: PointerEvent): void {
-    event.preventDefault();
     this.downPosition = Point.create(event.screenX, event.screenY);
     this.touchPoints.add(event.pointerId);
 

--- a/packages/viewer/src/lib/interactions/touchInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/touchInteractionHandler.ts
@@ -25,8 +25,6 @@ export class TouchInteractionHandler extends MultiTouchInteractionHandler {
 
   private handleTouchStart(event: TouchEvent): void {
     if (event.touches.length >= 1) {
-      event.preventDefault();
-
       const touch1 = event.touches[0];
       const touch2 = event.touches[1];
 
@@ -44,8 +42,6 @@ export class TouchInteractionHandler extends MultiTouchInteractionHandler {
   }
 
   private handleTouchMove(event: TouchEvent): void {
-    event.preventDefault();
-
     if (event.touches.length === 1) {
       this.handleOnePointTouchMove(event.touches[0]);
     } else if (event.touches.length === 2) {


### PR DESCRIPTION
## What

Removes `Event.preventDefault()` for most of the viewer interaction events. This caused problems with other UI elements not losing focus, and they don't appear to be needed. Tested on iOS to make sure this wasn't preventing page zooming on mobile.

## Ticket

https://vertexvis.atlassian.net/browse/API-2113
