### PR TITLE
[PLAT-271] Orthographic depth buffer support

### DIFF
--- a/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
@@ -17,7 +17,9 @@ export const Renderer3d: FunctionalComponent<Props> = (
   children
 ) => {
   const pMatrix = Matrix4.toObject(camera.projectionMatrix);
-  const fovY = pMatrix.m22 * (viewport.height / 2);
+  const fovY = camera.isOrthographic()
+    ? (2 * camera.near) / (2 * camera.fovHeight)
+    : pMatrix.m22 * (viewport.height / 2);
   const cameraTransform = [
     `translateZ(${fovY}px)`,
     getCameraCssMatrix(camera.viewMatrix),

--- a/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
@@ -17,9 +17,7 @@ export const Renderer3d: FunctionalComponent<Props> = (
   children
 ) => {
   const pMatrix = Matrix4.toObject(camera.projectionMatrix);
-  const fovY = camera.isOrthographic()
-    ? (2 * camera.near) / (2 * camera.fovHeight)
-    : pMatrix.m22 * (viewport.height / 2);
+  const fovY = pMatrix.m22 * (viewport.height / 2);
   const cameraTransform = [
     `translateZ(${fovY}px)`,
     getCameraCssMatrix(camera.viewMatrix),

--- a/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
@@ -174,6 +174,9 @@ export class ViewerDomRenderer {
 
     this.depthBuffer =
       depthBuffers === 'all' ? await frame?.depthBuffer() : undefined;
-    this.camera = frame?.scene?.camera;
+    this.camera =
+      frame?.scene.camera != null && frame.scene.camera.isOrthographic()
+        ? frame.scene.camera.toPerspective(frame.scene.boundingBox)
+        : frame?.scene?.camera;
   }
 }

--- a/packages/viewer/src/components/viewer-measurement-distance/__tests__/hitTest.spec.ts
+++ b/packages/viewer/src/components/viewer-measurement-distance/__tests__/hitTest.spec.ts
@@ -1,0 +1,56 @@
+import { BoundingBox, Point, Ray, Vector3 } from '@vertexvis/geometry';
+
+import { FrameCamera, FrameCameraBase, Viewport } from '../../../lib/types';
+import { makeDepthBuffer, makeStencilBuffer } from '../../../testing/fixtures';
+import { PointToPointHitTester } from '../hitTest';
+
+describe(PointToPointHitTester, () => {
+  describe('with an orthographic camera', () => {
+    const camera = FrameCameraBase.fromBoundingBox(
+      FrameCamera.createOrthographic(),
+      BoundingBox.create(Vector3.create(-1, -1, -1), Vector3.create(1, 1, 1)),
+      1
+    );
+
+    const viewport = new Viewport(100, 100);
+    const depthBuffer = makeDepthBuffer(100, 100, undefined, camera);
+    const depth = camera.far - camera.near + camera.near / 2;
+    const ray = viewport.transformPointToOrthographicRay(
+      Point.create(10, 10),
+      depthBuffer,
+      camera
+    );
+
+    it('transforms points to world coordinates for orthographic cameras with hit test', () => {
+      const hitTester = new PointToPointHitTester(
+        makeStencilBuffer(100, 100, () => 1, depthBuffer),
+        depthBuffer,
+        viewport,
+        camera
+      );
+
+      expect(
+        hitTester.transformPointToWorld(Point.create(10, 10))
+      ).toMatchObject(Ray.at(ray, depth));
+    });
+
+    it('transforms points to world coordinates for orthographic cameras with hit test', () => {
+      const failingHitTestBuffer = makeDepthBuffer(100, 100, undefined, camera);
+
+      jest.spyOn(failingHitTestBuffer, 'hitTest').mockReturnValue(false);
+
+      const hitTester = new PointToPointHitTester(
+        undefined,
+        failingHitTestBuffer,
+        viewport,
+        camera
+      );
+
+      expect(
+        hitTester.transformPointToWorld(Point.create(10, 10), {
+          ignoreHitTest: true,
+        })
+      ).toMatchObject(Ray.at(ray, depth));
+    });
+  });
+});

--- a/packages/viewer/src/components/viewer-measurement-distance/hitTest.ts
+++ b/packages/viewer/src/components/viewer-measurement-distance/hitTest.ts
@@ -12,7 +12,7 @@ export class PointToPointHitTester {
     private stencil: StencilBuffer | undefined,
     private depthBuffer: DepthBuffer,
     private viewport: Viewport,
-    private camera: FrameCameraBase
+    private camera?: FrameCameraBase
   ) {}
 
   public hitTest(pt: Point.Point): boolean {
@@ -42,11 +42,11 @@ export class PointToPointHitTester {
     const buffer = this.pickDepthBuffer(pt);
 
     if (buffer != null) {
-      return this.camera.isPerspective()
+      return this.camera == null || this.camera.isPerspective()
         ? this.viewport.transformPointToWorldSpace(pt, buffer)
         : this.viewport.transformPointToOrthographicWorldSpace(pt, buffer);
     } else if (ignoreHitTest) {
-      return this.camera.isPerspective()
+      return this.camera == null || this.camera.isPerspective()
         ? this.viewport.transformPointToWorldSpace(pt, this.depthBuffer)
         : this.viewport.transformPointToOrthographicWorldSpace(
             pt,

--- a/packages/viewer/src/components/viewer-measurement-distance/hitTest.ts
+++ b/packages/viewer/src/components/viewer-measurement-distance/hitTest.ts
@@ -1,12 +1,18 @@
 import { Point, Vector3 } from '@vertexvis/geometry';
 
-import { DepthBuffer, StencilBuffer, Viewport } from '../../lib/types';
+import {
+  DepthBuffer,
+  FrameCameraBase,
+  StencilBuffer,
+  Viewport,
+} from '../../lib/types';
 
 export class PointToPointHitTester {
   public constructor(
     private stencil: StencilBuffer | undefined,
     private depthBuffer: DepthBuffer,
-    private viewport: Viewport
+    private viewport: Viewport,
+    private camera: FrameCameraBase
   ) {}
 
   public hitTest(pt: Point.Point): boolean {
@@ -36,9 +42,16 @@ export class PointToPointHitTester {
     const buffer = this.pickDepthBuffer(pt);
 
     if (buffer != null) {
-      return this.viewport.transformPointToWorldSpace(pt, buffer);
+      return this.camera.isPerspective()
+        ? this.viewport.transformPointToWorldSpace(pt, buffer)
+        : this.viewport.transformPointToOrthographicWorldSpace(pt, buffer);
     } else if (ignoreHitTest) {
-      return this.viewport.transformPointToWorldSpace(pt, this.depthBuffer);
+      return this.camera.isPerspective()
+        ? this.viewport.transformPointToWorldSpace(pt, this.depthBuffer)
+        : this.viewport.transformPointToOrthographicWorldSpace(
+            pt,
+            this.depthBuffer
+          );
     }
   }
 

--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.spec.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.spec.tsx
@@ -9,7 +9,7 @@ import { Point, Vector3 } from '@vertexvis/geometry';
 
 import { loadImageBytes } from '../../lib/rendering/imageLoaders';
 import {
-  FrameCameraBase,
+  FramePerspectiveCamera,
   STENCIL_BUFFER_EMPTY_VALUE,
   STENCIL_BUFFER_FEATURE_VALUE,
   Viewport,
@@ -27,7 +27,7 @@ import { getMeasurementBoundingClientRect } from './dom';
 import { ViewerMeasurementDistance } from './viewer-measurement-distance';
 
 describe('vertex-viewer-measurement-distance', () => {
-  const camera = new FrameCameraBase(
+  const camera = new FramePerspectiveCamera(
     Vector3.create(0, 0, 100),
     Vector3.origin(),
     Vector3.up(),

--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
@@ -891,7 +891,7 @@ export class ViewerMeasurementDistance {
 
   private getHitTester(): PointToPointHitTester | undefined {
     const { stencil, depthBuffer } = this.stateMap;
-    if (depthBuffer != null && this.internalCamera != null) {
+    if (depthBuffer != null) {
       return new PointToPointHitTester(
         stencil,
         depthBuffer,

--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
@@ -891,8 +891,13 @@ export class ViewerMeasurementDistance {
 
   private getHitTester(): PointToPointHitTester | undefined {
     const { stencil, depthBuffer } = this.stateMap;
-    if (depthBuffer != null) {
-      return new PointToPointHitTester(stencil, depthBuffer, this.viewport);
+    if (depthBuffer != null && this.internalCamera != null) {
+      return new PointToPointHitTester(
+        stencil,
+        depthBuffer,
+        this.viewport,
+        this.internalCamera
+      );
     }
   }
 

--- a/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
@@ -118,7 +118,7 @@ describe(InteractionApi, () => {
 
       expect(update).toHaveBeenCalledTimes(2);
       expect(update.mock.calls[1][0].lookAt).toMatchObject({
-        x: -2,
+        x: -1,
         y: 0,
         z: 0,
       });

--- a/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
+++ b/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
@@ -212,11 +212,6 @@ export class InteractionApiOrthographic extends InteractionApi {
     const viewport = this.getViewport();
     const framePt = viewport.transformPointToFrame(point, depthBuffer);
     const hasDepth = depthBuffer.hitTest(framePt);
-    console.log(
-      hasDepth
-        ? viewport.transformPointToOrthographicWorldSpace(point, depthBuffer)
-        : fallbackPoint
-    );
     return hasDepth
       ? viewport.transformPointToOrthographicWorldSpace(point, depthBuffer)
       : fallbackPoint;

--- a/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
+++ b/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
@@ -186,13 +186,14 @@ export class InteractionApiOrthographic extends InteractionApi {
       }
 
       if (this.orthographicZoomData != null) {
-        const { hitPt } = this.orthographicZoomData;
+        const { hitPt, hitPlane } = this.orthographicZoomData;
 
         const relativeDelta = 2 * (camera.fovHeight / viewport.height) * delta;
         const fovHeight = Math.max(1, camera.fovHeight - relativeDelta);
+        const projectedLookAt = Plane.projectPoint(hitPlane, camera.lookAt);
         const diff = Vector3.scale(
           (camera.fovHeight - fovHeight) / camera.fovHeight,
-          Vector3.subtract(hitPt, camera.lookAt)
+          Vector3.subtract(hitPt, projectedLookAt)
         );
 
         return camera.update({

--- a/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
+++ b/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
@@ -5,14 +5,8 @@ import { StreamApi } from '@vertexvis/stream-api';
 import { ReceivedFrame } from '../..';
 import { CursorManager } from '../cursors';
 import { OrthographicCamera } from '../scenes';
-import {
-  ClippingPlanes,
-  DepthBuffer,
-  FrameCamera,
-  FramePerspectiveCamera,
-  Viewport,
-} from '../types';
-import { ZoomData } from '.';
+import { DepthBuffer, Viewport } from '../types';
+import { ZoomData } from './interactionApi';
 import {
   CameraTransform,
   InteractionApi,

--- a/packages/viewer/src/lib/types/__tests__/frame.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/frame.spec.ts
@@ -1,6 +1,6 @@
 import { BoundingBox, Line3, Matrix4, Vector3 } from '@vertexvis/geometry';
 
-import { ClippingPlanes, FrameCamera } from '..';
+import { FrameCamera } from '..';
 import { FrameOrthographicCamera, FramePerspectiveCamera } from '../frame';
 
 describe(FramePerspectiveCamera, () => {

--- a/packages/viewer/src/lib/types/__tests__/frame.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/frame.spec.ts
@@ -1,5 +1,6 @@
-import { Line3, Matrix4, Vector3 } from '@vertexvis/geometry';
+import { BoundingBox, Line3, Matrix4, Vector3 } from '@vertexvis/geometry';
 
+import { ClippingPlanes, FrameCamera } from '..';
 import { FrameOrthographicCamera, FramePerspectiveCamera } from '../frame';
 
 describe(FramePerspectiveCamera, () => {
@@ -12,6 +13,22 @@ describe(FramePerspectiveCamera, () => {
     1,
     45
   );
+
+  describe(FramePerspectiveCamera.prototype.toOrthographic, () => {
+    it('converts to an orthographic camera', () => {
+      const bounds = BoundingBox.create(
+        Vector3.create(-1, -1, -1),
+        Vector3.create(1, 1, 1)
+      );
+      const asOrthographic = FrameCamera.toOrthographic(camera, bounds);
+
+      expect(camera.toOrthographic(bounds)).toMatchObject({
+        ...asOrthographic,
+        near: -Math.sqrt(3),
+        far: Math.sqrt(3),
+      });
+    });
+  });
 
   describe(FramePerspectiveCamera.prototype.isPointBehindNear, () => {
     it('returns true if world point behind near plane', () => {
@@ -58,6 +75,21 @@ describe(FrameOrthographicCamera, () => {
     1,
     45
   );
+
+  describe(FrameOrthographicCamera.prototype.toPerspective, () => {
+    it('converts to a perspective camera', () => {
+      const bounds = BoundingBox.create(
+        Vector3.create(-1, -1, -1),
+        Vector3.create(1, 1, 1)
+      );
+      const asPerspective = FrameCamera.toPerspective(camera);
+      const converted = camera.toPerspective(bounds);
+
+      expect(converted).toMatchObject(asPerspective);
+      expect(converted.near).toBeCloseTo(52.5877);
+      expect(converted.far).toBeCloseTo(56.0518);
+    });
+  });
 
   describe(FrameOrthographicCamera.prototype.isPointBehindNear, () => {
     it('returns true if world point behind near plane', () => {

--- a/packages/viewer/src/lib/types/__tests__/viewport.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/viewport.spec.ts
@@ -1,0 +1,63 @@
+import { BoundingBox, Point, Ray, Vector3 } from '@vertexvis/geometry';
+
+import { makeDepthBuffer } from '../../../testing/fixtures';
+import { DepthBuffer } from '..';
+import { FrameCameraBase } from '../frame';
+import * as FrameCamera from '../frameCamera';
+import { Viewport } from '../viewport';
+
+describe('viewport utilities', () => {
+  const orthographic = FrameCameraBase.fromBoundingBox(
+    FrameCamera.createOrthographic(),
+    BoundingBox.create(Vector3.create(-1, -1, -1), Vector3.create(1, 1, 1)),
+    1
+  );
+
+  describe(Viewport.prototype.transformPointToOrthographicRay, () => {
+    it('creates an orthographic ray', () => {
+      const viewport = new Viewport(100, 100);
+
+      const expectedOrigin = Vector3.transformMatrix(
+        Vector3.transformMatrix(
+          Vector3.create(-0.8, 0.8, 0.5),
+          orthographic.projectionMatrixInverse
+        ),
+        orthographic.worldMatrix
+      );
+
+      expect(
+        viewport.transformPointToOrthographicRay(
+          Point.create(10, 10),
+          makeDepthBuffer(100, 100),
+          orthographic
+        )
+      ).toMatchObject({
+        origin: expectedOrigin,
+        direction: Vector3.normalize(orthographic.viewVector),
+      });
+    });
+
+    it('computes an orthographic world position', () => {
+      const viewport = new Viewport(100, 100);
+
+      const buffer = makeDepthBuffer(100, 100, undefined, orthographic);
+      const depth =
+        (0.5 / DepthBuffer.MAX_DEPTH_VALUE) *
+          (orthographic.far - orthographic.near) +
+        orthographic.near / 2;
+      const ray = viewport.transformPointToOrthographicRay(
+        Point.create(10, 10),
+        buffer,
+        orthographic
+      );
+
+      expect(
+        viewport.transformPointToOrthographicWorldSpace(
+          Point.create(10, 10),
+          buffer,
+          0.5
+        )
+      ).toMatchObject(Ray.at(ray, depth));
+    });
+  });
+});

--- a/packages/viewer/src/lib/types/depthBuffer.ts
+++ b/packages/viewer/src/lib/types/depthBuffer.ts
@@ -169,9 +169,7 @@ export class DepthBuffer implements FrameImageLike {
     const angle =
       Vector3.dot(vv, eyeToWorldPt) /
       (Vector3.magnitude(vv) * Vector3.magnitude(eyeToWorldPt));
-    console.log(angle);
-    console.log(Ray.at(ray, distance));
-    return Ray.at(ray, distance);
+    return Ray.at(ray, distance / angle);
   }
 
   public getOrthographicWorldPoint(

--- a/packages/viewer/src/lib/types/depthBuffer.ts
+++ b/packages/viewer/src/lib/types/depthBuffer.ts
@@ -78,7 +78,21 @@ export class DepthBuffer implements FrameImageLike {
       point,
       fallbackNormalizedDepth
     );
+
     return depth * (far - near) + near;
+  }
+
+  public getOrthographicDepthAtPoint(
+    point: Point.Point,
+    fallbackNormalizedDepth?: number
+  ): number {
+    const { near, far } = this.camera;
+    const depth = this.getNormalizedDepthAtPoint(
+      point,
+      fallbackNormalizedDepth
+    );
+
+    return depth * (far - near) + near / 2;
   }
 
   /**
@@ -155,7 +169,22 @@ export class DepthBuffer implements FrameImageLike {
     const angle =
       Vector3.dot(vv, eyeToWorldPt) /
       (Vector3.magnitude(vv) * Vector3.magnitude(eyeToWorldPt));
-    return Ray.at(ray, distance / angle);
+    console.log(angle);
+    console.log(Ray.at(ray, distance));
+    return Ray.at(ray, distance);
+  }
+
+  public getOrthographicWorldPoint(
+    point: Point.Point,
+    ray: Ray.Ray,
+    fallbackNormalizedDepth?: number
+  ): Vector3.Vector3 {
+    const distance = this.getOrthographicDepthAtPoint(
+      point,
+      fallbackNormalizedDepth
+    );
+
+    return Ray.at(ray, distance);
   }
 
   /**

--- a/packages/viewer/src/lib/types/depthBuffer.ts
+++ b/packages/viewer/src/lib/types/depthBuffer.ts
@@ -62,7 +62,7 @@ export class DepthBuffer implements FrameImageLike {
   /**
    * Computes the depth from a 2D point within the coordinate space of the depth
    * buffer. The returned depth is a value that's between the near and far plane
-   * of the camera.
+   * of the perspective camera.
    *
    * @param point A 2D point within the viewport.
    * @param fallbackNormalizedDepth A fallback value if the depth is the max
@@ -82,6 +82,16 @@ export class DepthBuffer implements FrameImageLike {
     return depth * (far - near) + near;
   }
 
+  /**
+   * Computes the depth from a 2D point within the coordinate space of the depth
+   * buffer. The returned depth is a value that's between the near and far plane
+   * of the orthographic camera.
+   *
+   * @param point A 2D point within the viewport.
+   * @param fallbackNormalizedDepth A fallback value if the depth is the max
+   *   depth value, or cannot be determined.
+   * @returns A depth between the near and far plane.
+   */
   public getOrthographicDepthAtPoint(
     point: Point.Point,
     fallbackNormalizedDepth?: number
@@ -144,7 +154,7 @@ export class DepthBuffer implements FrameImageLike {
   }
 
   /**
-   * Computes a 3D point in world space coordinates from the depth value at the
+   * Computes a 3D point in perspective world space coordinates from the depth value at the
    * given pixel and ray.
    *
    * @param point A pixel to use for reading a depth value.
@@ -172,6 +182,16 @@ export class DepthBuffer implements FrameImageLike {
     return Ray.at(ray, distance / angle);
   }
 
+  /**
+   * Computes a 3D point in orthographic world space coordinates from the depth value at the
+   * given pixel and ray.
+   *
+   * @param point A pixel to use for reading a depth value.
+   * @param ray A ray that specifies the origin and direction.
+   * @param fallbackNormalizedDepth A fallback value if the depth is the max
+   *   depth value, or cannot be determined.
+   * @returns A point in world space coordinates.
+   */
   public getOrthographicWorldPoint(
     point: Point.Point,
     ray: Ray.Ray,

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -357,6 +357,14 @@ export class FrameOrthographicCamera
     this.left = -this.right;
   }
 
+  public toPerspective(boundingBox: BoundingBox.BoundingBox): FrameCameraBase {
+    return FrameCameraBase.fromBoundingBox(
+      FrameCamera.toPerspective(this),
+      boundingBox,
+      this.aspectRatio
+    );
+  }
+
   public override isOrthographic(): this is FrameOrthographicCamera {
     return true;
   }

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -159,6 +159,10 @@ export class FrameCameraBase implements FrameCameraLike {
     return this.computeCameraMatrices().projectionViewMatrix;
   }
 
+  public get frustumProjectionViewMatrix(): Matrix4.Matrix4 {
+    return this.computeCameraMatrices().projectionViewMatrix;
+  }
+
   public static fromBoundingBox(
     camera: FrameCamera.FrameCamera,
     boundingBox: BoundingBox.BoundingBox,
@@ -355,6 +359,21 @@ export class FrameOrthographicCamera
 
   public override isOrthographic(): this is FrameOrthographicCamera {
     return true;
+  }
+
+  public override get frustumProjectionViewMatrix(): Matrix4.Matrix4 {
+    const frustumProjectionMatrix = Matrix4.makeFrustum(
+      this.left,
+      this.right,
+      this.top,
+      this.bottom,
+      this.near,
+      this.far
+    );
+    return Matrix4.multiply(
+      frustumProjectionMatrix,
+      this.computeCameraMatrices().viewMatrix
+    );
   }
 
   protected override computeCameraMatrices(): FrameCameraMatrices {

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -199,10 +199,16 @@ export class FrameCameraBase implements FrameCameraLike {
     }
   }
 
+  /**
+   * Returns whether this `FrameCameraBase` is an orthographic camera.
+   */
   public isOrthographic(): this is FrameOrthographicCamera {
     return false;
   }
 
+  /**
+   * Returns whether this `FrameCameraBase` is a perspective camera.
+   */
   public isPerspective(): this is FramePerspectiveCamera {
     return false;
   }
@@ -289,6 +295,20 @@ export class FramePerspectiveCamera
     super(position, lookAt, up, near, far, aspectRatio);
   }
 
+  /**
+   * Converts this `FramePerspectiveCamera` to a `FrameOrthographicCamera` using
+   * the provided `boundingBox` to compute the viewing frustum.
+   *
+   * @param boundingBox The visible bounding box.
+   */
+  public toOrthographic(boundingBox: BoundingBox.BoundingBox): FrameCameraBase {
+    return FrameCameraBase.fromBoundingBox(
+      FrameCamera.toOrthographic(this, boundingBox),
+      boundingBox,
+      this.aspectRatio
+    );
+  }
+
   public override isPerspective(): this is FramePerspectiveCamera {
     return true;
   }
@@ -357,6 +377,12 @@ export class FrameOrthographicCamera
     this.left = -this.right;
   }
 
+  /**
+   * Converts this `FrameOrthographicCamera` to a `FramePerspectiveCamera` using
+   * the provided `boundingBox` to compute the near and far clipping planes.
+   *
+   * @param boundingBox The visible bounding box.
+   */
   public toPerspective(boundingBox: BoundingBox.BoundingBox): FrameCameraBase {
     return FrameCameraBase.fromBoundingBox(
       FrameCamera.toPerspective(this),

--- a/packages/viewer/src/lib/types/viewport.ts
+++ b/packages/viewer/src/lib/types/viewport.ts
@@ -123,6 +123,24 @@ export class Viewport implements Dimensions.Dimensions {
     return depthBuffer.getWorldPoint(depthPt, ray, fallbackNormalizedDepth);
   }
 
+  public transformPointToOrthographicWorldSpace(
+    pt: Point.Point,
+    depthBuffer: DepthBuffer,
+    fallbackNormalizedDepth?: number
+  ): Vector3.Vector3 {
+    const depthPt = this.transformPointToFrame(pt, depthBuffer);
+    const ray = this.transformPointToOrthographicRay(
+      pt,
+      depthBuffer,
+      depthBuffer.camera
+    );
+    return depthBuffer.getOrthographicWorldPoint(
+      depthPt,
+      ray,
+      fallbackNormalizedDepth
+    );
+  }
+
   /**
    * Transforms a point in viewport coordinates to a ray. The returned ray will
    * have an origin that is at the position of the camera with a direction that
@@ -147,6 +165,23 @@ export class Viewport implements Dimensions.Dimensions {
     );
     const direction = Vector3.normalize(Vector3.subtract(world, origin));
     return Ray.create({ origin, direction });
+  }
+
+  public transformPointToOrthographicRay(
+    pt: Point.Point,
+    image: FrameImageLike,
+    camera: FrameCameraWithMatrices
+  ): Ray.Ray {
+    const ndc = this.transformScreenPointToNdc(pt, image);
+    const world = Vector3.transformNdcToWorldSpace(
+      Vector3.create(ndc.x, ndc.y, 0.5),
+      camera.worldMatrix,
+      camera.projectionMatrixInverse
+    );
+    return Ray.create({
+      origin: world,
+      direction: Vector3.normalize(camera.viewVector),
+    });
   }
 
   /**

--- a/packages/viewer/src/lib/types/viewport.ts
+++ b/packages/viewer/src/lib/types/viewport.ts
@@ -103,7 +103,7 @@ export class Viewport implements Dimensions.Dimensions {
   }
 
   /**
-   * Transforms a point in viewport coordinates to a point in world space
+   * Transforms a point in viewport coordinates to a point in perspective world space
    * coordinates. This method expects a depth buffer in order to compute a value
    * for the Z axis.
    *
@@ -123,6 +123,16 @@ export class Viewport implements Dimensions.Dimensions {
     return depthBuffer.getWorldPoint(depthPt, ray, fallbackNormalizedDepth);
   }
 
+  /**
+   * Transforms a point in viewport coordinates to a point in orthographic world space
+   * coordinates. This method expects a depth buffer in order to compute a value
+   * for the Z axis.
+   *
+   * @param pt A point in viewport coordinates.
+   * @param depthBuffer A depth buffer for computing the Z axis.
+   * @param fallbackNormalizedDepth A fallback value if the depth is the max
+   *   depth value, or cannot be determined.
+   */
   public transformPointToOrthographicWorldSpace(
     pt: Point.Point,
     depthBuffer: DepthBuffer,
@@ -167,6 +177,15 @@ export class Viewport implements Dimensions.Dimensions {
     return Ray.create({ origin, direction });
   }
 
+  /**
+   * Transforms a point in viewport coordinates to a ray. The returned ray will
+   * have an origin that is at the world point of viewport coordinate with a direction that
+   * is pointing into world space away from the camera.
+   *
+   * @param pt A point in viewport coordinates.
+   * @param image An image of a frame.
+   * @param camera A camera used to determine orientation of the scene.
+   */
   public transformPointToOrthographicRay(
     pt: Point.Point,
     image: FrameImageLike,

--- a/packages/viewer/src/testing/fixtures.ts
+++ b/packages/viewer/src/testing/fixtures.ts
@@ -1,4 +1,4 @@
-import { Dimensions, Point, Rectangle } from '@vertexvis/geometry';
+import { Dimensions, Point, Rectangle, Vector3 } from '@vertexvis/geometry';
 import { DrawFramePayload } from '@vertexvis/stream-api';
 import { Color, Mapper } from '@vertexvis/utils';
 import { encode } from 'fast-png';
@@ -11,6 +11,7 @@ import {
   DepthBuffer,
   FeatureMap,
   Frame,
+  FrameCameraBase,
   ImageAttributesLike,
   Orientation,
   STENCIL_BUFFER_FEATURE_VALUE,
@@ -218,7 +219,15 @@ export function makeHitTester({
     stencilBuffer ??
       makeStencilBuffer(200, 100, () => STENCIL_BUFFER_FEATURE_VALUE),
     depthBuffer ?? makeDepthBuffer(200, 100),
-    viewport ?? new Viewport(200, 100)
+    viewport ?? new Viewport(200, 100),
+    new FrameCameraBase(
+      Vector3.forward(),
+      Vector3.origin(),
+      Vector3.up(),
+      0,
+      100,
+      1
+    )
   );
 }
 

--- a/packages/viewer/src/testing/fixtures.ts
+++ b/packages/viewer/src/testing/fixtures.ts
@@ -12,6 +12,7 @@ import {
   FeatureMap,
   Frame,
   FrameCameraBase,
+  FramePerspectiveCamera,
   ImageAttributesLike,
   Orientation,
   STENCIL_BUFFER_FEATURE_VALUE,
@@ -224,13 +225,14 @@ export function makeHitTester({
     depthBuffer ?? makeDepthBuffer(200, 100),
     viewport ?? new Viewport(200, 100),
     camera ??
-      new FrameCameraBase(
+      new FramePerspectiveCamera(
         Vector3.forward(),
         Vector3.origin(),
         Vector3.up(),
         0,
         100,
-        1
+        1,
+        45
       )
   );
 }

--- a/packages/viewer/src/testing/fixtures.ts
+++ b/packages/viewer/src/testing/fixtures.ts
@@ -121,11 +121,12 @@ export function makeDepthImageBytes(
 export function makeDepthBuffer(
   width: number,
   height: number,
-  value = 2 ** 16 - 1
+  value = 2 ** 16 - 1,
+  camera?: FrameCameraBase
 ): DepthBuffer {
   return DepthBuffer.fromPng(
     { data: makeDepthImageBytes(width, height, value) },
-    makePerspectiveFrame().scene.camera,
+    camera ?? makePerspectiveFrame().scene.camera,
     makeImageAttributes(width, height)
   );
 }
@@ -210,24 +211,27 @@ export function makeHitTester({
   stencilBuffer,
   depthBuffer,
   viewport,
+  camera,
 }: {
   stencilBuffer?: StencilBuffer;
   depthBuffer?: DepthBuffer;
   viewport?: Viewport;
+  camera?: FrameCameraBase;
 } = {}): PointToPointHitTester {
   return new PointToPointHitTester(
     stencilBuffer ??
       makeStencilBuffer(200, 100, () => STENCIL_BUFFER_FEATURE_VALUE),
     depthBuffer ?? makeDepthBuffer(200, 100),
     viewport ?? new Viewport(200, 100),
-    new FrameCameraBase(
-      Vector3.forward(),
-      Vector3.origin(),
-      Vector3.up(),
-      0,
-      100,
-      1
-    )
+    camera ??
+      new FrameCameraBase(
+        Vector3.forward(),
+        Vector3.origin(),
+        Vector3.up(),
+        0,
+        100,
+        1
+      )
   );
 }
 


### PR DESCRIPTION
## Summary

Adds support for depth buffer interaction in orthographic mode. Specifically, this impacts a handful of features:
- Rotate around tap point in orthographic should work as expected now
- Zoom to point is now using the value from the depth buffer to determine the lookAt changes
- Point to point measurement is now properly supported
- `vertex-viewer-dom-element`s in `3d` mode will now be displayed (perspective based still, created https://vertexvis.atlassian.net/browse/PLAT-1244 to capture rendering those pins orthographically)

## Test Plan

- Test rotate around tap point in orthographic
- Test zoom to point in orthographic
- Test point to point measurement (perspective/orthographic)
- Test pins in (perspective/orthographic)

## Release Notes

N/A

## Possible Regressions

P2P measurement, pins, orthographic interactions

## Dependencies

N/A
