### PR TITLE
[PLAT-372] make the viewer mutable in precise measurement

### DIFF
--- a/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx
+++ b/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx
@@ -23,7 +23,7 @@ export class ViewerMeasurementPrecise {
   @Prop({ mutable: true })
   public measurementController?: MeasurementController;
 
-  @Prop()
+  @Prop({ mutable: true })
   public viewer?: HTMLVertexViewerElement;
 
   @Prop()


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
The viewer is by default `immutable` which my hunch is that the `PreciseMeasurement` is getting initialized prior to the viewer ref being present, and always returning `undefined`

The `JWT Provider` that is returning the jwt for precise measurement likely was getting a viewer that was null, which resulted in the error. https://github.com/Vertexvis/vertex-web-sdk/blob/master/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx#L81

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
