### PR TITLE
[PLAT-164] Add frame listener on load in dom-renderer

### DIFF
--- a/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
@@ -80,6 +80,8 @@ export class ViewerDomRenderer {
 
     const mutation = new MutationObserver(() => this.handleChildrenChange());
     mutation.observe(this.hostEl, { childList: true });
+
+    this.handleViewerChange(this.viewer, undefined);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a call to `handleViewerChange` in `componentWillLoad` to cover the case where the `@Watch` method is not invoked. This corrects an issue where the camera would never be defined for the renderer even with a defined viewer element.

## Test Plan

- Test using a `<vertex-viewer-dom-renderer>` where the `viewer` prop is defined prior to being connected to the DOM

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
