### PR TITLE
[PLAT-267] Move camera type checks

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1131,8 +1131,7 @@ export class Viewer {
       );
     }
 
-    return this.frame == null ||
-      FrameCamera.isPerspectiveFrameCamera(this.frame.scene.camera)
+    return this.frame == null || this.frame.scene.camera.isPerspective()
       ? new InteractionApiPerspective(
           this.stream,
           this.stateMap.cursorManager,
@@ -1246,11 +1245,11 @@ export class Viewer {
   private updateInteractionApi(previousFrame?: Frame): void {
     if (previousFrame != null && this.frame != null) {
       const hasChangedFromPerspective =
-        FrameCamera.isPerspectiveFrameCamera(previousFrame.scene.camera) &&
-        FrameCamera.isPerspectiveFrameCamera(this.frame.scene.camera);
+        previousFrame.scene.camera.isPerspective() &&
+        this.frame.scene.camera.isOrthographic();
       const hasChangedFromOrthographic =
-        FrameCamera.isOrthographicFrameCamera(previousFrame.scene.camera) &&
-        FrameCamera.isOrthographicFrameCamera(this.frame.scene.camera);
+        previousFrame.scene.camera.isOrthographic() &&
+        this.frame.scene.camera.isPerspective();
 
       if (hasChangedFromPerspective || hasChangedFromOrthographic) {
         this.interactionApi = this.createInteractionApi();
@@ -1262,7 +1261,7 @@ export class Viewer {
     if (this.frame != null) {
       if (
         this.cameraType === 'orthographic' &&
-        FrameCamera.isPerspectiveFrameCamera(this.frame.scene.camera)
+        this.frame.scene.camera.isPerspective()
       ) {
         this.stream?.replaceCamera({
           camera: FrameCamera.toProtobuf(
@@ -1271,7 +1270,7 @@ export class Viewer {
         });
       } else if (
         this.cameraType === 'perspective' &&
-        FrameCamera.isOrthographicFrameCamera(this.frame.scene.camera)
+        this.frame.scene.camera.isOrthographic()
       ) {
         this.stream?.replaceCamera({
           camera: FrameCamera.toProtobuf(

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -301,7 +301,7 @@ export class Scene {
   public camera(): Camera {
     const { scene } = this.frame;
 
-    if (scene.camera instanceof FrameOrthographicCamera) {
+    if (scene.camera.isOrthographic()) {
       return new OrthographicCamera(
         this.stream,
         Dimensions.aspectRatio(this.viewport()),
@@ -314,7 +314,7 @@ export class Scene {
         this.frame.scene.boundingBox,
         this.decodeFrame
       );
-    } else if (scene.camera instanceof FramePerspectiveCamera) {
+    } else if (scene.camera.isPerspective()) {
       return new PerspectiveCamera(
         this.stream,
         Dimensions.aspectRatio(this.viewport()),

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -5,7 +5,6 @@ import { UUID } from '@vertexvis/utils';
 
 import { InvalidArgumentError, InvalidCameraError } from '../errors';
 import { FrameDecoder } from '../mappers';
-import { FrameOrthographicCamera, FramePerspectiveCamera } from '../types';
 import { Frame } from '../types/frame';
 import { Camera, OrthographicCamera, PerspectiveCamera } from '.';
 import { ColorMaterial, fromHex } from './colorMaterial';

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -275,7 +275,7 @@ export class FramePerspectiveCamera
     public readonly near: number,
     public readonly far: number,
     public readonly aspectRatio: number,
-    public readonly fovY: number
+    public readonly fovY = 45
   ) {
     super(position, lookAt, up, near, far, aspectRatio);
   }

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -190,6 +190,14 @@ export class FrameCameraBase implements FrameCameraLike {
     }
   }
 
+  public isOrthographic(): this is FrameOrthographicCamera {
+    return false;
+  }
+
+  public isPerspective(): this is FramePerspectiveCamera {
+    return false;
+  }
+
   /**
    * Checks if the given point, in world space, is behind the near plane
    * of the camera.
@@ -272,6 +280,10 @@ export class FramePerspectiveCamera
     super(position, lookAt, up, near, far, aspectRatio);
   }
 
+  public override isPerspective(): this is FramePerspectiveCamera {
+    return true;
+  }
+
   protected override computeCameraMatrices(): FrameCameraMatrices {
     if (this.cameraMatrices == null) {
       const viewMatrix = Matrix4.makeLookAtView(
@@ -334,6 +346,10 @@ export class FrameOrthographicCamera
     this.bottom = -this.top;
     this.right = this.top * aspectRatio;
     this.left = -this.right;
+  }
+
+  public override isOrthographic(): this is FrameOrthographicCamera {
+    return true;
   }
 
   protected override computeCameraMatrices(): FrameCameraMatrices {

--- a/packages/viewer/src/lib/types/frameCamera.ts
+++ b/packages/viewer/src/lib/types/frameCamera.ts
@@ -84,7 +84,7 @@ export function toOrthographic(
     fovHeight:
       2 *
       Vector3.magnitude(viewVector) *
-      Math.tan(Angle.toRadians(data.fovY ?? 45 / 2.0)),
+      Math.tan(Angle.toRadians((data.fovY ?? 45) / 2.0)),
   };
 }
 


### PR DESCRIPTION
## Summary

Adds an `isOrthographic` and `isPerspective` method to the `FrameCameraBase` to avoid having to do `instanceof` checks. Additionally, this corrects an issue where the connect-app was unable to use the helpers for checking the type of a camera.

## Test Plan

- Test changing between perspective and orthographic cameras

## Release Notes

N/A

## Possible Regressions

Changing between orthographic and perspective cameras

## Dependencies

N/A
