### PR TITLE
[PLAT-285] Select multiple scene tree items at a time

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -174,17 +174,6 @@ export namespace Components {
      */
     overScanCount: number;
     /**
-     * Performs an API call that will select the items with indexes between the given bounds.
-     * @param lowerBound The smaller index of the set of rows to select.
-     * @param upperBound The larger index of the set of rows to select.
-     * @param viewer The viewer to select in.
-     */
-    performMultiSelection: (
-      lowerBound: number,
-      upperBound: number,
-      viewer: HTMLVertexViewerElement
-    ) => Promise<void>;
-    /**
      * A callback that is invoked immediately before a row is about to rendered. This callback can return additional data that can be bound to in a template.
      * @example ```html <script>   const table = document.querySelector('vertex-scene-tree-table');   table.rowData = (row) => {     return { func: () => console.log('row', row.node.name) };   } </script>  <vertex-scene-tree>  <vertex-scene-tree-table>    <vertex-scene-tree-table-column>      <template>        <button event:click="{{row.data.func}}">Hi</button>      </template>    </vertex-scene-tree-table-column>  </vertex-scene-tree-table> </vertex-scene-tree> ```
      */
@@ -210,6 +199,17 @@ export namespace Components {
     selectItem: (
       row: RowArg,
       { recurseParent, ...options }?: SelectItemOptions
+    ) => Promise<void>;
+    /**
+     * Performs an API call that will select the items with indexes between the given bounds.
+     * @param lowerBound The smaller index of the set of rows to select.
+     * @param upperBound The larger index of the set of rows to select.
+     * @param viewer The viewer to select in.
+     */
+    selectRange: (
+      lowerBound: number,
+      upperBound: number,
+      viewer: HTMLVertexViewerElement
     ) => Promise<void>;
     /**
      * Performs an API call that will show the item associated to the given row or row index.

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -17,9 +17,9 @@ import {
   FilterTreeOptions,
   SceneTreeController,
 } from './components/scene-tree/lib/controller';
+import { Row } from './components/scene-tree/lib/row';
 import { MetadataKey } from './components/scene-tree/interfaces';
 import { SceneTreeErrorDetails } from './components/scene-tree/lib/errors';
-import { Row } from './components/scene-tree/lib/row';
 import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
 import { SceneTreeTableCellEventDetails } from './components/scene-tree-table-cell/scene-tree-table-cell';
 import { RowDataProvider as RowDataProvider1 } from './components/scene-tree/scene-tree';
@@ -168,10 +168,22 @@ export namespace Components {
      * A list of part metadata keys that will be made available to each row. This metadata can be used for data binding inside the scene tree's template.
      */
     metadataKeys: MetadataKey[];
+    multiSelectedRows?: Row[];
     /**
      * The number of offscreen rows above and below the viewport to render. Having a higher number reduces the chance of the browser not displaying a row while scrolling.
      */
     overScanCount: number;
+    /**
+     * Performs an API call that will select the items with indexes between the given bounds.
+     * @param lowerBound The smaller index of the set of rows to select.
+     * @param upperBound The larger index of the set of rows to select.
+     * @param viewer The viewer to select in.
+     */
+    performMultiSelection: (
+      lowerBound: number,
+      upperBound: number,
+      viewer: HTMLVertexViewerElement
+    ) => Promise<void>;
     /**
      * A callback that is invoked immediately before a row is about to rendered. This callback can return additional data that can be bound to in a template.
      * @example ```html <script>   const table = document.querySelector('vertex-scene-tree-table');   table.rowData = (row) => {     return { func: () => console.log('row', row.node.name) };   } </script>  <vertex-scene-tree>  <vertex-scene-tree-table>    <vertex-scene-tree-table-column>      <template>        <button event:click="{{row.data.func}}">Hi</button>      </template>    </vertex-scene-tree-table-column>  </vertex-scene-tree-table> </vertex-scene-tree> ```
@@ -1409,6 +1421,7 @@ declare namespace LocalJSX {
      * A list of part metadata keys that will be made available to each row. This metadata can be used for data binding inside the scene tree's template.
      */
     metadataKeys?: MetadataKey[];
+    multiSelectedRows?: Row[];
     onConnectionError?: (event: CustomEvent<SceneTreeErrorDetails>) => void;
     /**
      * The number of offscreen rows above and below the viewport to render. Having a higher number reduces the chance of the browser not displaying a row while scrolling.

--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
@@ -215,6 +215,7 @@ export class SceneTreeTableCell {
       } else if (!this.node?.selected) {
         this.tree?.selectItem(this.node, {
           append: event.ctrlKey || event.metaKey,
+          inclusive: event.shiftKey,
         });
       }
       this.selectionToggled.emit({ node: this.node, originalEvent: event });

--- a/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
+++ b/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
@@ -3,6 +3,7 @@ import { ColorMaterial } from '../../..';
 export interface ViewerSelectItemOptions {
   material?: string | ColorMaterial.ColorMaterial;
   append?: boolean;
+  inclusive?: boolean;
 }
 
 export async function showItem(

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -390,16 +390,6 @@ Type: `Promise<void>`
 
 
 
-### `performMultiSelection(lowerBound: number, upperBound: number, viewer: HTMLVertexViewerElement) => Promise<void>`
-
-Performs an API call that will select the items with indexes between the given bounds.
-
-#### Returns
-
-Type: `Promise<void>`
-
-
-
 ### `scrollToIndex(index: number, options?: ScrollToOptions) => Promise<void>`
 
 Scrolls the tree to the given row index.
@@ -432,6 +422,16 @@ stateful. Each call to `selectItem` will track the ancestry of the passed
 in `rowArg`. If calling `selectItem` with a row not belonging to the
 ancestry of a previous selection, then this method will perform a standard
 selection.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `selectRange(lowerBound: number, upperBound: number, viewer: HTMLVertexViewerElement) => Promise<void>`
+
+Performs an API call that will select the items with indexes between the given bounds.
 
 #### Returns
 

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -232,16 +232,17 @@ stack toolbars.
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                                                                                         | Type                                                   | Default      |
-| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------ |
-| `config`         | --                | An object to configure the scene tree.                                                                                                                              | `Config \| undefined`                                  | `undefined`  |
-| `configEnv`      | `config-env`      | Sets the default environment for the viewer. This setting is used for auto-configuring network hosts.  Use the `config` property for manually setting hosts.        | `"platdev" \| "platprod" \| "platstaging"`             | `'platprod'` |
-| `controller`     | --                |                                                                                                                                                                     | `SceneTreeController \| undefined`                     | `undefined`  |
-| `metadataKeys`   | --                | A list of part metadata keys that will be made available to each row. This metadata can be used for data binding inside the scene tree's template.                  | `string[]`                                             | `[]`         |
-| `overScanCount`  | `over-scan-count` | The number of offscreen rows above and below the viewport to render. Having a higher number reduces the chance of the browser not displaying a row while scrolling. | `number`                                               | `25`         |
-| `rowData`        | --                | A callback that is invoked immediately before a row is about to rendered. This callback can return additional data that can be bound to in a template.              | `((row: Row) => Record<string, unknown>) \| undefined` | `undefined`  |
-| `viewer`         | --                | An instance of a `<vertex-viewer>` element. Either this property or `viewerSelector` must be set.                                                                   | `HTMLVertexViewerElement \| null \| undefined`         | `undefined`  |
-| `viewerSelector` | `viewer-selector` | A CSS selector that points to a `<vertex-viewer>` element. Either this property or `viewer` must be set.                                                            | `string \| undefined`                                  | `undefined`  |
+| Property            | Attribute         | Description                                                                                                                                                         | Type                                                   | Default      |
+| ------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------ |
+| `config`            | --                | An object to configure the scene tree.                                                                                                                              | `Config \| undefined`                                  | `undefined`  |
+| `configEnv`         | `config-env`      | Sets the default environment for the viewer. This setting is used for auto-configuring network hosts.  Use the `config` property for manually setting hosts.        | `"platdev" \| "platprod" \| "platstaging"`             | `'platprod'` |
+| `controller`        | --                |                                                                                                                                                                     | `SceneTreeController \| undefined`                     | `undefined`  |
+| `metadataKeys`      | --                | A list of part metadata keys that will be made available to each row. This metadata can be used for data binding inside the scene tree's template.                  | `string[]`                                             | `[]`         |
+| `multiSelectedRows` | --                |                                                                                                                                                                     | `Row[] \| undefined`                                   | `undefined`  |
+| `overScanCount`     | `over-scan-count` | The number of offscreen rows above and below the viewport to render. Having a higher number reduces the chance of the browser not displaying a row while scrolling. | `number`                                               | `25`         |
+| `rowData`           | --                | A callback that is invoked immediately before a row is about to rendered. This callback can return additional data that can be bound to in a template.              | `((row: Row) => Record<string, unknown>) \| undefined` | `undefined`  |
+| `viewer`            | --                | An instance of a `<vertex-viewer>` element. Either this property or `viewerSelector` must be set.                                                                   | `HTMLVertexViewerElement \| null \| undefined`         | `undefined`  |
+| `viewerSelector`    | `viewer-selector` | A CSS selector that points to a `<vertex-viewer>` element. Either this property or `viewer` must be set.                                                            | `string \| undefined`                                  | `undefined`  |
 
 
 ## Events
@@ -382,6 +383,16 @@ contents.
 
 **Note:** This is an asynchronous operation. The update may happen on the
 next frame.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `performMultiSelection(lowerBound: number, upperBound: number, viewer: HTMLVertexViewerElement) => Promise<void>`
+
+Performs an API call that will select the items with indexes between the given bounds.
 
 #### Returns
 

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -394,26 +394,22 @@ export class SceneTree {
    *
    * @param lowerBound The smaller index of the set of rows to select.
    * @param upperBound The larger index of the set of rows to select.
-   * @param viewer The viewer to select in.
    */
   @Method()
-  public async performMultiSelection(
+  public async selectRange(
     lowerBound: number,
-    upperBound: number,
-    viewer: HTMLVertexViewerElement
+    upperBound: number
   ): Promise<void> {
     const rowsToMultiSelect = this.rows.filter(
       (row) =>
         row?.index && row?.index <= upperBound && row?.index >= lowerBound
     );
     this.multiSelectedRows = rowsToMultiSelect;
-    if (viewer && rowsToMultiSelect) {
-      await rowsToMultiSelect.forEach((row) => {
-        if (row?.node?.id?.hex) {
-          selectItem(viewer, row?.node?.id?.hex, { append: true });
-        }
-      });
-    }
+    await rowsToMultiSelect.forEach((row) => {
+      if (row?.node?.id?.hex && this.viewer) {
+        selectItem(this.viewer, row?.node?.id?.hex, { append: true });
+      }
+    });
   }
 
   /**
@@ -458,27 +454,15 @@ export class SceneTree {
           selectionLowerBoundIndex &&
           currentRowIndex < selectionLowerBoundIndex
         ) {
-          this.performMultiSelection(
-            currentRowIndex,
-            selectionLowerBoundIndex,
-            viewer
-          );
+          this.selectRange(currentRowIndex, selectionLowerBoundIndex);
         } else if (
           currentRowIndex &&
           selectionUpperBoundIndex &&
           currentRowIndex > selectionUpperBoundIndex
         ) {
-          this.performMultiSelection(
-            selectionUpperBoundIndex,
-            currentRowIndex,
-            viewer
-          );
+          this.selectRange(selectionUpperBoundIndex, currentRowIndex);
         } else if (selectionLowerBoundIndex && selectionUpperBoundIndex) {
-          this.performMultiSelection(
-            selectionLowerBoundIndex,
-            selectionUpperBoundIndex,
-            viewer
-          );
+          this.selectRange(selectionLowerBoundIndex, selectionUpperBoundIndex);
         }
       } else {
         await selectItem(viewer, id, options);


### PR DESCRIPTION
## Summary
We want to be able to select adjacent parts in the scene tree when the user is holding down the shift key.

## Test Plan
Test holding down the shift key and selecting parts in the scene tree and verify that the entire range becomes selected. Also, holding down the meta key will also select the part you clicked on, without deselecting currently selected parts, though will not select the entire range. 

## Release Notes
Shift+click to multiselect in the BOM

## Possible Regressions
Scene tree selection

## Dependencies
None