### PR TITLE
[PLAT-895] Add withPoint query

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1142,6 +1142,7 @@ export class Viewer {
       frame,
       fromPbFrameOrThrow(worldOrientation),
       () => this.getImageScale(),
+      this.viewport,
       sceneViewId,
       selectionMaterial
     );

--- a/packages/viewer/src/lib/scenes/__tests__/queries.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/queries.spec.ts
@@ -1,3 +1,4 @@
+import { Point } from '@vertexvis/geometry';
 import { UUID } from '@vertexvis/utils';
 
 import { RootQuery } from '../queries';
@@ -110,6 +111,16 @@ describe(RootQuery, () => {
           type: 'supplied-id',
         },
       ],
+    });
+  });
+
+  it('should support point queries', () => {
+    const point = Point.create(50, 50);
+    const itemQueryBuilder = new RootQuery().withPoint(point);
+
+    expect(itemQueryBuilder.build()).toEqual({
+      type: 'point',
+      point,
     });
   });
 });

--- a/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
@@ -6,7 +6,7 @@ import { UUID } from '@vertexvis/utils';
 
 import { makeFrame } from '../../../testing/fixtures';
 import { fromPbFrameOrThrow } from '../../mappers';
-import { Orientation } from '../../types';
+import { Orientation, Viewport } from '../../types';
 import * as ColorMaterial from '../colorMaterial';
 import { Scene } from '../scene';
 
@@ -14,12 +14,14 @@ describe(Scene, () => {
   const sceneViewId: UUID.UUID = UUID.create();
   const streamApi = new StreamApi();
   const imageScaleProvider = (): Point.Point => Point.create(1, 1);
+  const viewport = new Viewport(50, 50);
   const colorMaterial = ColorMaterial.fromHex('#ff0000');
   const scene = new Scene(
     streamApi,
     makeFrame(),
     fromPbFrameOrThrow(Orientation.DEFAULT),
     imageScaleProvider,
+    viewport,
     sceneViewId,
     colorMaterial
   );

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -1,4 +1,5 @@
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
+import { Dimensions } from '@vertexvis/geometry';
 import { toProtoDuration } from '@vertexvis/stream-api';
 import { UUID } from '@vertexvis/utils';
 
@@ -6,9 +7,14 @@ import { Animation, FlyTo } from '../types';
 import { ItemOperation } from './operations';
 import { QueryExpression } from './queries';
 
+export interface BuildSceneOperationContext {
+  dimensions: Dimensions.Dimensions;
+}
+
 export function buildSceneOperation(
   query: QueryExpression,
-  operations: ItemOperation[]
+  operations: ItemOperation[],
+  context: BuildSceneOperationContext
 ): vertexvis.protobuf.stream.ISceneOperation {
   const operationTypes = buildOperationTypes(operations);
 
@@ -56,6 +62,14 @@ export function buildSceneOperation(
       return {
         override: {
           selection: {},
+        },
+        operationTypes,
+      };
+    case 'point':
+      return {
+        point: {
+          point: query.point,
+          viewport: context.dimensions,
         },
         operationTypes,
       };

--- a/packages/viewer/src/lib/scenes/queries.ts
+++ b/packages/viewer/src/lib/scenes/queries.ts
@@ -1,3 +1,5 @@
+import { Point } from '@vertexvis/geometry';
+
 import { ColorMaterial } from './colorMaterial';
 import { SceneItemOperationsBuilder } from './scene';
 
@@ -40,6 +42,11 @@ interface AllSelectedQueryExpression {
   type: 'all-selected';
 }
 
+interface PointQueryExpression {
+  type: 'point';
+  point: Point.Point;
+}
+
 /**
  * Represents the sum of all possible types of expressions.
  */
@@ -49,6 +56,7 @@ export type QueryExpression =
   | AndExpression
   | OrExpression
   | SceneTreeRangeQueryExpression
+  | PointQueryExpression
   | MetadataQueryExpression
   | AllSelectedQueryExpression;
 
@@ -103,6 +111,10 @@ export class RootQuery implements ItemQuery<SingleQuery> {
   public withSelected(): AllSelectedQuery {
     return new AllSelectedQuery();
   }
+
+  public withPoint(point: Point.Point): PointQuery {
+    return new PointQuery(point);
+  }
 }
 
 export class AllQuery implements TerminalQuery {
@@ -138,6 +150,17 @@ export class AllSelectedQuery implements TerminalQuery {
   public build(): AllSelectedQueryExpression {
     return {
       type: 'all-selected',
+    };
+  }
+}
+
+export class PointQuery implements TerminalQuery {
+  public constructor(private point: Point.Point) {}
+
+  public build(): PointQueryExpression {
+    return {
+      type: 'point',
+      point: this.point,
     };
   }
 }

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -180,6 +180,7 @@ export class ItemsOperationExecutor {
   public constructor(
     private sceneViewId: UUID.UUID,
     private stream: StreamApi,
+    private dimensions: Dimensions.Dimensions,
     private queryOperations: QueryOperation[]
   ) {}
 
@@ -187,7 +188,9 @@ export class ItemsOperationExecutor {
     executionOptions?: SceneExecutionOptions
   ): Promise<void> {
     const pbOperations = this.queryOperations.map((op) =>
-      buildSceneOperation(op.query, op.operations)
+      buildSceneOperation(op.query, op.operations, {
+        dimensions: this.dimensions,
+      })
     );
     const request = {
       sceneViewId: {
@@ -224,6 +227,7 @@ export class Scene {
     private frame: Frame,
     private decodeFrame: FrameDecoder,
     private imageScaleProvider: ImageScaleProvider,
+    private dimensions: Dimensions.Dimensions,
     public readonly sceneViewId: UUID.UUID,
     private defaultSelectionMaterial: ColorMaterial
   ) {}
@@ -285,6 +289,7 @@ export class Scene {
     return new ItemsOperationExecutor(
       this.sceneViewId,
       this.stream,
+      this.dimensions,
       operationList
     );
   }


### PR DESCRIPTION
## Summary

Adds a `withPoint` query that takes a point from a tap event to avoid needing to perform an explicit hit request for hit-based operations.

## Test Plan

- Test the `withPoint` query
  - Particularly on scaled up viewports to verify it operates on the correct item

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
