### PR TITLE
[PLAT-1266] Fix look at position in orthographic mode

### DIFF
--- a/packages/viewer/src/lib/interactions/__tests__/flyToPositionKeyInteraction.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/flyToPositionKeyInteraction.spec.ts
@@ -1,12 +1,15 @@
 import { Dimensions, Point, Vector3 } from '@vertexvis/geometry';
 import { StreamApi } from '@vertexvis/stream-api';
 
-import { makePerspectiveFrame } from '../../../testing/fixtures';
+import {
+  makeOrthographicFrame,
+  makePerspectiveFrame,
+} from '../../../testing/fixtures';
 import { Config } from '../../config';
 import { fromPbFrameOrThrow } from '../../mappers';
 import { Scene } from '../../scenes';
 import * as ColorMaterial from '../../scenes/colorMaterial';
-import { Orientation } from '../../types';
+import { Frame, Orientation } from '../../types';
 import { FlyToPositionKeyInteraction } from '../flyToPositionKeyInteraction';
 import { TapEventDetails } from '../tapEventDetails';
 
@@ -19,23 +22,33 @@ describe(FlyToPositionKeyInteraction, () => {
   }));
   streamApi.flyTo = jest.fn(async () => ({ flyTo: {} }));
   const sceneViewId = 'scene-view-id';
-  const scene = new Scene(
-    streamApi,
-    makePerspectiveFrame(),
-    fromPbFrameOrThrow(Orientation.DEFAULT),
-    () => Point.create(1, 1),
-    Dimensions.create(50, 50),
-    sceneViewId,
-    ColorMaterial.fromHex('#ffffff')
-  );
-  const flyToPositionKeyInteraction = new FlyToPositionKeyInteraction(
-    streamApi,
-    () => ({ animation: { durationMs: 500 } } as Config),
-    () => Point.create(1, 1),
-    () => scene
-  );
+
+  function createScene(frame: Frame): Scene {
+    return new Scene(
+      streamApi,
+      frame,
+      fromPbFrameOrThrow(Orientation.DEFAULT),
+      () => Point.create(1, 1),
+      Dimensions.create(50, 50),
+      sceneViewId,
+      ColorMaterial.fromHex('#ffffff')
+    );
+  }
+
+  function createInteraction(frame: Frame): FlyToPositionKeyInteraction {
+    return new FlyToPositionKeyInteraction(
+      streamApi,
+      () => ({ animation: { durationMs: 500 } } as Config),
+      () => Point.create(1, 1),
+      () => createScene(frame)
+    );
+  }
 
   it('returns true for its predicate with Alt and Shift pressed', () => {
+    const flyToPositionKeyInteraction = createInteraction(
+      makePerspectiveFrame()
+    );
+
     expect(
       flyToPositionKeyInteraction.predicate({
         ctrlKey: true,
@@ -70,7 +83,11 @@ describe(FlyToPositionKeyInteraction, () => {
     ).toBe(true);
   });
 
-  it('queries for hit results and sets the camera lookAt to the hit position', async () => {
+  it('queries for hit results and sets the camera lookAt to the hit position in perspective mode', async () => {
+    const flyToPositionKeyInteraction = createInteraction(
+      makePerspectiveFrame()
+    );
+
     const position = Point.create(1, 1);
     await flyToPositionKeyInteraction.fn({ position } as TapEventDetails);
 
@@ -85,6 +102,35 @@ describe(FlyToPositionKeyInteraction, () => {
       expect.objectContaining({
         camera: expect.objectContaining({
           lookAt: Vector3.create(10, 20, 30),
+          perspective: expect.objectContaining({
+            lookAt: Vector3.create(10, 20, 30),
+          }),
+        }),
+      })
+    );
+  });
+
+  it('queries for hit results and sets the camera lookAt to the hit position in orthographic mode', async () => {
+    const flyToPositionKeyInteraction = createInteraction(
+      makeOrthographicFrame()
+    );
+
+    const position = Point.create(1, 1);
+    await flyToPositionKeyInteraction.fn({ position } as TapEventDetails);
+
+    expect(streamApi.hitItems).toHaveBeenCalledWith(
+      expect.objectContaining({
+        point: position,
+      }),
+      true
+    );
+
+    expect(streamApi.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        camera: expect.objectContaining({
+          orthographic: expect.objectContaining({
+            lookAt: Vector3.create(10, 20, 30),
+          }),
         }),
       })
     );

--- a/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
+++ b/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
@@ -3,6 +3,7 @@ import { StreamApi, toProtoDuration } from '@vertexvis/stream-api';
 
 import { ConfigProvider } from '../config';
 import { ImageScaleProvider, Scene } from '../scenes';
+import { FrameCamera } from '../types';
 import { KeyInteraction } from './keyInteraction';
 import { TapEventDetails } from './tapEventDetails';
 
@@ -46,15 +47,17 @@ export class FlyToPositionKeyInteraction
         hit.hitPoint.z != null
       ) {
         await this.stream.flyTo({
-          camera: camera
-            .update({
-              lookAt: Vector3.create(
-                hit.hitPoint.x,
-                hit.hitPoint.y,
-                hit.hitPoint.z
-              ),
-            })
-            .toFrameCamera(),
+          camera: FrameCamera.toProtobuf(
+            camera
+              .update({
+                lookAt: Vector3.create(
+                  hit.hitPoint.x,
+                  hit.hitPoint.y,
+                  hit.hitPoint.z
+                ),
+              })
+              .toFrameCamera()
+          ),
           animation: {
             duration: toProtoDuration(
               this.configProvider().animation.durationMs


### PR DESCRIPTION
## Summary

Corrects the behavior of the look at position keybinding (Alt/Option + Shift + Click) in orthographic mode to properly send an orthographic camera.

## Test Plan

- Test look at position in perspective mode
- Test look at position in orthographic mode

## Release Notes

N/A

## Possible Regressions

Look at position in perspective mode

## Dependencies

N/A
