### PR TITLE
[PLAT-629] Fix makeRotation returning incorrect row-major matrix

### DIFF
--- a/packages/geometry/src/__tests__/euler.test.ts
+++ b/packages/geometry/src/__tests__/euler.test.ts
@@ -34,42 +34,42 @@ describe(Euler.fromRotationMatrix, () => {
 
   it('returns xyz euler', () => {
     const euler90 = Euler.fromRotationMatrix(m, 'xyz');
-    expect(euler90.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(euler90.y).toBeCloseTo(Angle.toRadians(90));
   });
 
   it('returns yxz euler', () => {
     const euler90 = Euler.fromRotationMatrix(m, 'yxz');
-    expect(euler90.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(euler90.y).toBeCloseTo(Angle.toRadians(90));
   });
 
   it('returns zxy euler', () => {
     const euler = Euler.fromRotationMatrix(m, 'zxy');
-    expect(euler.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(euler.y).toBeCloseTo(Angle.toRadians(90));
   });
 
   it('returns zyx euler', () => {
     const euler = Euler.fromRotationMatrix(m, 'zyx');
-    expect(euler.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(euler.y).toBeCloseTo(Angle.toRadians(90));
   });
 
   it('returns yzx euler', () => {
     const euler = Euler.fromRotationMatrix(m, 'yzx');
-    expect(euler.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(euler.y).toBeCloseTo(Angle.toRadians(90));
   });
 
   it('returns zxy euler', () => {
     const euler = Euler.fromRotationMatrix(m, 'zxy');
-    expect(euler.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(euler.y).toBeCloseTo(Angle.toRadians(90));
   });
 
   it('returns yzw euler', () => {
     const euler = Euler.fromRotationMatrix(m, 'yzx');
-    expect(euler.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(euler.y).toBeCloseTo(Angle.toRadians(90));
   });
 
   it('returns xzy euler', () => {
     const euler = Euler.fromRotationMatrix(m, 'xzy');
-    expect(euler.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(euler.y).toBeCloseTo(Angle.toRadians(90));
   });
 });
 

--- a/packages/geometry/src/__tests__/matrix4.test.ts
+++ b/packages/geometry/src/__tests__/matrix4.test.ts
@@ -65,7 +65,7 @@ describe(Matrix4.makeRotation, () => {
     const q = Quaternion.fromAxisAngle(Vector3.up(), Angle.toRadians(90));
     const m = Matrix4.makeRotation(q);
     const e = Euler.fromRotationMatrix(m, 'xyz');
-    expect(e.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(e.y).toBeCloseTo(Angle.toRadians(90));
   });
 });
 
@@ -122,7 +122,7 @@ describe(Matrix4.makeTRS, () => {
     const ss = Vector3.fromMatrixScale(m);
 
     expect(tt).toEqual(t);
-    expect(rr.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(rr.y).toBeCloseTo(Angle.toRadians(90));
     expect(ss).toEqual(s);
   });
 });

--- a/packages/geometry/src/__tests__/quaternion.test.ts
+++ b/packages/geometry/src/__tests__/quaternion.test.ts
@@ -22,7 +22,7 @@ describe(Quaternion.fromAxisAngle, () => {
     const m = Matrix4.makeRotation(q);
     const e = Euler.fromRotationMatrix(m);
 
-    expect(e.y).toBeCloseTo(-Angle.toRadians(90));
+    expect(e.y).toBeCloseTo(Angle.toRadians(90));
   });
 });
 

--- a/packages/geometry/src/matrix4.ts
+++ b/packages/geometry/src/matrix4.ts
@@ -132,13 +132,14 @@ export function makeTranslation(translation: Vector3.Vector3): Matrix4 {
  * Creates a rotation matrix.
  *
  * ```
- * 1-2y²-2z²,    2xy+2zw,    2xz-2yw,    0,
- * 2xy-2zw,      1-2x²-2z²,  2yz+2xw,    0,
- * 2xz+2yw,      2yz-2xw,    1-2x²-2y²,  0,
+ * 1-2y²-2z²,    2xy-2zw,    2xz+2yw,    0,
+ * 2xy+2zw,      1-2x²-2z²,  2yz-2xw,    0,
+ * 2xz-2yw,      2yz+2xw,    1-2x²-2y²,  0,
  * 0,            0,          0,          1,
  * ```
  *
  * @param rotation A quaternion representing the rotation.
+ * @see https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
  * @returns A rotation matrix.
  */
 export function makeRotation(rotation: Quaternion.Quaternion): Matrix4 {
@@ -159,9 +160,9 @@ export function makeRotation(rotation: Quaternion.Quaternion): Matrix4 {
 
   /* eslint-disable prettier/prettier */
   return [
-    1 - ( yy + zz ), xy - wz, xz + wy, 0,
-    xy + wz, 1 - ( xx + zz ), yz - wx, 0,
-    xz - wy, yz + wx, 1 - ( xx + yy ), 0,
+    1 - ( yy + zz ), xy + wz, xz - wy, 0,
+    xy - wz, 1 - ( xx + zz ), yz + wx, 0,
+    xz + wy, yz - wx, 1 - ( xx + yy ), 0,
     0, 0, 0, 1
   ];
   /* eslint-enable prettier/prettier */

--- a/packages/viewer/src/components/viewer-view-cube/viewer-view-cube-components.tsx
+++ b/packages/viewer/src/components/viewer-view-cube/viewer-view-cube-components.tsx
@@ -24,20 +24,20 @@ const viewCubeSides: Record<ViewCubeSide, ViewCubeSideData> = {
     quaternion: Quaternion.fromAxisAngle(Vector3.up(), Math.PI),
   },
   left: {
-    direction: Vector3.right(),
+    direction: Vector3.left(),
     quaternion: Quaternion.fromAxisAngle(Vector3.down(), Math.PI / 2),
   },
   right: {
-    direction: Vector3.left(),
+    direction: Vector3.right(),
     quaternion: Quaternion.fromAxisAngle(Vector3.up(), Math.PI / 2),
   },
   top: {
     direction: Vector3.up(),
-    quaternion: Quaternion.fromAxisAngle(Vector3.right(), Math.PI / 2),
+    quaternion: Quaternion.fromAxisAngle(Vector3.right(), -Math.PI / 2),
   },
   bottom: {
     direction: Vector3.down(),
-    quaternion: Quaternion.fromAxisAngle(Vector3.left(), Math.PI / 2),
+    quaternion: Quaternion.fromAxisAngle(Vector3.left(), -Math.PI / 2),
   },
 };
 

--- a/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.tsx
+++ b/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.tsx
@@ -221,12 +221,12 @@ export class ViewerViewCube {
               <TriadAxis
                 label="Y"
                 length={this.boxLength}
-                rotationAxis={Vector3.forward()}
+                rotationAxis={Vector3.back()}
               />
               <TriadAxis
                 label="Z"
                 length={this.boxLength}
-                rotationAxis={Vector3.up()}
+                rotationAxis={Vector3.down()}
               />
             </vertex-viewer-dom-group>
           )}
@@ -257,14 +257,14 @@ export class ViewerViewCube {
               label={this.xNegativeLabel}
               length={this.boxLength}
               side="left"
-              onPointerDown={this.handleStandardView(StandardView.LEFT)}
+              onPointerDown={this.handleStandardView(StandardView.RIGHT)}
               disabled={this.standardViewsOff}
             />
             <ViewCubeSide
               label={this.xPositiveLabel}
               length={this.boxLength}
               side="right"
-              onPointerDown={this.handleStandardView(StandardView.RIGHT)}
+              onPointerDown={this.handleStandardView(StandardView.LEFT)}
               disabled={this.standardViewsOff}
             />
             <ViewCubeSide
@@ -296,7 +296,7 @@ export class ViewerViewCube {
               length={this.boxLength}
               face1Side="front"
               face1Edge="right"
-              face2Side="left"
+              face2Side="right"
               face2Edge="left"
               onPointerDown={this.handleStandardView(StandardView.FRONT_LEFT)}
               disabled={this.standardViewsOff}
@@ -314,7 +314,7 @@ export class ViewerViewCube {
               length={this.boxLength}
               face1Side="front"
               face1Edge="left"
-              face2Side="right"
+              face2Side="left"
               face2Edge="right"
               onPointerDown={this.handleStandardView(StandardView.FRONT_RIGHT)}
               disabled={this.standardViewsOff}
@@ -323,7 +323,7 @@ export class ViewerViewCube {
               length={this.boxLength}
               face1Side="top"
               face1Edge="right"
-              face2Side="left"
+              face2Side="right"
               face2Edge="top"
               onPointerDown={this.handleStandardView(StandardView.TOP_LEFT)}
               disabled={this.standardViewsOff}
@@ -332,7 +332,7 @@ export class ViewerViewCube {
               length={this.boxLength}
               face1Side="back"
               face1Edge="left"
-              face2Side="left"
+              face2Side="right"
               face2Edge="right"
               onPointerDown={this.handleStandardView(StandardView.BACK_LEFT)}
               disabled={this.standardViewsOff}
@@ -341,7 +341,7 @@ export class ViewerViewCube {
               length={this.boxLength}
               face1Side="bottom"
               face1Edge="right"
-              face2Side="left"
+              face2Side="right"
               face2Edge="bottom"
               onPointerDown={this.handleStandardView(StandardView.BOTTOM_LEFT)}
               disabled={this.standardViewsOff}
@@ -359,7 +359,7 @@ export class ViewerViewCube {
               length={this.boxLength}
               face1Side="back"
               face1Edge="right"
-              face2Side="right"
+              face2Side="left"
               face2Edge="left"
               onPointerDown={this.handleStandardView(StandardView.BACK_RIGHT)}
               disabled={this.standardViewsOff}
@@ -377,7 +377,7 @@ export class ViewerViewCube {
               length={this.boxLength}
               face1Side="top"
               face1Edge="left"
-              face2Side="right"
+              face2Side="left"
               face2Edge="top"
               onPointerDown={this.handleStandardView(StandardView.TOP_RIGHT)}
               disabled={this.standardViewsOff}
@@ -386,7 +386,7 @@ export class ViewerViewCube {
               length={this.boxLength}
               face1Side="bottom"
               face1Edge="left"
-              face2Side="right"
+              face2Side="left"
               face2Edge="bottom"
               onPointerDown={this.handleStandardView(StandardView.BOTTOM_RIGHT)}
               disabled={this.standardViewsOff}
@@ -399,7 +399,7 @@ export class ViewerViewCube {
               face1Corner="bottom-left"
               face2Side="front"
               face2Corner="top-left"
-              face3Side="right"
+              face3Side="left"
               face3Corner="top-right"
               onPointerDown={this.handleStandardView(
                 StandardView.TOP_FRONT_RIGHT
@@ -412,7 +412,7 @@ export class ViewerViewCube {
               face1Corner="bottom-right"
               face2Side="front"
               face2Corner="top-right"
-              face3Side="left"
+              face3Side="right"
               face3Corner="top-left"
               onPointerDown={this.handleStandardView(
                 StandardView.TOP_FRONT_LEFT
@@ -425,7 +425,7 @@ export class ViewerViewCube {
               face1Corner="top-right"
               face2Side="front"
               face2Corner="bottom-right"
-              face3Side="left"
+              face3Side="right"
               face3Corner="bottom-left"
               onPointerDown={this.handleStandardView(
                 StandardView.BOTTOM_FRONT_LEFT
@@ -438,7 +438,7 @@ export class ViewerViewCube {
               face1Corner="top-left"
               face2Side="front"
               face2Corner="bottom-left"
-              face3Side="right"
+              face3Side="left"
               face3Corner="bottom-right"
               onPointerDown={this.handleStandardView(
                 StandardView.BOTTOM_FRONT_RIGHT
@@ -451,7 +451,7 @@ export class ViewerViewCube {
               face1Corner="top-right"
               face2Side="back"
               face2Corner="top-left"
-              face3Side="left"
+              face3Side="right"
               face3Corner="top-right"
               onPointerDown={this.handleStandardView(
                 StandardView.TOP_BACK_LEFT
@@ -464,7 +464,7 @@ export class ViewerViewCube {
               face1Corner="top-left"
               face2Side="back"
               face2Corner="top-right"
-              face3Side="right"
+              face3Side="left"
               face3Corner="top-left"
               onPointerDown={this.handleStandardView(
                 StandardView.TOP_BACK_RIGHT
@@ -477,7 +477,7 @@ export class ViewerViewCube {
               face1Corner="bottom-left"
               face2Side="back"
               face2Corner="bottom-right"
-              face3Side="right"
+              face3Side="left"
               face3Corner="bottom-left"
               onPointerDown={this.handleStandardView(
                 StandardView.BOTTOM_BACK_RIGHT
@@ -490,7 +490,7 @@ export class ViewerViewCube {
               face1Corner="bottom-right"
               face2Side="back"
               face2Corner="bottom-left"
-              face3Side="left"
+              face3Side="right"
               face3Corner="bottom-right"
               onPointerDown={this.handleStandardView(
                 StandardView.BOTTOM_BACK_LEFT

--- a/packages/viewer/src/lib/types/standardView.ts
+++ b/packages/viewer/src/lib/types/standardView.ts
@@ -12,12 +12,12 @@ export class StandardView {
   /**
    * A standard view that positions the camera facing the left of the scene.
    */
-  public static LEFT = new StandardView(Vector3.right(), Vector3.up());
+  public static RIGHT = new StandardView(Vector3.left(), Vector3.up());
 
   /**
    * A standard view that positions the camera facing the right of the scene.
    */
-  public static RIGHT = new StandardView(Vector3.left(), Vector3.up());
+  public static LEFT = new StandardView(Vector3.right(), Vector3.up());
 
   /**
    * A standard view that positions the camera facing the back of the scene.


### PR DESCRIPTION
## Summary

`makeRotation` was returning a row-major matrix. Our Matrix4 expects column-major.

https://vertexvis.atlassian.net/browse/PLAT-629

