### PR TITLE
[PLAT-993] Remove getDeviceId call from viewer constructor

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -322,23 +322,25 @@ describe('vertex-viewer', () => {
   describe('device id', () => {
     it('generates and stores device id', async () => {
       const { stream, ws } = makeViewerStream();
+      const deviceId = 'device-id';
       const viewer = await newViewerSpec({
-        template: () => <vertex-viewer clientId={clientId} stream={stream} />,
+        template: () => (
+          <vertex-viewer
+            clientId={clientId}
+            stream={stream}
+            deviceId={deviceId}
+          />
+        ),
       });
-
-      const storedDeviceId = Storage.getStorageEntry(
-        Storage.StorageKeys.DEVICE_ID,
-        (records) => records['device-id']
-      );
 
       const load = jest.spyOn(stream, 'load');
       await loadViewerStreamKey(key1, { stream, ws, viewer });
 
-      expect(storedDeviceId).toBe(viewer.deviceId);
+      expect(deviceId).toBe(viewer.deviceId);
       expect(load).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        storedDeviceId,
+        deviceId,
         expect.anything()
       );
     });

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -378,7 +378,6 @@ export class Viewer {
 
   public constructor() {
     this.handleElementResize = this.handleElementResize.bind(this);
-    this.getDeviceId();
   }
 
   /**


### PR DESCRIPTION
## Summary

Ran into issues upgrading the Xamarin SDK to latest due to attempts to access local storage to retrieve a device ID. Xamarin will set this value prior to loading a model so it avoids the lookup, but this constructor call still attempts a lookup before the ID can be set. Didn't appear to be any need for that constructor lookup, so this PR removes it.

## Test Plan

- Verify the device ID in local storage still persists and is used as expected

## Release Notes

N/A

## Possible Regressions

Device ID lookups

## Dependencies

N/A
