### PR TITLE
[PLAT-445] Include original PointerEvent with node when dispatching selection, expansion, & visibility events on SceneTreeTableCell

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.ts
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.ts
@@ -106,10 +106,17 @@ describe('<vertex-scene-tree-table-cell>', () => {
     cell.addEventListener('expandToggled', expandToggled);
 
     const expandBtn = cell.shadowRoot?.querySelector('.expand-btn');
-    expandBtn?.dispatchEvent(new MouseEvent('pointerdown'));
+    const originalEvent = new MouseEvent('pointerdown');
+    expandBtn?.dispatchEvent(originalEvent);
 
     expect(tree.toggleExpandItem).toHaveBeenCalled();
-    expect(expandToggled).toHaveBeenCalled();
+    expect(expandToggled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          originalEvent,
+        }),
+      })
+    );
   });
 
   it('does not expands cell if interaction disabled', async () => {
@@ -153,10 +160,17 @@ describe('<vertex-scene-tree-table-cell>', () => {
     cell.addEventListener('visibilityToggled', visibilityToggled);
 
     const expandBtn = cell.shadowRoot?.querySelector('.visibility-btn');
-    expandBtn?.dispatchEvent(new MouseEvent('pointerdown'));
+    const originalEvent = new MouseEvent('pointerdown');
+    expandBtn?.dispatchEvent(originalEvent);
 
     expect(tree.toggleItemVisibility).toHaveBeenCalled();
-    expect(visibilityToggled).toHaveBeenCalled();
+    expect(visibilityToggled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          originalEvent,
+        }),
+      })
+    );
   });
 
   it('does not toggle visibility cell if interaction disabled', async () => {
@@ -199,10 +213,18 @@ describe('<vertex-scene-tree-table-cell>', () => {
     const selected = jest.fn();
     cell.addEventListener('selectionToggled', selected);
 
-    cell.dispatchEvent(new MouseEvent('pointerdown', { button: 0 }));
+    const originalEvent = new MouseEvent('pointerdown', { button: 0 });
+    cell.dispatchEvent(originalEvent);
 
     expect(tree.selectItem).toHaveBeenCalled();
     expect(selected).toHaveBeenCalled();
+    expect(selected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          originalEvent,
+        }),
+      })
+    );
   });
 
   it('appends selection if unselected and meta key', async () => {
@@ -221,15 +243,23 @@ describe('<vertex-scene-tree-table-cell>', () => {
     const selected = jest.fn();
     cell.addEventListener('selectionToggled', selected);
 
-    cell.dispatchEvent(
-      new MouseEvent('pointerdown', { button: 0, metaKey: true })
-    );
+    const originalEvent = new MouseEvent('pointerdown', {
+      button: 0,
+      metaKey: true,
+    });
+    cell.dispatchEvent(originalEvent);
 
     expect(tree.selectItem).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ append: true })
     );
-    expect(selected).toHaveBeenCalled();
+    expect(selected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          originalEvent,
+        }),
+      })
+    );
   });
 
   it('appends selection if unselected and ctrl key', async () => {
@@ -339,12 +369,20 @@ describe('<vertex-scene-tree-table-cell>', () => {
     const selected = jest.fn();
     cell.addEventListener('selectionToggled', selected);
 
-    cell.dispatchEvent(
-      new MouseEvent('pointerdown', { button: 0, ctrlKey: true })
-    );
+    const originalEvent = new MouseEvent('pointerdown', {
+      button: 0,
+      ctrlKey: true,
+    });
+    cell.dispatchEvent(originalEvent);
 
     expect(tree.deselectItem).toHaveBeenCalled();
-    expect(selected).toHaveBeenCalled();
+    expect(selected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          originalEvent,
+        }),
+      })
+    );
   });
 
   it('does not select if event default behavior prevented', async () => {
@@ -381,10 +419,16 @@ describe('<vertex-scene-tree-table-cell>', () => {
     const hovered = jest.fn();
     cell.addEventListener('hovered', hovered);
 
-    cell.dispatchEvent(new MouseEvent('pointerenter'));
+    const originalEvent = new MouseEvent('pointerenter');
+    cell.dispatchEvent(originalEvent);
 
     expect(hovered).toHaveBeenCalledWith(
-      expect.objectContaining({ detail: node })
+      expect.objectContaining({
+        detail: {
+          node,
+          originalEvent,
+        },
+      })
     );
   });
 
@@ -400,12 +444,19 @@ describe('<vertex-scene-tree-table-cell>', () => {
     const hovered = jest.fn();
     cell.addEventListener('hovered', hovered);
 
-    cell.dispatchEvent(new MouseEvent('pointerenter'));
+    const originalEvent = new MouseEvent('pointerenter');
+    cell.dispatchEvent(originalEvent);
     cell.dispatchEvent(new MouseEvent('pointerleave'));
 
     expect(hovered).toHaveBeenCalledWith(
-      expect.objectContaining({ detail: node })
+      expect.objectContaining({
+        detail: {
+          node,
+          originalEvent,
+        },
+      })
     );
+
     expect(hovered).toHaveBeenCalledWith(
       expect.objectContaining({ detail: undefined })
     );

--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
@@ -10,6 +10,11 @@ import {
 import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
 import classNames from 'classnames';
 
+export interface SceneTreeTableCellEventDetails {
+  node?: Node.AsObject;
+  originalEvent: PointerEvent;
+}
+
 @Component({
   tag: 'vertex-scene-tree-table-cell',
   styleUrl: 'scene-tree-table-cell.css',
@@ -84,28 +89,28 @@ export class SceneTreeTableCell {
    * @internal
    */
   @Event({ bubbles: true })
-  public hovered!: EventEmitter<Node.AsObject | undefined>;
+  public hovered!: EventEmitter<SceneTreeTableCellEventDetails | undefined>;
 
   /**
    * An event that is emitted when a user requests to expand the node. This is
    * emitted even if interactions are disabled.
    */
   @Event({ bubbles: true })
-  public expandToggled!: EventEmitter<Node.AsObject>;
+  public expandToggled!: EventEmitter<SceneTreeTableCellEventDetails>;
 
   /**
    * An event that is emitted when a user requests to change the node's
    * visibility. This event is emitted even if interactions are disabled.
    */
   @Event({ bubbles: true })
-  public visibilityToggled!: EventEmitter<Node.AsObject>;
+  public visibilityToggled!: EventEmitter<SceneTreeTableCellEventDetails>;
 
   /**
    * An event that is emitted when a user requests to change the node's selection
    * state. This event is emitted even if interactions are disabled.
    */
   @Event({ bubbles: true })
-  public selectionToggled!: EventEmitter<Node.AsObject>;
+  public selectionToggled!: EventEmitter<SceneTreeTableCellEventDetails>;
 
   @Element()
   private hostEl!: HTMLElement;
@@ -124,8 +129,11 @@ export class SceneTreeTableCell {
   public render(): h.JSX.IntrinsicElements {
     return (
       <Host
-        onPointerEnter={() => {
-          this.hovered.emit(this.node);
+        onPointerEnter={(e: PointerEvent) => {
+          this.hovered.emit({
+            node: this.node,
+            originalEvent: e,
+          });
         }}
         onPointerLeave={() => {
           this.hovered.emit(undefined);
@@ -142,7 +150,7 @@ export class SceneTreeTableCell {
               data-test-id={'expand-' + this.node?.name}
               onPointerDown={(event) => {
                 event.preventDefault();
-                this.toggleExpansion();
+                this.toggleExpansion(event);
               }}
             >
               {!this.node?.isLeaf && (
@@ -163,7 +171,7 @@ export class SceneTreeTableCell {
               data-test-id={'visibility-btn-' + this.node?.name}
               onPointerDown={(event) => {
                 event?.preventDefault();
-                this.toggleVisibility();
+                this.toggleVisibility(event);
               }}
             >
               <div
@@ -209,22 +217,22 @@ export class SceneTreeTableCell {
           append: event.ctrlKey || event.metaKey,
         });
       }
-      this.selectionToggled.emit(this.node);
+      this.selectionToggled.emit({ node: this.node, originalEvent: event });
     }
   };
 
-  private toggleExpansion = (): void => {
+  private toggleExpansion = (event: PointerEvent): void => {
     if (this.tree != null && this.node != null && !this.interactionsDisabled) {
       this.tree.toggleExpandItem(this.node);
     }
-    this.expandToggled.emit(this.node);
+    this.expandToggled.emit({ node: this.node, originalEvent: event });
   };
 
-  private toggleVisibility = (): void => {
+  private toggleVisibility = (event: PointerEvent): void => {
     if (this.tree != null && this.node != null && !this.interactionsDisabled) {
       this.tree.toggleItemVisibility(this.node);
     }
-    this.visibilityToggled.emit(this.node);
+    this.visibilityToggled.emit({ node: this.node, originalEvent: event });
   };
 
   private toggleAttribute(attr: string, value: boolean): void {

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -250,7 +250,7 @@ export class Scene {
    */
   public async reset(
     opts: ResetViewOptions = {}
-  ): Promise<vertexvis.protobuf.stream.ILoadSceneViewStateResult | undefined> {
+  ): Promise<vertexvis.protobuf.stream.IResetViewResult | undefined> {
     return await this.stream.resetSceneView(
       {
         includeCamera: opts.includeCamera,


### PR DESCRIPTION
## Summary
Include original PointerEvent with node when dispatching selection, expansion, & visibility events on SceneTreeTableCell

