### PR TITLE
[PLAT-1131] Trivial support for Web SDK in iframes

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1223,16 +1223,27 @@ export class Viewer {
 
   private getDeviceId(): string | undefined {
     if (this.deviceId == null) {
-      this.deviceId = getStorageEntry(
-        StorageKeys.DEVICE_ID,
-        (entry) => entry['device-id']
-      );
+      try {
+        this.deviceId = getStorageEntry(
+          StorageKeys.DEVICE_ID,
+          (entry) => entry['device-id']
+        );
+      } catch (e) {
+        console.warn('Cannot read device ID. Local storage is not supported.');
+      }
 
       if (this.deviceId == null) {
         this.deviceId = UUID.create();
-        upsertStorageEntry(StorageKeys.DEVICE_ID, {
-          ['device-id']: this.deviceId,
-        });
+
+        try {
+          upsertStorageEntry(StorageKeys.DEVICE_ID, {
+            ['device-id']: this.deviceId,
+          });
+        } catch (e) {
+          console.warn(
+            'Cannot write device ID. Local storage is not supported.'
+          );
+        }
       }
     }
     return this.deviceId;


### PR DESCRIPTION
## Summary

While testing support for local development in PowerBI, the SDK was throwing an error because iframes don't have access to local storage when loading a local file. This will log a warning if trying to retrieve/save the device ID.

https://vertexvis.atlassian.net/browse/PLAT-1131