### PR TITLE
[PLAT-688] Scene tree cursor in Safari

### DIFF
--- a/packages/viewer/src/components/scene-tree/scene-tree.css
+++ b/packages/viewer/src/components/scene-tree/scene-tree.css
@@ -10,6 +10,8 @@
   width: 300px;
   height: 100%;
   user-select: none;
+  -webkit-user-select: none;
+  cursor: default;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Summary
In Safari, the text in the scene tree was selectable and had the text selection cursor.  After this PR, the behavior in Safari matches other browsers.

Before:

![SafariSceneTreeBefore](https://user-images.githubusercontent.com/39739917/149577924-473ba3fb-76ab-4cb0-9b63-6f6af2bed29d.gif)

After:
![SafariSceneTreeAfter](https://user-images.githubusercontent.com/39739917/149577988-0669fd55-d573-40aa-8049-7830d9eb01c0.gif)

## Test Plan
Look at the scene tree in Safari

## Release Notes
None

## Possible Regressions
Scene tree

## Dependencies
None