### PR TITLE
[PLAT-287] Add lookAt shortcut

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -25,6 +25,7 @@ import { PointerInteractionHandler } from '../../lib/interactions/pointerInterac
 import { TouchInteractionHandler } from '../../lib/interactions/touchInteractionHandler';
 import { TapInteractionHandler } from '../../lib/interactions/tapInteractionHandler';
 import { FlyToPartKeyInteraction } from '../../lib/interactions/flyToPartKeyInteraction';
+import { FlyToPositionKeyInteraction } from '../../lib/interactions/flyToPositionKeyInteraction';
 import { Environment } from '../../lib/environment';
 import {
   ViewerInitializationError,
@@ -462,6 +463,14 @@ export class Viewer {
           this.stream,
           () => this.getResolvedConfig(),
           () => this.getImageScale()
+        )
+      );
+      this.registerTapKeyInteraction(
+        new FlyToPositionKeyInteraction(
+          this.stream,
+          () => this.getResolvedConfig(),
+          () => this.getImageScale(),
+          () => this.createScene()
         )
       );
     }

--- a/packages/viewer/src/lib/interactions/__tests__/flyToPartKeyInteraction.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/flyToPartKeyInteraction.spec.ts
@@ -18,10 +18,16 @@ describe(FlyToPartKeyInteraction, () => {
 
   it('Returns true for its predicate with Command or Control pressed', () => {
     expect(
-      flyToPartKeyInteraction.predicate({ ctrlKey: true } as TapEventDetails)
+      flyToPartKeyInteraction.predicate({
+        ctrlKey: true,
+        altKey: false,
+      } as TapEventDetails)
     ).toBe(false);
     expect(
-      flyToPartKeyInteraction.predicate({ metaKey: true } as TapEventDetails)
+      flyToPartKeyInteraction.predicate({
+        metaKey: true,
+        altKey: false,
+      } as TapEventDetails)
     ).toBe(false);
     expect(
       flyToPartKeyInteraction.predicate({ altKey: true } as TapEventDetails)

--- a/packages/viewer/src/lib/interactions/__tests__/flyToPartKeyInteraction.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/flyToPartKeyInteraction.spec.ts
@@ -1,6 +1,6 @@
 import { FlyToPartKeyInteraction } from '../flyToPartKeyInteraction';
 import { StreamApi } from '@vertexvis/stream-api';
-import { Config } from '../../config/config';
+import { Config } from '../../config';
 import { TapEventDetails } from '../tapEventDetails';
 import { Point } from '@vertexvis/geometry';
 
@@ -26,6 +26,15 @@ describe(FlyToPartKeyInteraction, () => {
     expect(
       flyToPartKeyInteraction.predicate({ altKey: true } as TapEventDetails)
     ).toBe(true);
+  });
+
+  it('returns false for its predicate with Shift pressed', () => {
+    expect(
+      flyToPartKeyInteraction.predicate({
+        altKey: true,
+        shiftKey: true,
+      } as TapEventDetails)
+    ).toBe(false);
   });
 
   it('Queries for hit results and fits to the item if present', async () => {

--- a/packages/viewer/src/lib/interactions/__tests__/flyToPositionKeyInteraction.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/flyToPositionKeyInteraction.spec.ts
@@ -1,0 +1,82 @@
+import { FlyToPositionKeyInteraction } from '../flyToPositionKeyInteraction';
+import { StreamApi } from '@vertexvis/stream-api';
+import { Config } from '../../config';
+import { TapEventDetails } from '../tapEventDetails';
+import { Point, Vector3 } from '@vertexvis/geometry';
+import { Scene } from '../../scenes';
+import { fromPbFrameOrThrow } from '../../mappers';
+import { Orientation } from '../../types';
+import * as ColorMaterial from '../../scenes/colorMaterial';
+import { frame } from '../../../testing/fixtures';
+
+describe(FlyToPositionKeyInteraction, () => {
+  const streamApi = new StreamApi();
+  streamApi.hitItems = jest.fn(async () => ({
+    hitItems: {
+      hits: [{ itemId: { hex: 'item-id' }, hitPoint: { x: 10, y: 20, z: 30 } }],
+    },
+  }));
+  streamApi.flyTo = jest.fn(async () => ({ flyTo: {} }));
+  const sceneViewId = 'scene-view-id';
+  const scene = new Scene(
+    streamApi,
+    frame,
+    fromPbFrameOrThrow(Orientation.DEFAULT),
+    () => Point.create(1, 1),
+    sceneViewId,
+    ColorMaterial.fromHex('#ffffff')
+  );
+  const flyToPositionKeyInteraction = new FlyToPositionKeyInteraction(
+    streamApi,
+    () => ({ animation: { durationMs: 500 } } as Config),
+    () => Point.create(1, 1),
+    () => scene
+  );
+
+  it('returns true for its predicate with Alt and Shift pressed', () => {
+    expect(
+      flyToPositionKeyInteraction.predicate({
+        ctrlKey: true,
+      } as TapEventDetails)
+    ).toBe(false);
+    expect(
+      flyToPositionKeyInteraction.predicate({
+        metaKey: true,
+      } as TapEventDetails)
+    ).toBe(false);
+    expect(
+      flyToPositionKeyInteraction.predicate({ altKey: true } as TapEventDetails)
+    ).toBe(false);
+    expect(
+      flyToPositionKeyInteraction.predicate({
+        shiftKey: true,
+      } as TapEventDetails)
+    ).toBe(false);
+    expect(
+      flyToPositionKeyInteraction.predicate({
+        altKey: true,
+        shiftKey: true,
+      } as TapEventDetails)
+    ).toBe(true);
+  });
+
+  it('queries for hit results and sets the camera lookAt to the hit position', async () => {
+    const position = Point.create(1, 1);
+    await flyToPositionKeyInteraction.fn({ position } as TapEventDetails);
+
+    expect(streamApi.hitItems).toHaveBeenCalledWith(
+      expect.objectContaining({
+        point: position,
+      }),
+      true
+    );
+
+    expect(streamApi.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        camera: expect.objectContaining({
+          lookAt: Vector3.create(10, 20, 30),
+        }),
+      })
+    );
+  });
+});

--- a/packages/viewer/src/lib/interactions/__tests__/flyToPositionKeyInteraction.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/flyToPositionKeyInteraction.spec.ts
@@ -37,19 +37,27 @@ describe(FlyToPositionKeyInteraction, () => {
     expect(
       flyToPositionKeyInteraction.predicate({
         ctrlKey: true,
+        altKey: false,
+        shiftKey: false,
       } as TapEventDetails)
     ).toBe(false);
     expect(
       flyToPositionKeyInteraction.predicate({
         metaKey: true,
+        altKey: false,
+        shiftKey: false,
       } as TapEventDetails)
     ).toBe(false);
     expect(
-      flyToPositionKeyInteraction.predicate({ altKey: true } as TapEventDetails)
+      flyToPositionKeyInteraction.predicate({
+        altKey: true,
+        shiftKey: false,
+      } as TapEventDetails)
     ).toBe(false);
     expect(
       flyToPositionKeyInteraction.predicate({
         shiftKey: true,
+        altKey: false,
       } as TapEventDetails)
     ).toBe(false);
     expect(

--- a/packages/viewer/src/lib/interactions/flyToPartKeyInteraction.ts
+++ b/packages/viewer/src/lib/interactions/flyToPartKeyInteraction.ts
@@ -15,7 +15,7 @@ export class FlyToPartKeyInteraction
   ) {}
 
   public predicate(e: TapEventDetails): boolean {
-    return !!e.altKey;
+    return !!e.altKey && !e.shiftKey;
   }
 
   public async fn(e: TapEventDetails): Promise<void> {

--- a/packages/viewer/src/lib/interactions/flyToPartKeyInteraction.ts
+++ b/packages/viewer/src/lib/interactions/flyToPartKeyInteraction.ts
@@ -15,7 +15,7 @@ export class FlyToPartKeyInteraction
   ) {}
 
   public predicate(e: TapEventDetails): boolean {
-    return !!e.altKey && !e.shiftKey;
+    return e.altKey && !e.shiftKey;
   }
 
   public async fn(e: TapEventDetails): Promise<void> {

--- a/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
+++ b/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
@@ -1,0 +1,74 @@
+import { StreamApi, toProtoDuration } from '@vertexvis/stream-api';
+import { KeyInteraction } from './keyInteraction';
+import { ConfigProvider } from '../config';
+import { TapEventDetails } from './tapEventDetails';
+import { ImageScaleProvider, Scene } from '../scenes';
+import { Point, Vector3 } from '@vertexvis/geometry';
+
+type SceneProvider = () => Scene;
+
+export class FlyToPositionKeyInteraction
+  implements KeyInteraction<TapEventDetails>
+{
+  public constructor(
+    private stream: StreamApi,
+    private configProvider: ConfigProvider,
+    private imageScaleProvider: ImageScaleProvider,
+    private sceneProvider: SceneProvider
+  ) {}
+
+  public predicate(e: TapEventDetails): boolean {
+    return !!e.altKey && !!e.shiftKey;
+  }
+
+  public async fn(e: TapEventDetails): Promise<void> {
+    const scale = this.imageScaleProvider();
+    const hitResult = await this.stream.hitItems(
+      {
+        point: Point.scale(e.position, scale?.x || 1, scale?.y || 1),
+      },
+      true
+    );
+
+    if (
+      hitResult.hitItems?.hits != null &&
+      hitResult.hitItems.hits.length > 0 &&
+      hitResult.hitItems.hits[0].hitPoint != null
+    ) {
+      const camera = this.sceneProvider().camera();
+      const hit = hitResult.hitItems.hits[0];
+
+      if (
+        hit.hitPoint != null &&
+        hit.hitPoint.x != null &&
+        hit.hitPoint.y != null &&
+        hit.hitPoint.z != null
+      ) {
+        await this.stream.flyTo({
+          camera: camera
+            .update({
+              lookAt: Vector3.create(
+                hit.hitPoint.x,
+                hit.hitPoint.y,
+                hit.hitPoint.z
+              ),
+            })
+            .toFrameCamera(),
+          animation: {
+            duration: toProtoDuration(
+              this.configProvider().animation.durationMs
+            ),
+          },
+        });
+      } else {
+        console.debug(
+          `No hit position found for fly to position [position={x: ${e.position.x}, y: ${e.position.y}}, hit-id={${hit.itemId?.hex}}]`
+        );
+      }
+    } else {
+      console.debug(
+        `No hit results found for fly to position [position={x: ${e.position.x}, y: ${e.position.y}}]`
+      );
+    }
+  }
+}

--- a/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
+++ b/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
@@ -18,7 +18,7 @@ export class FlyToPositionKeyInteraction
   ) {}
 
   public predicate(e: TapEventDetails): boolean {
-    return !!e.altKey && !!e.shiftKey;
+    return e.altKey && e.shiftKey;
   }
 
   public async fn(e: TapEventDetails): Promise<void> {


### PR DESCRIPTION
## Summary

Adds support for a "Fly to Position" keybind (`Alt` + `Shift`), and modifies the existing "Fly to Part" keybind (`Alt` + !`Shift`).

https://user-images.githubusercontent.com/5252480/147977038-6bc78afa-646a-4cb0-8958-8550157f2ef7.mov

## Test Plan

- Test fly to part (`Alt` + Click)
- Test fly to position (`Alt` + `Shift` + Click)

## Release Notes

N/A

## Possible Regressions

Fly to part

## Dependencies

N/A
