### PR TITLE
[PLAT-542] Add method to query entity types in feature map

### DIFF
--- a/packages/viewer/src/lib/types/__tests__/featureMap.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/featureMap.spec.ts
@@ -1,0 +1,51 @@
+import { Point } from '@vertexvis/geometry';
+import { Color } from '@vertexvis/utils';
+
+import { makeFeatureMap } from '../../../testing/fixtures';
+import { EntityType } from '../entities';
+import { FeatureMap } from '../featureMap';
+
+describe(FeatureMap, () => {
+  describe(FeatureMap.prototype.getEntityType, () => {
+    const featureMap = makeFeatureMap(10, 10, ({ y }) => {
+      if (y === 0) {
+        return Color.create(0, 0, 0, EntityType.CROSS_SECTION);
+      } else if (y === 1) {
+        return Color.create(0, 0, 0, EntityType.GENERIC_GEOMETRY);
+      } else if (y === 2) {
+        return Color.create(0, 0, 0, EntityType.IMPRECISE_EDGE);
+      } else if (y === 3) {
+        return Color.create(0, 0, 0, EntityType.IMPRECISE_SURFACE);
+      } else if (y === 4) {
+        return Color.create(0, 0, 0, EntityType.PRECISE_EDGE);
+      } else if (y === 5) {
+        return Color.create(0, 0, 0, EntityType.PRECISE_SURFACE);
+      } else {
+        return Color.create(0, 0, 0, 0);
+      }
+    });
+
+    it('should return the correct entity type', () => {
+      let type = featureMap.getEntityType(Point.create(1, 0));
+      expect(type).toEqual(EntityType.CROSS_SECTION);
+
+      type = featureMap.getEntityType(Point.create(1, 1));
+      expect(type).toEqual(EntityType.GENERIC_GEOMETRY);
+
+      type = featureMap.getEntityType(Point.create(1, 2));
+      expect(type).toEqual(EntityType.IMPRECISE_EDGE);
+
+      type = featureMap.getEntityType(Point.create(1, 3));
+      expect(type).toEqual(EntityType.IMPRECISE_SURFACE);
+
+      type = featureMap.getEntityType(Point.create(1, 4));
+      expect(type).toEqual(EntityType.PRECISE_EDGE);
+
+      type = featureMap.getEntityType(Point.create(1, 5));
+      expect(type).toEqual(EntityType.PRECISE_SURFACE);
+
+      type = featureMap.getEntityType(Point.create(1, 6));
+      expect(type).toBeUndefined();
+    });
+  });
+});

--- a/packages/viewer/src/lib/types/entities.ts
+++ b/packages/viewer/src/lib/types/entities.ts
@@ -1,0 +1,37 @@
+// The source of these values are from:
+// https://github.com/Vertexvis/rendering-worker-service/blob/fc1c864d1da4b5eb12794478dc720fa046412ee2/src/embree.isph#L163
+
+/**
+ * An enumeration of the possible types of entities in a frame.
+ */
+export enum EntityType {
+  /**
+   * A value that represents the presence of a cross section.
+   */
+  CROSS_SECTION = 0xff, // == 255
+
+  /**
+   * A value that represents the presence of an edge with BREP.
+   */
+  PRECISE_EDGE = 0xe0, // == 224
+
+  /**
+   * A value that represents the presence of a surface with BREP.
+   */
+  PRECISE_SURFACE = 0xc0, // == 192
+
+  /**
+   * A value that represents the presence of an edge without BREP.
+   */
+  IMPRECISE_EDGE = 0xa0, // == 160
+
+  /**
+   * A value that represents the presence of an surface without BREP.
+   */
+  IMPRECISE_SURFACE = 0x80, // == 128
+
+  /**
+   * A value that represents the presence of geometry without BREP.
+   */
+  GENERIC_GEOMETRY = 0x60, // == 96
+}

--- a/packages/viewer/src/lib/types/featureMap.ts
+++ b/packages/viewer/src/lib/types/featureMap.ts
@@ -1,12 +1,89 @@
+import { Point } from '@vertexvis/geometry';
+import { Color } from '@vertexvis/utils';
+import type { DecodedPng } from 'fast-png';
+
+import { EntityType } from './entities';
+import { FrameImageLike, ImageAttributesLike } from './frame';
+
 /**
- * A `FeatureMap` represents the surfaces, edges and cross sections rendered in
- * a frame.
+ * A `FeatureMap` contains metadata about the location of entities and features
+ * rendered in a scene. This metadata includes any surfaces, edges, cross
+ * sections and BREP.
  */
-export class FeatureMap {
+export class FeatureMap implements FrameImageLike {
   /**
    * Constructor.
    *
-   * @param pixels The pixels containing feature information of a frame.
+   * @param pixels The PNG containing feature information of a frame.
+   * @param imageAttr The attributes of the feature map image.
    */
-  public constructor(private readonly pixels: Uint8Array) {}
+  public constructor(
+    private readonly pixels: Uint8Array,
+    public readonly imageAttr: ImageAttributesLike
+  ) {}
+
+  /**
+   * Constructs a new `FeatureMap` from a decoded PNG.
+   *
+   * @param png The decoded PNG data.
+   * @param imageAttr The image attributes of the frame.
+   * @returns A new feature map.
+   */
+  public static fromPng(
+    png: Pick<DecodedPng, 'data'>,
+    imageAttr: ImageAttributesLike
+  ): FeatureMap {
+    if (png.data instanceof Uint8Array) {
+      return new FeatureMap(png.data, imageAttr);
+    } else {
+      throw new Error(
+        'Cannot create FeatureMap. Expected decoded PNG to be a Uint8Array.'
+      );
+    }
+  }
+
+  /**
+   * Returns the type of entity at the given frame location. If no entity is
+   * found, then `undefined` is returned.
+   *
+   * @param point The point to query.
+   * @returns The type of entity at the given location, or `undefined` if no
+   * entity exists.
+   */
+  public getEntityType(point: Point.Point): EntityType | undefined {
+    const color = this.getColor(point);
+
+    if (color?.a === EntityType.CROSS_SECTION) {
+      return EntityType.CROSS_SECTION;
+    } else if (color?.a === EntityType.GENERIC_GEOMETRY) {
+      return EntityType.GENERIC_GEOMETRY;
+    } else if (color?.a === EntityType.IMPRECISE_EDGE) {
+      return EntityType.IMPRECISE_EDGE;
+    } else if (color?.a === EntityType.IMPRECISE_SURFACE) {
+      return EntityType.IMPRECISE_SURFACE;
+    } else if (color?.a === EntityType.PRECISE_EDGE) {
+      return EntityType.PRECISE_EDGE;
+    } else if (color?.a === EntityType.PRECISE_SURFACE) {
+      return EntityType.PRECISE_SURFACE;
+    }
+  }
+
+  private getColor(point: Point.Point): Color.Color | undefined {
+    const { width, height } = this.imageAttr.imageRect;
+
+    const offset = Point.subtract(point, this.imageAttr.imageRect);
+    const scale = 1 / this.imageAttr.imageScale;
+    const pixel = Point.scale(offset, scale, scale);
+
+    if (pixel.x >= 0 && pixel.y >= 0 && pixel.x < width && pixel.y < height) {
+      const index = Math.floor(pixel.x) * 4 + Math.floor(pixel.y) * 4 * width;
+
+      const r = this.pixels[index];
+      const g = this.pixels[index + 1];
+      const b = this.pixels[index + 2];
+      const a = this.pixels[index + 3];
+
+      return Color.create(r, g, b, a);
+    } else return undefined;
+  }
 }

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -57,9 +57,7 @@ export class Frame {
 
   private async decodeFeatureMap(bytes: Uint8Array): Promise<FeatureMap> {
     const png = await decodePng(bytes);
-    if (png.data instanceof Uint8Array) {
-      return new FeatureMap(png.data);
-    } else throw new Error('Feature map could not be decoded as a Uint8Array');
+    return FeatureMap.fromPng(png, this.image.imageAttr);
   }
 }
 

--- a/packages/viewer/src/lib/types/index.ts
+++ b/packages/viewer/src/lib/types/index.ts
@@ -12,6 +12,7 @@ import * as Interactions from './interactions';
 import * as LoadableResource from './loadableResource';
 
 export * from './depthBuffer';
+export * from './entities';
 export * from './featureMap';
 export * from './frame';
 export * from './markup';


### PR DESCRIPTION
## Summary

Adds a method `FeatureMap.getEntityType` to query the feature map for the type of entity at a given point.

https://vertexvis.atlassian.net/browse/PLAT-542