### PR TITLE
[PLAT-1009] Fix measurement overlay lines

### DIFF
--- a/packages/viewer/src/components/viewer-measurement-distance/utils.ts
+++ b/packages/viewer/src/components/viewer-measurement-distance/utils.ts
@@ -1,4 +1,4 @@
-import { Line3, Matrix4, Point, Vector3 } from '@vertexvis/geometry';
+import { Line3, Point } from '@vertexvis/geometry';
 
 import { FramePerspectiveCamera, Viewport } from '../../lib/types';
 
@@ -14,18 +14,8 @@ export interface MeasurementElementPositions {
 }
 
 export interface RenderParams {
-  projectionViewMatrix: Matrix4.Matrix4;
   viewport: Viewport;
   camera: FramePerspectiveCamera;
-}
-
-export function translateWorldPtToViewport(
-  pt: Vector3.Vector3,
-  projectionViewMatrix: Matrix4.Matrix4,
-  viewport: Viewport
-): Point.Point {
-  const ndc = Vector3.transformMatrix(pt, projectionViewMatrix);
-  return viewport.transformVectorToViewport(ndc);
 }
 
 export function translateWorldLineToViewport(
@@ -37,7 +27,7 @@ export function translateWorldLineToViewport(
   hideStart: boolean;
   hideEnd: boolean;
 } {
-  const { camera, projectionViewMatrix, viewport } = params;
+  const { camera, viewport } = params;
 
   const isStartBehindCamera = camera.isPointBehindNear(line.start);
   const isEndBehindCamera = camera.isPointBehindNear(line.end);
@@ -52,7 +42,7 @@ export function translateWorldLineToViewport(
       end: isEndBehindCamera && pt != null ? pt : line.end,
     });
 
-    const ndc = Line3.transformMatrix(newLine, projectionViewMatrix);
+    const ndc = Line3.transformMatrix(newLine, camera.projectionViewMatrix);
     return {
       start: viewport.transformVectorToViewport(ndc.start),
       end: viewport.transformVectorToViewport(ndc.end),
@@ -60,7 +50,7 @@ export function translateWorldLineToViewport(
       hideEnd: isEndBehindCamera,
     };
   } else {
-    const ndc = Line3.transformMatrix(line, projectionViewMatrix);
+    const ndc = Line3.transformMatrix(line, camera.projectionViewMatrix);
     return {
       start: viewport.transformVectorToViewport(ndc.start),
       end: viewport.transformVectorToViewport(ndc.end),
@@ -104,9 +94,8 @@ function getIndicatorPtForAnchor(
   anchor: Anchor,
   params: RenderParams
 ): Point.Point {
-  return translateWorldPtToViewport(
+  return params.viewport.transformWorldToViewport(
     anchor === 'start' ? line.start : line.end,
-    params.projectionViewMatrix,
-    params.viewport
+    params.camera.projectionViewMatrix
   );
 }

--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
@@ -10,7 +10,7 @@ import {
   State,
   Watch,
 } from '@stencil/core';
-import { Line3, Matrix4, Point, Vector3 } from '@vertexvis/geometry';
+import { Line3, Point, Vector3 } from '@vertexvis/geometry';
 import { Disposable } from '@vertexvis/utils';
 
 import {
@@ -46,7 +46,6 @@ import {
   Anchor,
   getViewingElementPositions,
   MeasurementElementPositions,
-  translateWorldPtToViewport,
 } from './utils';
 import { DistanceMeasurementRenderer } from './viewer-measurement-distance-components';
 
@@ -535,10 +534,7 @@ export class ViewerMeasurementDistance {
   private computeEditOrViewElementPositions(): MeasurementElementPositions {
     const measurement = this.model.getMeasurement();
     if (this.internalCamera != null && measurement != null) {
-      return this.computeLineElementPositions(
-        this.internalCamera.projectionViewMatrix,
-        Line3.create(measurement)
-      );
+      return this.computeLineElementPositions(Line3.create(measurement));
     } else {
       return {};
     }
@@ -550,18 +546,14 @@ export class ViewerMeasurementDistance {
 
       const line =
         measurement != null
-          ? this.computeLineElementPositions(
-              this.internalCamera.projectionViewMatrix,
-              Line3.create(measurement)
-            )
+          ? this.computeLineElementPositions(Line3.create(measurement))
           : {};
       const indicator =
         this.indicatorPt != null
           ? {
-              indicatorPt: translateWorldPtToViewport(
+              indicatorPt: this.viewport.transformWorldToViewport(
                 this.indicatorPt,
-                this.internalCamera.projectionViewMatrix,
-                this.viewport
+                this.internalCamera.projectionViewMatrix
               ),
             }
           : {};
@@ -573,12 +565,10 @@ export class ViewerMeasurementDistance {
   }
 
   private computeLineElementPositions(
-    matrix: Matrix4.Matrix4,
     line: Line3.Line3
   ): MeasurementElementPositions {
     if (this.internalCamera != null) {
       return getViewingElementPositions(line, this.interactingAnchor, {
-        projectionViewMatrix: matrix,
         viewport: this.viewport,
         camera: this.internalCamera,
       });

--- a/packages/viewer/src/components/viewer-measurement-overlays/viewer-measurement-overlays-components.tsx
+++ b/packages/viewer/src/components/viewer-measurement-overlays/viewer-measurement-overlays-components.tsx
@@ -7,6 +7,10 @@ import {
   MeasurementOverlay,
 } from '../../lib/measurement';
 import { FramePerspectiveCamera, Viewport } from '../../lib/types';
+import {
+  RenderParams,
+  translateWorldLineToViewport,
+} from '../viewer-measurement-distance/utils';
 
 interface MeasurementOverlayViewProps<O extends MeasurementOverlay> {
   overlay: O;
@@ -34,17 +38,20 @@ export const MeasurementOverlayView: FunctionalComponent<
 
 const LineOverlayView: FunctionalComponent<
   MeasurementOverlayViewProps<LineOverlay>
-> = ({ overlay: { start, end }, camera, viewport }) => {
+> = ({ overlay, camera, viewport }) => {
   const m = camera.projectionViewMatrix;
 
-  const sw = viewport.transformWorldToViewport(start, m);
-  const ew = viewport.transformWorldToViewport(end, m);
+  const { start, end } = translateWorldLineToViewport(overlay, {
+    camera,
+    projectionViewMatrix: m,
+    viewport,
+  });
 
   return (
     <vertex-viewer-measurement-line
       class="measurement-line"
-      start={sw}
-      end={ew}
+      start={start}
+      end={end}
     />
   );
 };
@@ -53,13 +60,11 @@ const DistanceVectorOverlayView: FunctionalComponent<
   MeasurementOverlayViewProps<DistanceVectorOverlay>
 > = ({ overlay: { x, y, z }, camera, viewport }) => {
   const m = camera.projectionViewMatrix;
+  const params: RenderParams = { camera, projectionViewMatrix: m, viewport };
 
-  const xs = viewport.transformWorldToViewport(x.start, m);
-  const xe = viewport.transformWorldToViewport(x.end, m);
-  const ys = viewport.transformWorldToViewport(y.start, m);
-  const ye = viewport.transformWorldToViewport(y.end, m);
-  const zs = viewport.transformWorldToViewport(z.start, m);
-  const ze = viewport.transformWorldToViewport(z.end, m);
+  const { start: xs, end: xe } = translateWorldLineToViewport(x, params);
+  const { start: ys, end: ye } = translateWorldLineToViewport(y, params);
+  const { start: zs, end: ze } = translateWorldLineToViewport(z, params);
 
   return (
     <Fragment>

--- a/packages/viewer/src/components/viewer-measurement-overlays/viewer-measurement-overlays-components.tsx
+++ b/packages/viewer/src/components/viewer-measurement-overlays/viewer-measurement-overlays-components.tsx
@@ -39,11 +39,8 @@ export const MeasurementOverlayView: FunctionalComponent<
 const LineOverlayView: FunctionalComponent<
   MeasurementOverlayViewProps<LineOverlay>
 > = ({ overlay, camera, viewport }) => {
-  const m = camera.projectionViewMatrix;
-
   const { start, end } = translateWorldLineToViewport(overlay, {
     camera,
-    projectionViewMatrix: m,
     viewport,
   });
 
@@ -59,8 +56,7 @@ const LineOverlayView: FunctionalComponent<
 const DistanceVectorOverlayView: FunctionalComponent<
   MeasurementOverlayViewProps<DistanceVectorOverlay>
 > = ({ overlay: { x, y, z }, camera, viewport }) => {
-  const m = camera.projectionViewMatrix;
-  const params: RenderParams = { camera, projectionViewMatrix: m, viewport };
+  const params: RenderParams = { camera, viewport };
 
   const { start: xs, end: xe } = translateWorldLineToViewport(x, params);
   const { start: ys, end: ye } = translateWorldLineToViewport(y, params);


### PR DESCRIPTION
## Summary

Measurement overlay lines would appear mispositioned if one of its anchors was positioned behind the camera. Now the lines are clipped to the screen plane.

https://vertexvis.atlassian.net/browse/PLAT-1009
