### PR TITLE
[PLAT-689] Append by default with range selection

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
+++ b/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
@@ -44,7 +44,7 @@ export async function selectRangeInSceneTree(
   viewer: HTMLVertexViewerElement,
   start: number,
   end: number,
-  { material, append = false }: ViewerSelectItemOptions
+  { material, append = true }: ViewerSelectItemOptions
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene


### PR DESCRIPTION
## Summary
We want to append to the current scene-tree by default when using multi-selection. 

## Test Plan
Try to multi-select.

## Release Notes
None

## Possible Regressions
Multi-selection

## Dependencies
None