### PR TITLE
[PLAT-385] Make session ID an optional stream property

### DIFF
--- a/packages/viewer/src/lib/mappers/frameStreaming.ts
+++ b/packages/viewer/src/lib/mappers/frameStreaming.ts
@@ -288,7 +288,7 @@ export const fromPbStartStreamResponse: M.Func<
   {
     streamId: string;
     sceneViewId: string;
-    sessionId: string;
+    sessionId?: string;
     worldOrientation: Orientation;
     token: Token;
   }
@@ -304,7 +304,7 @@ export const fromPbStartStreamResponse: M.Func<
     ),
     M.compose(
       M.requiredProp('startStream'),
-      M.mapRequiredProp('sessionId', fromPbUuid)
+      M.mapProp('sessionId', M.ifDefined(fromPbUuid))
     ),
     M.compose(
       M.requiredProp('startStream'),
@@ -318,7 +318,7 @@ export const fromPbStartStreamResponse: M.Func<
   ([streamId, sceneViewId, sessionId, worldOrientation, token]) => ({
     streamId,
     sceneViewId,
-    sessionId,
+    sessionId: sessionId || undefined,
     worldOrientation,
     token,
   })

--- a/packages/viewer/src/lib/stream/state.ts
+++ b/packages/viewer/src/lib/stream/state.ts
@@ -19,7 +19,7 @@ export interface Connected {
   readonly connection: Disposable;
   readonly streamId: string;
   readonly sceneViewId: string;
-  readonly sessionId: string;
+  readonly sessionId?: string;
   readonly worldOrientation: Orientation;
   readonly token: Token;
   readonly frame: Frame;


### PR DESCRIPTION
## Summary

This fixes an issue where the viewer would throw an exception if the session ID was not passed back from FSS, which happens when a client ID is not set. Making this property optional, to reflect the behavior of FSS.

https://vertexvis.atlassian.net/browse/PLAT-385