### PR TITLE
[PLAT-385] Set min size for viewer

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.css
+++ b/packages/viewer/src/components/viewer/viewer.css
@@ -16,6 +16,8 @@
   position: relative;
   width: 300px;
   height: 300px;
+  min-width: 1px;
+  min-height: 1px;
 }
 
 .canvas-container {

--- a/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
+++ b/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
@@ -425,6 +425,58 @@ describe(ViewerStream, () => {
     });
   });
 
+  describe('update', () => {
+    it('updates stream attributes if defined', async () => {
+      const { stream, ws } = makeStream();
+
+      jest
+        .spyOn(stream, 'startStream')
+        .mockResolvedValue(Fixtures.Responses.startStream().response);
+      jest
+        .spyOn(stream, 'syncTime')
+        .mockResolvedValue(Fixtures.Responses.syncTime().response);
+
+      const updateStream = jest.spyOn(stream, 'updateStream');
+      const connected123 = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connected' && s.resource.resource.id === '123'
+      );
+      stream.load(urn123, clientId, sessionId, config);
+      await simulateFrame(ws);
+      await connected123;
+
+      stream.update({});
+      expect(updateStream).not.toBeCalled();
+
+      stream.update({ streamAttributes: { depthBuffers: 'final' } });
+      expect(updateStream).toHaveBeenCalled();
+    });
+
+    it('updates dimensions if defined', async () => {
+      const { stream, ws } = makeStream();
+
+      jest
+        .spyOn(stream, 'startStream')
+        .mockResolvedValue(Fixtures.Responses.startStream().response);
+      jest
+        .spyOn(stream, 'syncTime')
+        .mockResolvedValue(Fixtures.Responses.syncTime().response);
+
+      const updateDimensions = jest.spyOn(stream, 'updateDimensions');
+      const connected123 = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connected' && s.resource.resource.id === '123'
+      );
+      stream.load(urn123, clientId, sessionId, config);
+      await simulateFrame(ws);
+      await connected123;
+
+      stream.update({});
+      expect(updateDimensions).not.toBeCalled();
+
+      stream.update({ dimensions: Dimensions.create(100, 100) });
+      expect(updateDimensions).toHaveBeenCalled();
+    });
+  });
+
   function makeStream(): { stream: ViewerStream; ws: WebSocketClientMock } {
     const ws = new WebSocketClientMock();
     const stream = new ViewerStream(ws, {

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -161,15 +161,18 @@ export class ViewerStream extends StreamApi {
       ? fields.frameBgColor
       : this.frameBgColor;
 
-    if (this.dimensions !== fields.dimensions) {
-      this.dimensions = fields.dimensions ?? Dimensions.create(0, 0);
+    if (fields.dimensions != null && fields.dimensions !== this.dimensions) {
+      this.dimensions = fields.dimensions;
       this.ifState('connected', () =>
         this.updateDimensions({ dimensions: this.dimensions })
       );
     }
 
-    if (this.streamAttributes !== fields.streamAttributes) {
-      this.streamAttributes = fields.streamAttributes ?? {};
+    if (
+      fields.streamAttributes != null &&
+      this.streamAttributes !== fields.streamAttributes
+    ) {
+      this.streamAttributes = fields.streamAttributes;
       this.ifState('connected', () =>
         this.updateStream({
           streamAttributes: toPbStreamAttributesOrThrow(this.streamAttributes),


### PR DESCRIPTION
## Summary

Fixes a couple bugs during testing with Connect+ where the viewer would fail to connect because the dimensions were `(0,0)`. We now set a min width/height on the viewer of 1px and check if the args to update stream have empty dimensions.

https://vertexvis.atlassian.net/browse/PLAT-385