### PR TITLE
[PLAT-374] Handle interaction handlers when measurement component added/removed

### DIFF
--- a/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.spec.tsx
+++ b/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.spec.tsx
@@ -24,4 +24,31 @@ describe('vertex-viewer-measurement-precise', () => {
       expect.arrayContaining([expect.any(PreciseMeasurementInteractionHandler)])
     );
   });
+
+  it('registers and deregisters interaction handler when component added or removed', async () => {
+    const page = await newSpecPage({
+      components: [Viewer, ViewerMeasurementPrecise],
+      html: `
+      <vertex-viewer>
+        <vertex-viewer-measurement-precise></vertex-viewer-measurement-precise>
+      </vertex-viewer>`,
+    });
+
+    const measurement = page.body.querySelector(
+      'vertex-viewer-measurement-precise'
+    ) as HTMLVertexViewerMeasurementPreciseElement;
+    const viewer = page.body.querySelector('vertex-viewer');
+
+    measurement.remove();
+    let handlers = await viewer?.getInteractionHandlers();
+    expect(handlers).not.toEqual(
+      expect.arrayContaining([expect.any(PreciseMeasurementInteractionHandler)])
+    );
+
+    viewer?.appendChild(measurement);
+    handlers = await viewer?.getInteractionHandlers();
+    expect(handlers).toEqual(
+      expect.arrayContaining([expect.any(PreciseMeasurementInteractionHandler)])
+    );
+  });
 });

--- a/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx
+++ b/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx
@@ -38,10 +38,18 @@ export class ViewerMeasurementPrecise {
   private registeredInteractionHandler?: Promise<Disposable>;
   private onEntitiesChangedDisposable?: Disposable;
 
+  protected connectedCallback(): void {
+    this.setupInteractionHandler();
+  }
+
   protected componentWillLoad(): void {
     this.setupController();
     this.setupInteractionHandler();
     this.setupModelListeners();
+  }
+
+  protected disconnectedCallback(): void {
+    this.clearInteractionHandler();
   }
 
   @Watch('measurementController')
@@ -74,9 +82,13 @@ export class ViewerMeasurementPrecise {
     );
   }
 
-  private setupInteractionHandler(): void {
+  private clearInteractionHandler(): void {
     this.registeredInteractionHandler?.then((handler) => handler.dispose());
     this.registeredInteractionHandler = undefined;
+  }
+
+  private setupInteractionHandler(): void {
+    this.clearInteractionHandler();
 
     if (this.measurementController != null) {
       this.registeredInteractionHandler =
@@ -86,8 +98,14 @@ export class ViewerMeasurementPrecise {
     }
   }
 
-  private setupModelListeners(): void {
+  private clearModelListeners(): void {
     this.onEntitiesChangedDisposable?.dispose();
+    this.onEntitiesChangedDisposable = undefined;
+  }
+
+  private setupModelListeners(): void {
+    this.clearModelListeners();
+
     this.onEntitiesChangedDisposable = this.measurementModel?.onEntitiesChanged(
       this.handleEntitiesChanged
     );


### PR DESCRIPTION
## Summary

Fixes a bug where face highlighting would still happen if the `<vertex-viewer-measurement-precise>` element was removed from the DOM. This happened because we did not deregister the interaction handler when the component was removed from the DOM.

https://vertexvis.atlassian.net/browse/PLAT-374