### PR TITLE
[PLAT-763] Maintain create overlay while drawing

### DIFF
--- a/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
+++ b/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
@@ -208,7 +208,7 @@ export class ViewerMarkupCircle {
 
       return (
         <Host>
-          <svg class="svg" onTouchStart={(event) => event.preventDefault()}>
+          <svg class="svg" onTouchStart={this.handleTouchStart}>
             <defs>
               <SvgShadow id="circle-shadow" />
             </defs>
@@ -253,6 +253,12 @@ export class ViewerMarkupCircle {
               }
             />
           )}
+          {this.mode === 'create' && (
+            <div
+              class="create-overlay"
+              onTouchStart={this.handleTouchStart}
+            ></div>
+          )}
         </Host>
       );
     } else {
@@ -260,7 +266,7 @@ export class ViewerMarkupCircle {
         <Host>
           <div
             class="create-overlay"
-            onTouchStart={(event) => event.preventDefault()}
+            onTouchStart={this.handleTouchStart}
           ></div>
         </Host>
       );
@@ -332,8 +338,16 @@ export class ViewerMarkupCircle {
     }
   };
 
+  private handleTouchStart = (event: TouchEvent): void => {
+    event.preventDefault();
+  };
+
   private startMarkup = (event: PointerEvent): void => {
-    if (this.mode !== '' && this.elementBounds != null) {
+    if (
+      this.mode !== '' &&
+      this.elementBounds != null &&
+      this.pointerId == null
+    ) {
       const position = translatePointToRelative(
         getMouseClientPosition(event, this.elementBounds),
         this.elementBounds
@@ -348,19 +362,22 @@ export class ViewerMarkupCircle {
     }
   };
 
-  private endMarkup = (): void => {
-    if (
-      this.mode !== '' &&
-      this.bounds != null &&
-      this.bounds?.width > 0 &&
-      this.bounds?.height > 0
-    ) {
-      this.editAnchor = 'bottom-right';
-      this.editEnd.emit();
-    } else {
-      this.bounds = undefined;
-    }
+  private endMarkup = (event: PointerEvent): void => {
+    if (this.pointerId === event.pointerId) {
+      if (
+        this.mode !== '' &&
+        this.bounds != null &&
+        this.bounds?.width > 0 &&
+        this.bounds?.height > 0
+      ) {
+        this.editAnchor = 'bottom-right';
+        this.editEnd.emit();
+      } else {
+        this.bounds = undefined;
+      }
 
-    this.removeDrawingInteractionListeners();
+      this.pointerId = undefined;
+      this.removeDrawingInteractionListeners();
+    }
   };
 }

--- a/packages/viewer/src/components/viewer-markup-freeform.tsx/viewer-markup-freeform.tsx
+++ b/packages/viewer/src/components/viewer-markup-freeform.tsx/viewer-markup-freeform.tsx
@@ -241,7 +241,7 @@ export class ViewerMarkupFreeform {
     if (this.screenPoints.length > 0 && this.elementBounds != null) {
       return (
         <Host>
-          <svg class="svg" onTouchStart={(event) => event.preventDefault()}>
+          <svg class="svg" onTouchStart={this.handleTouchStart}>
             <defs>
               <SvgShadow id="freeform-markup-shadow" />
             </defs>
@@ -284,6 +284,12 @@ export class ViewerMarkupFreeform {
               }
             />
           )}
+          {this.mode === 'create' && (
+            <div
+              class="create-overlay"
+              onTouchStart={this.handleTouchStart}
+            ></div>
+          )}
         </Host>
       );
     } else {
@@ -291,7 +297,7 @@ export class ViewerMarkupFreeform {
         <Host>
           <div
             class="create-overlay"
-            onTouchStart={(event) => event.preventDefault()}
+            onTouchStart={this.handleTouchStart}
           ></div>
         </Host>
       );
@@ -344,6 +350,10 @@ export class ViewerMarkupFreeform {
     if (isValidStartEvent(event)) {
       this.startMarkup(event);
     }
+  };
+
+  private handleTouchStart = (event: TouchEvent): void => {
+    event.preventDefault();
   };
 
   private updateEditAnchor = (
@@ -429,33 +439,37 @@ export class ViewerMarkupFreeform {
   };
 
   private endMarkup = (event: PointerEvent): void => {
-    if (
-      this.pointerId === event.pointerId &&
-      this.mode !== '' &&
-      this.points != null &&
-      this.points.length > 2 &&
-      this.elementBounds != null
-    ) {
-      const screenPosition = getMouseClientPosition(event, this.elementBounds);
-      const position = translatePointToRelative(
-        screenPosition,
-        this.elementBounds
-      );
+    if (this.pointerId === event.pointerId) {
+      if (
+        this.mode !== '' &&
+        this.points != null &&
+        this.points.length > 2 &&
+        this.elementBounds != null
+      ) {
+        const screenPosition = getMouseClientPosition(
+          event,
+          this.elementBounds
+        );
+        const position = translatePointToRelative(
+          screenPosition,
+          this.elementBounds
+        );
 
-      this.updateMinAndMax(position);
+        this.updateMinAndMax(position);
 
-      this.points = [...this.points, position];
-      this.screenPoints = [...this.screenPoints, screenPosition];
+        this.points = [...this.points, position];
+        this.screenPoints = [...this.screenPoints, screenPosition];
 
-      this.editEnd.emit();
-    } else {
-      this.points = undefined;
+        this.editEnd.emit();
+      } else {
+        this.points = undefined;
+      }
+
+      this.min = undefined;
+      this.max = undefined;
+      this.pointerId = undefined;
+      this.removeDrawingInteractionListeners();
     }
-
-    this.min = undefined;
-    this.max = undefined;
-    this.pointerId = undefined;
-    this.removeDrawingInteractionListeners();
   };
 
   private endEdit = (): void => {


### PR DESCRIPTION
## Summary

Updates the markup elements to continue to render the `create-overlay` div when in create mode, regardless of whether the drawing has started. This corrects an issue where starting a markup on mobile with a single touch point, then accidentally or intentionally touching the screen a second time (due to how the stylus is held, hand resting on the screen, etc) would cause the model to rotate and the markup to behave unexpectedly.

## Test Plan

- Test markup on mobile
- Test markup on desktop
- Test starting a markup on mobile with a single touch, then touching the screen a second time during the drawing

## Release Notes

N/A

## Possible Regressions

Markup

## Dependencies

N/A
