### PR TITLE
[PLAT-464] Add test for cell hover

### DIFF
--- a/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
@@ -223,7 +223,7 @@ describe('<vertex-scene-tree>', () => {
 
       const row = tree.querySelectorAll(
         'vertex-scene-tree-table-cell'
-      )[0] as HTMLVertexSceneTreeRowElement;
+      )[0] as HTMLVertexSceneTreeTableCellElement;
       expect(row.node?.name).toEqual(res.toObject().itemsList[0].name);
     });
   });


### PR DESCRIPTION
## Summary

Adds a test for #286 to ensure that cells properly receive the hovered cell IDs to prevent issues with the way that the event listeners are registered.

## Test Plan

- Unit tests

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
