### PR TITLE
[PLAT-19] Fix clipping bug with measurement lines when point behind camera

### DIFF
--- a/packages/geometry/src/plane.ts
+++ b/packages/geometry/src/plane.ts
@@ -75,7 +75,7 @@ export function intersectLine(
   if (t < 0 || t > 1) {
     return undefined;
   } else {
-    return Vector3.add(line.start, Vector3.scale(t, direction));
+    return Vector3.add(Vector3.scale(t, direction), line.start);
   }
 }
 

--- a/packages/viewer/src/lib/types/__tests__/frame.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/frame.spec.ts
@@ -1,0 +1,48 @@
+import { Line3, Vector3 } from '@vertexvis/geometry';
+import { FramePerspectiveCamera } from '../frame';
+
+describe(FramePerspectiveCamera, () => {
+  const camera = new FramePerspectiveCamera(
+    Vector3.scale(2, Vector3.back()),
+    Vector3.origin(),
+    Vector3.up(),
+    1,
+    10,
+    1,
+    45
+  );
+
+  describe(FramePerspectiveCamera.prototype.isPointBehindNear, () => {
+    it('returns true if world point behind near plane', () => {
+      const pt = camera.position;
+      expect(camera.isPointBehindNear(pt)).toBe(true);
+    });
+
+    it('returns false if world point in front of near plane', () => {
+      const pt = Vector3.origin();
+      expect(camera.isPointBehindNear(pt)).toBe(false);
+    });
+  });
+
+  describe(FramePerspectiveCamera.prototype.intersectLineWithNear, () => {
+    it('returns point on near plane if line intersects', () => {
+      const line = Line3.create({
+        start: Vector3.origin(),
+        end: camera.position,
+      });
+
+      const pt = camera.intersectLineWithNear(line);
+      expect(pt).toEqual(Vector3.create(0, 0, camera.near));
+    });
+
+    it('returns undefined if line does not intersect near plane', () => {
+      const line = Line3.create({
+        start: Vector3.left(),
+        end: Vector3.right(),
+      });
+
+      const pt = camera.intersectLineWithNear(line);
+      expect(pt).toBeUndefined();
+    });
+  });
+});

--- a/packages/viewer/src/lib/types/depthBuffer.ts
+++ b/packages/viewer/src/lib/types/depthBuffer.ts
@@ -143,13 +143,13 @@ export class DepthBuffer implements FrameImageLike {
     ray: Ray.Ray,
     fallbackNormalizedDepth?: number
   ): Vector3.Vector3 {
+    const { position, viewVector: vv, far } = this.camera;
     const distance = this.getLinearDepthAtPoint(point, fallbackNormalizedDepth);
-    const vv = Vector3.subtract(this.camera.lookAt, this.camera.position);
 
     // Compute the world position along the ray at the far plane.
     // This is used to determine the angle with the view vector.
-    const worldPt = Ray.at(ray, this.camera.far);
-    const eyeToWorldPt = Vector3.subtract(worldPt, this.camera.position);
+    const worldPt = Ray.at(ray, far);
+    const eyeToWorldPt = Vector3.subtract(worldPt, position);
 
     const angle =
       Vector3.dot(vv, eyeToWorldPt) /

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -223,16 +223,15 @@ export class FramePerspectiveCamera
    * intersect with the near plane.
    */
   public intersectLineWithNear(line: Line3.Line3): Vector3.Vector3 | undefined {
-    const { position, lookAt, direction, near } = this;
+    const { position, direction, near } = this;
 
-    const vs = Vector3.subtract(line.start, lookAt);
-    const ve = Vector3.subtract(line.end, lookAt);
+    const vs = Vector3.subtract(line.start, position);
+    const ve = Vector3.subtract(line.end, position);
     const vl = Line3.create({ start: vs, end: ve });
 
-    const dist = Vector3.distance(lookAt, position) - near;
-    const nearP = Plane.create({ normal: direction, constant: dist });
+    const nearP = Plane.create({ normal: direction, constant: -near });
     const pt = Plane.intersectLine(nearP, vl);
 
-    return pt != null ? Vector3.add(pt, lookAt) : undefined;
+    return pt != null ? Vector3.add(pt, position) : undefined;
   }
 }

--- a/packages/viewer/src/lib/types/viewport.ts
+++ b/packages/viewer/src/lib/types/viewport.ts
@@ -1,6 +1,5 @@
 import {
   Dimensions,
-  Plane,
   Point,
   Ray,
   Rectangle,
@@ -47,21 +46,6 @@ export class Viewport implements Dimensions.Dimensions {
    */
   public static fromDimensions(dimensions: Dimensions.Dimensions): Viewport {
     return new Viewport(dimensions.width, dimensions.height);
-  }
-
-  /**
-   * Returns the screen plane for this viewport and given `camera`.
-   *
-   * @param camera A camera.
-   * @returns The screen plane.
-   */
-  public plane(camera: FramePerspectiveCamera): Plane.Plane {
-    const direction = camera.direction;
-    const distance = Vector3.distance(camera.position, camera.lookAt);
-    return Plane.create({
-      normal: direction,
-      constant: distance - camera.near,
-    });
   }
 
   /**
@@ -164,27 +148,6 @@ export class Viewport implements Dimensions.Dimensions {
       (framePt.x / image.imageAttr.frameDimensions.width) * 2 - 1,
       -(framePt.y / image.imageAttr.frameDimensions.height) * 2 + 1
     );
-  }
-
-  /**
-   * Maps a point in screen space to a world point that is coplanar with the
-   * camera's near plane.
-   *
-   * @param screenPt The screen point to transform.
-   * @param image An image of frame.
-   * @param camera The camera used to map a 2D point to 3D point.
-   * @returns A point on the screen in world space.
-   */
-  public transformPointToScreenWorld(
-    screenPt: Point.Point,
-    image: FrameImageLike,
-    camera: FramePerspectiveCamera
-  ): Vector3.Vector3 | undefined {
-    const { direction, near } = camera;
-
-    const ray = this.transformPointToRay(screenPt, image, camera);
-    const screen = Plane.create({ normal: direction, constant: near });
-    return Ray.intersectPlane(ray, screen);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes an issue where measurement lines were mispositioned if one of its anchors were behind the camera's near plane. Math should be fixed now.

https://vertexvis.atlassian.net/browse/PLAT-19

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
