### PR TITLE
[PLAT-464] Correct retrieval of ID for hovered scene tree cells

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -21,6 +21,7 @@ import { MetadataKey } from './components/scene-tree/interfaces';
 import { SceneTreeErrorDetails } from './components/scene-tree/lib/errors';
 import { Row } from './components/scene-tree/lib/row';
 import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
+import { SceneTreeTableCellEventDetails } from './components/scene-tree-table-cell/scene-tree-table-cell';
 import { RowDataProvider as RowDataProvider1 } from './components/scene-tree/scene-tree';
 import {
   FeatureHighlightOptions,
@@ -1465,16 +1466,24 @@ declare namespace LocalJSX {
     /**
      * An event that is emitted when a user requests to expand the node. This is emitted even if interactions are disabled.
      */
-    onExpandToggled?: (event: CustomEvent<Node.AsObject>) => void;
-    onHovered?: (event: CustomEvent<Node.AsObject | undefined>) => void;
+    onExpandToggled?: (
+      event: CustomEvent<SceneTreeTableCellEventDetails>
+    ) => void;
+    onHovered?: (
+      event: CustomEvent<SceneTreeTableCellEventDetails | undefined>
+    ) => void;
     /**
      * An event that is emitted when a user requests to change the node's selection state. This event is emitted even if interactions are disabled.
      */
-    onSelectionToggled?: (event: CustomEvent<Node.AsObject>) => void;
+    onSelectionToggled?: (
+      event: CustomEvent<SceneTreeTableCellEventDetails>
+    ) => void;
     /**
      * An event that is emitted when a user requests to change the node's visibility. This event is emitted even if interactions are disabled.
      */
-    onVisibilityToggled?: (event: CustomEvent<Node.AsObject>) => void;
+    onVisibilityToggled?: (
+      event: CustomEvent<SceneTreeTableCellEventDetails>
+    ) => void;
     /**
      * The value to display in this cell if the `value` specified is undefined. Defaults to "--".
      */

--- a/packages/viewer/src/components/scene-tree-table-cell/readme.md
+++ b/packages/viewer/src/components/scene-tree-table-cell/readme.md
@@ -21,11 +21,11 @@
 
 ## Events
 
-| Event               | Description                                                                                                                                  | Type                                                                                                                                                                                                                                       |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `expandToggled`     | An event that is emitted when a user requests to expand the node. This is emitted even if interactions are disabled.                         | `CustomEvent<{ id?: AsObject \| undefined; depth: number; name: string; visible: boolean; selected: boolean; expanded: boolean; isLeaf: boolean; suppliedId?: AsObject \| undefined; partiallyVisible: boolean; columnsList: string[]; }>` |
-| `selectionToggled`  | An event that is emitted when a user requests to change the node's selection state. This event is emitted even if interactions are disabled. | `CustomEvent<{ id?: AsObject \| undefined; depth: number; name: string; visible: boolean; selected: boolean; expanded: boolean; isLeaf: boolean; suppliedId?: AsObject \| undefined; partiallyVisible: boolean; columnsList: string[]; }>` |
-| `visibilityToggled` | An event that is emitted when a user requests to change the node's visibility. This event is emitted even if interactions are disabled.      | `CustomEvent<{ id?: AsObject \| undefined; depth: number; name: string; visible: boolean; selected: boolean; expanded: boolean; isLeaf: boolean; suppliedId?: AsObject \| undefined; partiallyVisible: boolean; columnsList: string[]; }>` |
+| Event               | Description                                                                                                                                  | Type                                          |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `expandToggled`     | An event that is emitted when a user requests to expand the node. This is emitted even if interactions are disabled.                         | `CustomEvent<SceneTreeTableCellEventDetails>` |
+| `selectionToggled`  | An event that is emitted when a user requests to change the node's selection state. This event is emitted even if interactions are disabled. | `CustomEvent<SceneTreeTableCellEventDetails>` |
+| `visibilityToggled` | An event that is emitted when a user requests to change the node's visibility. This event is emitted even if interactions are disabled.      | `CustomEvent<SceneTreeTableCellEventDetails>` |
 
 
 ## CSS Custom Properties

--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
@@ -2,6 +2,7 @@ import { Component, Host, h, Prop, State, Element } from '@stencil/core';
 import { Point } from '@vertexvis/geometry';
 import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
 import { readDOM } from '../../lib/stencil';
+import { SceneTreeTableCellEventDetails } from '../scene-tree-table-cell/scene-tree-table-cell';
 import { Binding } from '../scene-tree/lib/binding';
 import { SceneTreeController } from '../scene-tree/lib/controller';
 import { getSceneTreeViewportHeight } from '../scene-tree/lib/dom';
@@ -624,9 +625,9 @@ export class SceneTreeTableLayout {
   };
 
   private handleCellHover = (
-    event: CustomEvent<Node.AsObject | undefined>
+    event: CustomEvent<SceneTreeTableCellEventDetails | undefined>
   ): void => {
-    this.hoveredNodeId = event.detail?.id?.hex;
+    this.hoveredNodeId = event.detail?.node?.id?.hex;
   };
 
   private bindHeaderData = (): void => {

--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, h, Prop, State, Element } from '@stencil/core';
 import { Point } from '@vertexvis/geometry';
-import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
 import { readDOM } from '../../lib/stencil';
 import { SceneTreeTableCellEventDetails } from '../scene-tree-table-cell/scene-tree-table-cell';
 import { Binding } from '../scene-tree/lib/binding';


### PR DESCRIPTION
## Summary

Updates the retrieval of the ID for a hovered node in the `scene-tree-table-layout` element.

## Test Plan

- Test hovering a scene tree cell and changing visibility

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
