### PR TITLE
[PLAT-1151] Fix rotate around tap

### DIFF
--- a/packages/viewer/src/lib/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/camera.spec.ts
@@ -6,6 +6,7 @@ import { StreamApi, toProtoDuration } from '@vertexvis/stream-api';
 import { UUID } from '@vertexvis/utils';
 
 import { FrameCamera } from '../../types';
+import { fromBoundingBoxAndPerspectiveCamera } from '../../types/clippingPlanes';
 import { Camera } from '../camera';
 
 describe(Camera, () => {
@@ -351,12 +352,6 @@ describe(Camera, () => {
         Vector3.create(-1, -1, -1),
         Vector3.create(1, 1, 1)
       );
-      const boundingBoxCenter = BoundingBox.center(newBoundingBox);
-      const centerToBoundingPlane = Vector3.subtract(
-        newBoundingBox.max,
-        boundingBoxCenter
-      );
-      const radius = 1.1 * Vector3.magnitude(centerToBoundingPlane);
 
       const newCamera = new Camera(
         stream,
@@ -370,8 +365,13 @@ describe(Camera, () => {
         newBoundingBox
       );
 
-      expect(newCamera.far).toBe(1 + radius);
-      expect(newCamera.near).toBe((1 + radius) * 0.01);
+      const { near, far } = fromBoundingBoxAndPerspectiveCamera(
+        newBoundingBox,
+        newCamera
+      );
+
+      expect(newCamera.far).toBe(far);
+      expect(newCamera.near).toBe(near);
     });
   });
 });

--- a/packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts
@@ -92,14 +92,14 @@ describe(DepthBuffer, () => {
   });
 
   describe(DepthBuffer.prototype.getWorldPoint, () => {
-    const camera = FramePerspectiveCamera.fromBoundingBox(
-      {
-        position: { x: 0, y: 0, z: 5 },
-        lookAt: Vector3.origin(),
-        up: Vector3.up(),
-      },
-      BoundingBox.create(Vector3.origin(), { x: 0, y: 0, z: 100 }),
-      1
+    const camera = new FramePerspectiveCamera(
+      { x: 0, y: 0, z: 5 },
+      Vector3.origin(),
+      Vector3.up(),
+      1,
+      100,
+      1,
+      45
     );
 
     function createDepthBufferWithDepth(depthValue: number): {


### PR DESCRIPTION
## Summary

Corrects the calculation of the `near` and `far` clipping plane values to match those computed in RCL.

Also created https://vertexvis.atlassian.net/browse/PLAT-1187 to discuss/address this issue in the future.

## Test Plan

- Test rotate around tap when zoomed in close to a part

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
