### PR TITLE
[APP-2619] Correct SVG filter issue on Safari

### DIFF
--- a/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.css
+++ b/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.css
@@ -88,6 +88,16 @@
   ;
 }
 
+.root {
+  pointer-events: none;
+  filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.3));
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .svg {
   pointer-events: none;
   position: absolute;

--- a/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.css
+++ b/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.css
@@ -90,6 +90,9 @@
 
 .svg {
   pointer-events: none;
+  position: absolute;
+  left: 0;
+  top: 0;
   width: 100%;
   height: 100%;
 }

--- a/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.tsx
+++ b/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.tsx
@@ -211,7 +211,7 @@ export class ViewerMarkupArrow {
             <defs>
               <SvgShadow id="arrow-shadow" />
             </defs>
-            <g filter="url(#arrow-shadow)">
+            <g filter="/_display/url(#arrow-shadow)">
               <polygon
                 id="arrow-head"
                 class="head"

--- a/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.tsx
+++ b/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.tsx
@@ -17,7 +17,6 @@ import {
   arrowheadPointsToPolygonPoints,
   parsePoint,
 } from './utils';
-import { SvgShadow } from '../viewer-markup/viewer-markup-components';
 import { BoundingBox1d } from './viewer-markup-arrow-components';
 import {
   translatePointToRelative,
@@ -207,45 +206,44 @@ export class ViewerMarkupArrow {
 
       return (
         <Host>
-          <svg class="svg">
-            <defs>
-              <SvgShadow id="arrow-shadow" />
-            </defs>
-            <g filter="/_display/url(#arrow-shadow)">
-              <polygon
-                id="arrow-head"
-                class="head"
-                points={arrowheadPointsToPolygonPoints(arrowheadPoints)}
-              />
-              <line
-                id="arrow-line"
-                class="line"
-                x1={screenStart.x}
-                y1={screenStart.y}
-                x2={arrowheadPoints.base.x}
-                y2={arrowheadPoints.base.y}
-              />
-              {this.mode === 'edit' && (
+          <div class="root">
+            <svg class="svg">
+              <g>
+                <polygon
+                  id="arrow-head"
+                  class="head"
+                  points={arrowheadPointsToPolygonPoints(arrowheadPoints)}
+                />
                 <line
-                  id="bounding-box-1d-line"
-                  class="bounds-line"
+                  id="arrow-line"
+                  class="line"
                   x1={screenStart.x}
                   y1={screenStart.y}
-                  x2={screenEnd.x}
-                  y2={screenEnd.y}
+                  x2={arrowheadPoints.base.x}
+                  y2={arrowheadPoints.base.y}
                 />
-              )}
-            </g>
-          </svg>
-          {this.mode === 'edit' && (
-            <BoundingBox1d
-              start={screenStart}
-              end={screenEnd}
-              onStartAnchorPointerDown={this.editStartPoint}
-              onCenterAnchorPointerDown={this.editCenterPoint}
-              onEndAnchorPointerDown={this.editEndPoint}
-            />
-          )}
+                {this.mode === 'edit' && (
+                  <line
+                    id="bounding-box-1d-line"
+                    class="bounds-line"
+                    x1={screenStart.x}
+                    y1={screenStart.y}
+                    x2={screenEnd.x}
+                    y2={screenEnd.y}
+                  />
+                )}
+              </g>
+            </svg>
+            {this.mode === 'edit' && (
+              <BoundingBox1d
+                start={screenStart}
+                end={screenEnd}
+                onStartAnchorPointerDown={this.editStartPoint}
+                onCenterAnchorPointerDown={this.editCenterPoint}
+                onEndAnchorPointerDown={this.editEndPoint}
+              />
+            )}
+          </div>
         </Host>
       );
     } else {

--- a/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.css
+++ b/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.css
@@ -77,6 +77,16 @@
   --viewer-markup-circle-bounds-anchor-height: 9px;
 }
 
+.root {
+  pointer-events: none;
+  filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.3));
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .svg {
   pointer-events: none;
   position: absolute;

--- a/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.css
+++ b/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.css
@@ -79,6 +79,9 @@
 
 .svg {
   pointer-events: none;
+  position: absolute;
+  left: 0;
+  top: 0;
   width: 100%;
   height: 100%;
 }

--- a/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
+++ b/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
@@ -185,7 +185,7 @@ export class ViewerMarkupCircle {
             <defs>
               <SvgShadow id="circle-shadow" />
             </defs>
-            <g filter="url(#circle-shadow)">
+            <g filter="/_display/url(#circle-shadow)">
               <ellipse
                 class="ellipse"
                 cx={center.x}

--- a/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
+++ b/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
@@ -17,7 +17,6 @@ import {
   translateRectToScreen,
   translatePointToRelative,
 } from '../viewer-markup/utils';
-import { SvgShadow } from '../viewer-markup/viewer-markup-components';
 import { BoundingBox2d } from './viewer-markup-circle-components';
 import { parseBounds, transformCircle } from './utils';
 import { getMarkupBoundingClientRect } from '../viewer-markup/dom';
@@ -181,51 +180,52 @@ export class ViewerMarkupCircle {
 
       return (
         <Host>
-          <svg class="svg">
-            <defs>
-              <SvgShadow id="circle-shadow" />
-            </defs>
-            <g filter="/_display/url(#circle-shadow)">
-              <ellipse
-                class="ellipse"
-                cx={center.x}
-                cy={center.y}
-                rx={relativeBounds.width / 2}
-                ry={relativeBounds.height / 2}
-                stroke={'#000ff0'}
-                stroke-width={4}
-                fill={'none'}
+          <div class="root">
+            <svg class="svg">
+              <g>
+                <ellipse
+                  class="ellipse"
+                  cx={center.x}
+                  cy={center.y}
+                  rx={relativeBounds.width / 2}
+                  ry={relativeBounds.height / 2}
+                  stroke={'#000ff0'}
+                  stroke-width={4}
+                  fill={'none'}
+                />
+              </g>
+            </svg>
+            {this.mode === 'edit' && (
+              <BoundingBox2d
+                bounds={relativeBounds}
+                onTopLeftAnchorPointerDown={(e) =>
+                  this.updateEditAnchor(e, 'top-left')
+                }
+                onTopRightAnchorPointerDown={(e) =>
+                  this.updateEditAnchor(e, 'top-right')
+                }
+                onTopAnchorPointerDown={(e) => this.updateEditAnchor(e, 'top')}
+                onBottomLeftAnchorPointerDown={(e) =>
+                  this.updateEditAnchor(e, 'bottom-left')
+                }
+                onBottomRightAnchorPointerDown={(e) =>
+                  this.updateEditAnchor(e, 'bottom-right')
+                }
+                onBottomAnchorPointerDown={(e) =>
+                  this.updateEditAnchor(e, 'bottom')
+                }
+                onLeftAnchorPointerDown={(e) =>
+                  this.updateEditAnchor(e, 'left')
+                }
+                onRightAnchorPointerDown={(e) =>
+                  this.updateEditAnchor(e, 'right')
+                }
+                onCenterAnchorPointerDown={(e) =>
+                  this.updateEditAnchor(e, 'center')
+                }
               />
-            </g>
-          </svg>
-          {this.mode === 'edit' && (
-            <BoundingBox2d
-              bounds={relativeBounds}
-              onTopLeftAnchorPointerDown={(e) =>
-                this.updateEditAnchor(e, 'top-left')
-              }
-              onTopRightAnchorPointerDown={(e) =>
-                this.updateEditAnchor(e, 'top-right')
-              }
-              onTopAnchorPointerDown={(e) => this.updateEditAnchor(e, 'top')}
-              onBottomLeftAnchorPointerDown={(e) =>
-                this.updateEditAnchor(e, 'bottom-left')
-              }
-              onBottomRightAnchorPointerDown={(e) =>
-                this.updateEditAnchor(e, 'bottom-right')
-              }
-              onBottomAnchorPointerDown={(e) =>
-                this.updateEditAnchor(e, 'bottom')
-              }
-              onLeftAnchorPointerDown={(e) => this.updateEditAnchor(e, 'left')}
-              onRightAnchorPointerDown={(e) =>
-                this.updateEditAnchor(e, 'right')
-              }
-              onCenterAnchorPointerDown={(e) =>
-                this.updateEditAnchor(e, 'center')
-              }
-            />
-          )}
+            )}
+          </div>
         </Host>
       );
     } else {

--- a/packages/viewer/src/components/viewer-markup/viewer-markup-components.tsx
+++ b/packages/viewer/src/components/viewer-markup/viewer-markup-components.tsx
@@ -35,22 +35,3 @@ export const RelativeAnchor: FunctionalComponent<RelativeAnchorProps> = (
     </div>
   );
 };
-
-export interface SvgShadowProps {
-  id: string;
-}
-
-export const SvgShadow: FunctionalComponent<SvgShadowProps> = ({ id }) => {
-  return (
-    <filter id={id} filterUnits="userSpaceOnUse">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="2" />
-      <feOffset dx="0" dy="1" result="offsetblur" />
-      <feFlood flood-color="#000000" flood-opacity="0.25" />
-      <feComposite in2="offsetblur" operator="in" />
-      <feMerge>
-        <feMergeNode />
-        <feMergeNode in="SourceGraphic" />
-      </feMerge>
-    </filter>
-  );
-};


### PR DESCRIPTION
## Summary

Corrects an issue where the `filter` attribute on markup SVG elements was causing them to "disappear" on Safari when multiple were placed. Also updates the `.svg` to be positioned absolutely so the `width` and `height` property properly reflect the host bounds.

## Test Plan

- Test that adding multiple markups displays as expected in Safari
- Test that adding multiple markups still displays as expected in Chrome/Firefox

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
