### PR TITLE
[PLAT-245] Fix setting occluded attribute

### DIFF
--- a/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.spec.tsx
+++ b/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.spec.tsx
@@ -77,4 +77,17 @@ describe('vertex-viewer-dom-element', () => {
     await page.waitForChanges();
     expect(el.quaternion).toEqual(Quaternion.fromEuler(rotation));
   });
+
+  it('sets occluded attribute if occluded', async () => {
+    const page = await newSpecPage({
+      components: [ViewerDomElement],
+      html: `<vertex-viewer-dom-element></vertex-viewer-dom-element>`,
+    });
+
+    const el = page.root as HTMLVertexViewerDomElementElement;
+    el.occluded = true;
+
+    await page.waitForChanges();
+    expect(el).toHaveAttribute('occluded');
+  });
 });

--- a/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
+++ b/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
@@ -192,8 +192,12 @@ export class ViewerDomElement implements HTMLDomRendererPositionableElement {
   /**
    * @ignore
    */
-  protected componentShouldUpdate(): boolean {
-    return false;
+  protected componentShouldUpdate(
+    newValue: unknown,
+    oldValue: unknown,
+    prop: string
+  ): boolean {
+    return prop === 'occluded';
   }
 
   private syncProperties(): void {


### PR DESCRIPTION
## Summary

StencilJS doesn't set attributes if `componentShouldUpdate` returns `false`. This caused problems with occlusion styling via CSS.

https://vertexvis.atlassian.net/browse/PLAT-245

## Test Plan

There's a test.