### PR TITLE
[PLAT-300] Add watch for freeform template

### DIFF
--- a/packages/viewer/src/components/viewer-markup/viewer-markup.tsx
+++ b/packages/viewer/src/components/viewer-markup/viewer-markup.tsx
@@ -270,6 +270,14 @@ export class ViewerMarkup {
   /**
    * @ignore
    */
+  @Watch('freeformTemplateId')
+  protected handleFreeformTemplateIdChanged(): void {
+    this.updatePropsOnMarkupTool();
+  }
+
+  /**
+   * @ignore
+   */
   @Watch('viewer')
   protected async handleViewerChanged(
     newViewer: HTMLVertexViewerElement | undefined


### PR DESCRIPTION
## Summary

Adds a watch for the `freeformTemplateId` property on the viewer markup element. This corrects an issue on the connect-app side with the updates to modify markup color where the markup tool would not pick up the newly modified template.

## Test Plan

- Test updating the freeform markup template ID on a `<viewer-markup>` element
  - freeform markup ID on the nested `<viewer-markup-tool>` element should be updated

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
