### PR TITLE
[PLAT-113] Add helper for converting hits into measurement entities

### DIFF
--- a/packages/viewer/src/lib/measurement/__tests__/controller.spec.ts
+++ b/packages/viewer/src/lib/measurement/__tests__/controller.spec.ts
@@ -2,8 +2,10 @@ jest.mock(
   '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb_service'
 );
 
-import { MeasureEntity } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb';
+import { Vector3 } from '@vertexvis/geometry';
+import { ModelEntity } from '@vertexvis/scene-view-protos/core/protos/model_entity_pb';
 import { SceneViewAPIClient } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb_service';
+import { MeasurementEntity } from '..';
 import {
   createMeasureResponse,
   createMinimumDistanceResult,
@@ -15,6 +17,15 @@ import { MeasurementModel } from '../model';
 
 describe('MeasurementController', () => {
   const model = new MeasurementModel();
+  const entity1 = new MeasurementEntity(
+    Vector3.create(),
+    new ModelEntity().serializeBinary()
+  );
+  const entity2 = new MeasurementEntity(
+    Vector3.create(),
+    new ModelEntity().serializeBinary()
+  );
+
   const client = new SceneViewAPIClient(random.url());
   const jwtProvider = (): string => random.string();
   const controller = new MeasurementController(model, client, jwtProvider);
@@ -33,8 +44,8 @@ describe('MeasurementController', () => {
         )
       );
 
-      const entity = new MeasureEntity();
-      const results = await controller.addEntity(entity);
+      await controller.addEntity(entity1);
+      const results = await controller.addEntity(entity2);
 
       expect(results).toEqual([
         expect.objectContaining({ type: 'minimum-distance' }),
@@ -48,9 +59,9 @@ describe('MeasurementController', () => {
         )
       );
 
-      const entity = new MeasureEntity();
-      controller.addEntity(entity);
-      const results = await controller.addEntity(entity);
+      controller.addEntity(entity1);
+      await controller.addEntity(entity2);
+      const results = await controller.addEntity(entity2);
 
       expect(client.measure).toHaveBeenCalledTimes(1);
       expect(results).toEqual([
@@ -67,14 +78,14 @@ describe('MeasurementController', () => {
         )
       );
 
-      const entity = new MeasureEntity();
-      await controller.addEntity(entity);
+      await controller.addEntity(entity1);
+      await controller.addEntity(entity2);
 
       (client.measure as jest.Mock).mockImplementation(
         mockGrpcUnaryResult(createMeasureResponse())
       );
 
-      const results = await controller.removeEntity(entity);
+      const results = await controller.removeEntity(entity2);
       expect(results).toEqual([]);
     });
   });

--- a/packages/viewer/src/lib/measurement/__tests__/model.spec.ts
+++ b/packages/viewer/src/lib/measurement/__tests__/model.spec.ts
@@ -1,43 +1,44 @@
-import { MeasureEntity } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb';
 import { MeasurementModel, MinimumDistanceMeasurementResult } from '../model';
 import { random } from '../../../testing';
 import { Vector3 } from '@vertexvis/geometry';
+import { ModelEntity } from '@vertexvis/scene-view-protos/core/protos/model_entity_pb';
+import { MeasurementEntity } from '..';
 
 describe('MeasurementModel', () => {
+  const point = Vector3.create();
+  const modelEntity = new ModelEntity().serializeBinary();
+  const measureEntity = new MeasurementEntity(point, modelEntity);
+
   describe(MeasurementModel.prototype.addEntity, () => {
     it('adds the entity if not registered', () => {
       const model = new MeasurementModel();
-      const entity = new MeasureEntity();
 
-      expect(model.addEntity(entity)).toBe(true);
-      expect(model.getEntities()).toEqual([entity]);
+      expect(model.addEntity(measureEntity)).toBe(true);
+      expect(model.getEntities()).toEqual([measureEntity]);
     });
 
     it('wont duplicate entities', () => {
       const model = new MeasurementModel();
-      const entity = new MeasureEntity();
-      model.addEntity(entity);
+      model.addEntity(measureEntity);
 
-      expect(model.addEntity(entity)).toBe(false);
-      expect(model.getEntities()).toEqual([entity]);
+      expect(model.addEntity(measureEntity)).toBe(false);
+      expect(model.getEntities()).toEqual([measureEntity]);
     });
   });
 
   describe(MeasurementModel.prototype.removeEntity, () => {
     it('removes entity if registered', () => {
       const model = new MeasurementModel();
-      const entity = new MeasureEntity();
-      model.addEntity(entity);
+      model.addEntity(measureEntity);
 
-      expect(model.removeEntity(entity)).toBe(true);
+      expect(model.removeEntity(measureEntity)).toBe(true);
       expect(model.getEntities()).toEqual([]);
     });
 
     it('does not remove entity if unregistered', () => {
       const model = new MeasurementModel();
-      const entity = new MeasureEntity();
 
-      expect(model.removeEntity(entity)).toBe(false);
+      expect(model.removeEntity(measureEntity)).toBe(false);
       expect(model.getEntities()).toEqual([]);
     });
   });
@@ -95,8 +96,7 @@ describe('MeasurementModel', () => {
   describe(MeasurementModel.prototype.clearEntities, () => {
     it('removes all results', () => {
       const model = new MeasurementModel();
-      const entity = new MeasureEntity();
-      model.addEntity(entity);
+      model.addEntity(measureEntity);
 
       model.clearEntities();
       expect(model.getEntities()).toEqual([]);


### PR DESCRIPTION
## Summary

Adding a helper to convert a `Hit` into `MeasurementEntity`.

https://vertexvis.atlassian.net/browse/PLAT-113