### PR TITLE
[PLAT-550] Fix html-templates package locally

### DIFF
--- a/packages/html-templates/package.json
+++ b/packages/html-templates/package.json
@@ -15,7 +15,6 @@
   "main": "./dist/bundle.cjs.js",
   "module": "./dist/bundle.esm.js",
   "typings": "./dist/index.d.ts",
-  "browser": "./dist/browser.esm.js",
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"


### PR DESCRIPTION
## Summary

Corrects an issue where the Stencil dev server was unable to find the `@vertexvis/html-templates` package. Stencil was looking for the `browser` bundle, which the package indicates that it has, though it is not actually generated.

## Test Plan

- Test running `yarn start` from the viewer package
  - The scene tree should load properly

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
