### PR TITLE
[PLAT-175] Twist interaction updates

### DIFF
--- a/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
@@ -252,6 +252,13 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   }
 
   protected endDrag(event: BaseEvent): void {
+    if (
+      this.keyboardControls &&
+      this.currentInteraction === this.twistInteraction
+    ) {
+      this.currentInteraction = undefined;
+    }
+
     if (this.draggingInteraction != null && this.interactionApi != null) {
       this.draggingInteraction.endDrag(event, this.interactionApi);
       this.draggingInteraction = undefined;

--- a/packages/viewer/src/lib/interactions/interactionApi.ts
+++ b/packages/viewer/src/lib/interactions/interactionApi.ts
@@ -198,7 +198,7 @@ export class InteractionApi {
         return camera.rotateAroundAxis(angleInRadians, axis);
       } else if (args.length === 1) {
         const center = Point.create(viewport.width / 2, viewport.height / 2);
-        const currentAngle = Angle.fromPointsInDegrees(center, args[0]);
+        const currentAngle = Angle.toDegrees(Angle.fromPoints(center, args[0]));
         const angleDelta =
           this.lastAngle != null ? currentAngle - this.lastAngle : 0;
 

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -241,12 +241,12 @@ export class TwistInteraction extends MouseInteraction {
     canvasPosition: Point.Point,
     api: InteractionApi
   ): void {
-    this.currentPosition = Point.create(event.screenX, event.screenY);
+    this.currentPosition = Point.create(event.clientX, event.clientY);
     api.beginInteraction();
   }
 
   public drag(event: MouseEvent, api: InteractionApi): void {
-    const position = Point.create(event.screenX, event.screenY);
+    const position = Point.create(event.clientX, event.clientY);
     this.currentPosition = position;
 
     api.twistCamera(position);


### PR DESCRIPTION
## Summary

Makes a couple updates to the twist (Alt+Shift) interaction:
- Moves to using client X/Y instead of screen X/Y. This corrects some odd behavior when the viewport is scaled, since the `twistCamera` method uses the center of the viewport as a reference point for angles.
- Adds a check when ending an interaction to set the `currentInteraction` back to undefined in the case of twist to prevent the current case where twist applies to the interaction immediately following it 

## Test Plan

- Test scaling a browser window to 50% -- twist should work as expected
- Test performing a twist, then a second interaction with no modifier keys -- this should default back to the primary interaction

## Release Notes

N/A

## Possible Regressions

Twist

## Dependencies

N/A
