### PR TITLE
[PLAT-1307] Pin label state improvements

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2543,7 +2543,15 @@ declare namespace LocalJSX {
      * The dimensions of the canvas for the pins
      */
     elementBounds?: DOMRect;
+    /**
+     * Emitted whenever the label is blurred, with the ID of the associated pin (or undefined if no pin is provided).
+     */
+    onLabelBlurred?: (event: CustomEvent<string | undefined>) => void;
     onLabelChanged?: (event: CustomEvent<void>) => void;
+    /**
+     * Emitted whenever the label is focused, with the ID of the associated pin (or undefined if no pin is provided).
+     */
+    onLabelFocused?: (event: CustomEvent<string | undefined>) => void;
     /**
      * The pin to draw for the group
      */

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.spec.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.spec.tsx
@@ -55,7 +55,7 @@ describe('vertex-view-pin-group', () => {
         </vertex-viewer-pin-label-line>
         <vertex-viewer-pin-label>
         <div class="pin-label-input-wrapper" id="pin-label-my-pin-id" style="top: 50px; left: 50px; min-width: var(--viewer-annotations-pin-label-min-width); max-width: min(var(--viewer-annotations-pin-label-max-width), calc(100px - 50px)); max-height: min(var(--viewer-annotations-pin-label-max-height), calc(100px - 50px));">
-          <div class="pin-input-drag-target"></div><textarea class="pin-label-input pin-label-text readonly" disabled="" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea>
+          <textarea class="pin-label-input pin-label-text readonly" disabled="" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea><div class="pin-input-drag-target"></div>
         </div>
         <div class="pin-label-hidden pin-label-text" style="max-width: min(var(--viewer-annotations-pin-label-max-width), calc(100px - 50px)); max-height: min(var(--viewer-annotations-pin-label-max-height), calc(100px - 50px));">
           My New Pin

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.spec.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.spec.tsx
@@ -54,9 +54,12 @@ describe('vertex-view-pin-group', () => {
           </svg>
         </vertex-viewer-pin-label-line>
         <vertex-viewer-pin-label>
-          <div class="pin-label" id="pin-label-my-pin-id" style="top: 50px; left: 50px;">
-            My New Pin
-          </div>
+        <div class="pin-label-input-wrapper" id="pin-label-my-pin-id" style="top: 50px; left: 50px; min-width: var(--viewer-annotations-pin-label-min-width); max-width: min(var(--viewer-annotations-pin-label-max-width), calc(100px - 50px)); max-height: min(var(--viewer-annotations-pin-label-max-height), calc(100px - 50px));">
+          <textarea class="pin-label-input pin-label-text readonly" disabled="" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea>
+        </div>
+        <div class="pin-label-hidden pin-label-text" style="max-width: min(var(--viewer-annotations-pin-label-max-width), calc(100px - 50px)); max-height: min(var(--viewer-annotations-pin-label-max-height), calc(100px - 50px));">
+          My New Pin
+        </div>
         </vertex-viewer-pin-label>
       </vertex-viewer-pin-group>
     `);

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.spec.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.spec.tsx
@@ -55,7 +55,7 @@ describe('vertex-view-pin-group', () => {
         </vertex-viewer-pin-label-line>
         <vertex-viewer-pin-label>
         <div class="pin-label-input-wrapper" id="pin-label-my-pin-id" style="top: 50px; left: 50px; min-width: var(--viewer-annotations-pin-label-min-width); max-width: min(var(--viewer-annotations-pin-label-max-width), calc(100px - 50px)); max-height: min(var(--viewer-annotations-pin-label-max-height), calc(100px - 50px));">
-          <textarea class="pin-label-input pin-label-text readonly" disabled="" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea>
+          <div class="pin-input-drag-target"></div><textarea class="pin-label-input pin-label-text readonly" disabled="" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea>
         </div>
         <div class="pin-label-hidden pin-label-text" style="max-width: min(var(--viewer-annotations-pin-label-max-width), calc(100px - 50px)); max-height: min(var(--viewer-annotations-pin-label-max-height), calc(100px - 50px));">
           My New Pin

--- a/packages/viewer/src/components/viewer-pin-label/readme.md
+++ b/packages/viewer/src/components/viewer-pin-label/readme.md
@@ -38,18 +38,20 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                                              | Description                                                                       |
-| ------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `--viewer-annotations-pin-label-background-color` | A CSS color that specifies the color of the label background                      |
-| `--viewer-annotations-pin-label-border`           | A var that specifies the border of the label                                      |
-| `--viewer-annotations-pin-label-border-color`     | A CSS color that specifies the color of the label's border                        |
-| `--viewer-annotations-pin-label-border-radius`    | A var that specifies the border radius of the label                               |
-| `--viewer-annotations-pin-label-color`            | A CSS color that specifies the color of the label                                 |
-| `--viewer-annotations-pin-label-max-height`       | A CSS length that specifies the maximum height of the label. Defaults to `50rem`. |
-| `--viewer-annotations-pin-label-max-width`        | A CSS length that specifies the maximum width of the label. Defaults to `25rem`.  |
-| `--viewer-annotations-pin-label-min-width`        | A CSS length that specifies the minimum width of the label. Defaults to `1rem`.   |
-| `--viewer-annotations-pin-label-padding-x`        | A var that specifies the horizontal padding of the label                          |
-| `--viewer-annotations-pin-label-padding-y`        | A var that specifies the vertical padding of the label                            |
+| Name                                                  | Description                                                                           |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `--viewer-annotations-pin-label-background-color`     | A CSS color that specifies the color of the label background                          |
+| `--viewer-annotations-pin-label-border-color`         | A CSS color that specifies the color of the label's border                            |
+| `--viewer-annotations-pin-label-border-radius`        | A var that specifies the border radius of the label                                   |
+| `--viewer-annotations-pin-label-border-style`         | A CSS variable that specifies the style of border on this label. Defaults to `solid`. |
+| `--viewer-annotations-pin-label-border-width`         | A CSS length that specifies the width of the border on this label. Defaults to `2px`. |
+| `--viewer-annotations-pin-label-color`                | A CSS color that specifies the color of the label                                     |
+| `--viewer-annotations-pin-label-focused-border-color` | A CSS color that specifies the color of the label's border when focused.              |
+| `--viewer-annotations-pin-label-max-height`           | A CSS length that specifies the maximum height of the label. Defaults to `50rem`.     |
+| `--viewer-annotations-pin-label-max-width`            | A CSS length that specifies the maximum width of the label. Defaults to `25rem`.      |
+| `--viewer-annotations-pin-label-min-width`            | A CSS length that specifies the minimum width of the label. Defaults to `1rem`.       |
+| `--viewer-annotations-pin-label-padding-x`            | A var that specifies the horizontal padding of the label                              |
+| `--viewer-annotations-pin-label-padding-y`            | A var that specifies the vertical padding of the label                                |
 
 
 ## Dependencies

--- a/packages/viewer/src/components/viewer-pin-label/readme.md
+++ b/packages/viewer/src/components/viewer-pin-label/readme.md
@@ -15,6 +15,14 @@
 | `value`         | `value`   | The current text value of the component. Value is updated on user interaction. | `string`                     | `undefined` |
 
 
+## Events
+
+| Event          | Description                                                                                                    | Type                               |
+| -------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `labelBlurred` | Emitted whenever the label is blurred, with the ID of the associated pin (or undefined if no pin is provided). | `CustomEvent<string \| undefined>` |
+| `labelFocused` | Emitted whenever the label is focused, with the ID of the associated pin (or undefined if no pin is provided). | `CustomEvent<string \| undefined>` |
+
+
 ## Methods
 
 ### `setFocus() => Promise<void>`
@@ -30,13 +38,18 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                                              | Description                                                  |
-| ------------------------------------------------- | ------------------------------------------------------------ |
-| `--viewer-annotations-pin-label-background-color` | A CSS color that specifies the color of the label background |
-| `--viewer-annotations-pin-label-border`           | A var that specifies the border of the label                 |
-| `--viewer-annotations-pin-label-border-radius`    | A var that specifies the border radius of the label          |
-| `--viewer-annotations-pin-label-color`            | A CSS color that specifies the color of the label            |
-| `--viewer-annotations-pin-label-padding`          | A var that specifies the padding of the label                |
+| Name                                              | Description                                                                       |
+| ------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `--viewer-annotations-pin-label-background-color` | A CSS color that specifies the color of the label background                      |
+| `--viewer-annotations-pin-label-border`           | A var that specifies the border of the label                                      |
+| `--viewer-annotations-pin-label-border-color`     | A CSS color that specifies the color of the label's border                        |
+| `--viewer-annotations-pin-label-border-radius`    | A var that specifies the border radius of the label                               |
+| `--viewer-annotations-pin-label-color`            | A CSS color that specifies the color of the label                                 |
+| `--viewer-annotations-pin-label-max-height`       | A CSS length that specifies the maximum height of the label. Defaults to `50rem`. |
+| `--viewer-annotations-pin-label-max-width`        | A CSS length that specifies the maximum width of the label. Defaults to `25rem`.  |
+| `--viewer-annotations-pin-label-min-width`        | A CSS length that specifies the minimum width of the label. Defaults to `1rem`.   |
+| `--viewer-annotations-pin-label-padding-x`        | A var that specifies the horizontal padding of the label                          |
+| `--viewer-annotations-pin-label-padding-y`        | A var that specifies the vertical padding of the label                            |
 
 
 ## Dependencies

--- a/packages/viewer/src/components/viewer-pin-label/utils.ts
+++ b/packages/viewer/src/components/viewer-pin-label/utils.ts
@@ -1,0 +1,3 @@
+export function getComputedStyle(el: HTMLElement): CSSStyleDeclaration {
+  return window.getComputedStyle(el);
+}

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
@@ -3,38 +3,56 @@
    * @prop --viewer-annotations-pin-label-background-color: A CSS color that
    * specifies the color of the label background
    */
-   --viewer-annotations-pin-label-background-color: var(--blue-200);
+  --viewer-annotations-pin-label-background-color: var(--blue-200);
 
   /**
-   * @prop --viewer-annotations-pin-label-background-color: A CSS color that
-   * specifies the color of the label background
+   * @prop --viewer-annotations-pin-label-border-color: A CSS color that
+   * specifies the color of the label's border
    */
-   --viewer-annotations-pin-label-border-color: var(--blue-600);
+  --viewer-annotations-pin-label-border-color: var(--blue-600);
 
   /**
    * @prop --viewer-annotations-pin-label-color: A CSS color that
    * specifies the color of the label 
    */
-   --viewer-annotations-pin-label-color: var(--white);
+  --viewer-annotations-pin-label-color: var(--white);
 
   /**
-   * @prop --viewer-annotations-pin-label-padding: A var that
-   * specifies the padding of the label 
+   * @prop --viewer-annotations-pin-label-padding-y: A var that
+   * specifies the vertical padding of the label
    */
-   --viewer-annotations-pin-label-padding: 0.375em 0.5em;
+  --viewer-annotations-pin-label-padding-y: 0.375em;
+
+  /**
+   * @prop --viewer-annotations-pin-label-padding-x: A var that
+   * specifies the horizontal padding of the label
+   */
+  --viewer-annotations-pin-label-padding-x:  0.5em;
 
   /**
    * @prop --viewer-annotations-pin-label-border: A var that
    * specifies the border of the label
    */
-   --viewer-annotations-pin-label-border: 2px solid var(--viewer-annotations-pin-label-border-color);
+  --viewer-annotations-pin-label-border: 2px solid var(--viewer-annotations-pin-label-border-color);
 
-     /**
+  /**
    * @prop --viewer-annotations-pin-label-border-radius: A var that
    * specifies the border radius of the label
    */
-   --viewer-annotations-pin-label-border-radius: 0.25em;
-   
+  --viewer-annotations-pin-label-border-radius: 0.25em;
+
+  /**
+   * @prop --viewer-annotations-pin-label-min-width: A CSS length that
+   * specifies the minimum width of the label. Defaults to `1rem`.
+   */
+  --viewer-annotations-pin-label-min-width: 2rem;
+
+  /**
+   * @prop --viewer-annotations-pin-label-max-width: A CSS length that
+   * specifies the maximum width of the label. Defaults to `25rem`.
+   */
+  --viewer-annotations-pin-label-max-width: 25rem;
+
   overflow: hidden;
   pointer-events: none;
 }
@@ -44,15 +62,53 @@
   background: var(--viewer-annotations-pin-label-background-color);
 }
 
-.pin-label {
+.pin-label-text {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
+.pin-label-input-wrapper {
+  display: flex;
   position: absolute;
+  pointer-events: auto;
+  min-width: var(--viewer-annotations-pin-label-min-width);
+  max-width: var(--viewer-annotations-pin-label-max-width);
   background: var(--viewer-annotations-pin-label-background-color);
   border: var(--viewer-annotations-pin-label-border);
   border-radius: var(--viewer-annotations-pin-label-border-radius);
-  padding: var(--viewer-annotations-pin-label-padding);
-  pointer-events: auto;
+}
+
+.pin-label-input-wrapper.focused {
+  min-width: var(--viewer-annotations-pin-label-max-width);
+}
+
+.pin-label-input {
+  resize: none;
+  position: relative;
+  outline: none;
+  border: none;
+  padding: 0 0 0 0;
+  background-color: transparent;
+  overflow: hidden;
+  margin: var(--viewer-annotations-pin-label-padding-y) var(--viewer-annotations-pin-label-padding-x);
+  width: 100%;
+  max-width: calc(var(--viewer-annotations-pin-label-max-width) - calc(2 * var(--viewer-annotations-pin-label-padding-x)));
+}
+
+.pin-label-input.readonly {
+  color: black;
   cursor: pointer;
-  min-width: 16px;
-  min-height: 14px;
+}
+
+.pin-label-hidden {
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
   width: auto;
+  height: auto;
+  margin: var(--viewer-annotations-pin-label-padding-y) var(--viewer-annotations-pin-label-padding-x);
+  max-width: calc(var(--viewer-annotations-pin-label-max-width) - calc(2 * var(--viewer-annotations-pin-label-padding-x)));
 }

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
@@ -53,6 +53,12 @@
    */
   --viewer-annotations-pin-label-max-width: 25rem;
 
+  /**
+   * @prop --viewer-annotations-pin-label-max-height: A CSS length that
+   * specifies the maximum height of the label. Defaults to `50rem`.
+   */
+   --viewer-annotations-pin-label-max-height: 50rem;
+
   overflow: hidden;
   pointer-events: none;
 }
@@ -66,7 +72,7 @@
   font-family: Arial, Helvetica, sans-serif;
   font-size: 0.875rem;
   line-height: 1rem;
-  word-break: break-all;
+  word-break: break-word;
   white-space: pre-wrap;
 }
 
@@ -74,8 +80,10 @@
   display: flex;
   position: absolute;
   pointer-events: auto;
+  box-sizing: border-box;
   min-width: var(--viewer-annotations-pin-label-min-width);
   max-width: var(--viewer-annotations-pin-label-max-width);
+  max-height: var(--viewer-annotations-pin-label-max-height);
   background: var(--viewer-annotations-pin-label-background-color);
   border: var(--viewer-annotations-pin-label-border);
   border-radius: var(--viewer-annotations-pin-label-border-radius);
@@ -90,11 +98,13 @@
   position: relative;
   outline: none;
   border: none;
+  word-break: break-word;
   padding: 0 0 0 0;
   background-color: transparent;
-  overflow: hidden;
   margin: var(--viewer-annotations-pin-label-padding-y) var(--viewer-annotations-pin-label-padding-x);
-  width: 100%;
+  width: var(--viewer-annotations-pin-label-min-width);
+  flex-grow: 1;
+  overflow: hidden;
   max-width: calc(var(--viewer-annotations-pin-label-max-width) - calc(2 * var(--viewer-annotations-pin-label-padding-x)));
 }
 
@@ -109,6 +119,9 @@
   pointer-events: none;
   width: auto;
   height: auto;
-  margin: var(--viewer-annotations-pin-label-padding-y) var(--viewer-annotations-pin-label-padding-x);
+  box-sizing: border-box;
+  border: var(--viewer-annotations-pin-label-border);
+  margin: var(--viewer-annotations-pin-label-padding-y) 0;
+  padding: 0 var(--viewer-annotations-pin-label-padding-x);
   max-width: calc(var(--viewer-annotations-pin-label-max-width) - calc(2 * var(--viewer-annotations-pin-label-padding-x)));
 }

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
@@ -12,6 +12,12 @@
   --viewer-annotations-pin-label-border-color: var(--blue-600);
 
   /**
+   * @prop --viewer-annotations-pin-label-focused-border-color: A CSS color that
+   * specifies the color of the label's border when focused. 
+   */
+   --viewer-annotations-pin-label-focused-border-color: var(--blue-700);
+
+  /**
    * @prop --viewer-annotations-pin-label-color: A CSS color that
    * specifies the color of the label 
    */
@@ -30,10 +36,16 @@
   --viewer-annotations-pin-label-padding-x:  0.5em;
 
   /**
-   * @prop --viewer-annotations-pin-label-border: A var that
-   * specifies the border of the label
+   * @prop --viewer-annotations-pin-label-border-width: A CSS length that
+   * specifies the width of the border on this label. Defaults to `2px`.
    */
-  --viewer-annotations-pin-label-border: 2px solid var(--viewer-annotations-pin-label-border-color);
+  --viewer-annotations-pin-label-border-width: 2px;
+
+  /**
+   * @prop --viewer-annotations-pin-label-border-style: A CSS variable that
+   * specifies the style of border on this label. Defaults to `solid`.
+   */
+  --viewer-annotations-pin-label-border-style: solid;
 
   /**
    * @prop --viewer-annotations-pin-label-border-radius: A var that
@@ -85,12 +97,25 @@
   max-width: var(--viewer-annotations-pin-label-max-width);
   max-height: var(--viewer-annotations-pin-label-max-height);
   background: var(--viewer-annotations-pin-label-background-color);
-  border: var(--viewer-annotations-pin-label-border);
+  border-width: var(--viewer-annotations-pin-label-border-width);
+  border-style: var(--viewer-annotations-pin-label-border-style);
+  border-color: var(--viewer-annotations-pin-label-border-color);
   border-radius: var(--viewer-annotations-pin-label-border-radius);
 }
 
 .pin-label-input-wrapper.focused {
   min-width: var(--viewer-annotations-pin-label-max-width);
+  border-color: var(--viewer-annotations-pin-label-focused-border-color);
+}
+
+.pin-input-drag-target {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  cursor: pointer;
 }
 
 .pin-label-input {
@@ -109,6 +134,7 @@
 }
 
 .pin-label-input.readonly {
+  pointer-events: auto;
   color: black;
   cursor: pointer;
 }
@@ -120,7 +146,9 @@
   width: auto;
   height: auto;
   box-sizing: border-box;
-  border: var(--viewer-annotations-pin-label-border);
+  border-width: var(--viewer-annotations-pin-label-border-width);
+  border-style: var(--viewer-annotations-pin-label-border-style);
+  border-color: var(--viewer-annotations-pin-label-border-color);
   margin: var(--viewer-annotations-pin-label-padding-y) 0;
   padding: 0 var(--viewer-annotations-pin-label-padding-x);
   max-width: calc(var(--viewer-annotations-pin-label-max-width) - calc(2 * var(--viewer-annotations-pin-label-padding-x)));

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
@@ -114,7 +114,6 @@
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
   cursor: pointer;
 }
 

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.spec.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.spec.tsx
@@ -1,3 +1,16 @@
+jest.mock('../../lib/stencil', () => ({
+  readDOM: jest.fn((fn) => fn()),
+}));
+
+const mockGetComputedStyle = jest.fn(() => ({
+  height: '10px',
+  borderWidth: '1px',
+  lineHeight: '1px',
+}));
+jest.mock('./utils', () => ({
+  getComputedStyle: mockGetComputedStyle,
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
@@ -5,9 +18,33 @@ import { Dimensions, Point, Vector3 } from '@vertexvis/geometry';
 
 import { PinController } from '../../lib/pins/controller';
 import { PinModel, TextPin } from '../../lib/pins/model';
+import { triggerResizeObserver } from '../../testing/resizeObserver';
 import { VertexPinLabel } from './viewer-pin-label';
 
 describe('vertex-viewer-pin-label', () => {
+  function clickLabel(label: HTMLDivElement): void {
+    label.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        clientX: 50,
+        clientY: 50,
+      })
+    );
+
+    window.dispatchEvent(
+      new MouseEvent('pointermove', {
+        clientX: 50,
+        clientY: 50,
+      })
+    );
+
+    window.dispatchEvent(
+      new MouseEvent('pointerup', {
+        clientX: 50,
+        clientY: 50,
+      })
+    );
+  }
+
   it('should render a label for a pin and support dragging the label', async () => {
     const worldPosition = Vector3.create();
 
@@ -39,17 +76,16 @@ describe('vertex-viewer-pin-label', () => {
 
     const el = page.root as HTMLVertexViewerPinLabelLineElement;
 
-    const labelLine = el.querySelector(`#pin-label-${pin.id}`);
+    const label = el.querySelector(`#pin-label-${pin.id}`) as HTMLDivElement;
 
-    expect(labelLine).toEqualHtml(`
-      <div class="pin-label" id="pin-label-my-pin-id" style="top: 50px; left: 50px;">
-        My New Pin
-      </div>
-    `);
+    expect(label.style.top).toBe('50px');
+    expect(label.style.left).toBe('50px');
 
     const originalPin = pinModel.getPinById(pin.id) as TextPin;
     expect(originalPin.label.point).toEqual({ x: 0, y: 0 });
-    labelLine?.dispatchEvent(new MouseEvent('pointerdown'));
+    label?.dispatchEvent(
+      new MouseEvent('pointerdown', { clientX: 50, clientY: 50 })
+    );
 
     const draggingPoint = Point.create(40, 90);
     window.dispatchEvent(
@@ -60,12 +96,6 @@ describe('vertex-viewer-pin-label', () => {
     );
 
     await page.waitForChanges();
-
-    expect(el.querySelector(`#pin-label-${pin.id}`)).toEqualHtml(`
-      <div class="pin-label" id="pin-label-my-pin-id" style="top: 50px; left: 50px;">
-        My New Pin
-      </div>
-    `);
 
     const updatedPin = pinModel.getPinById(pin.id) as TextPin;
 
@@ -103,46 +133,24 @@ describe('vertex-viewer-pin-label', () => {
 
     const el = page.root as HTMLVertexViewerPinLabelLineElement;
 
-    const labelLine = el.querySelector(`#pin-label-${pin.id}`);
+    const label = el.querySelector(`#pin-label-${pin.id}`) as HTMLDivElement;
+    const input = el.querySelector(
+      `#pin-label-input-${pin.id}`
+    ) as HTMLTextAreaElement;
 
-    expect(labelLine).toEqualHtml(`
-      <div class="pin-label" id="pin-label-my-pin-id" style="top: 50px; left: 50px;">
-        My New Pin
-      </div>
+    expect(input).toEqualHtml(`
+      <textarea class="pin-label-input pin-label-text readonly" disabled="" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea>
     `);
 
     const originalPin = pinModel.getPinById(pin.id) as TextPin;
     expect(originalPin.label.point).toEqual({ x: 0, y: 0 });
-    labelLine?.dispatchEvent(
-      new MouseEvent('pointerdown', {
-        clientX: 50,
-        clientY: 50,
-      })
-    );
-
-    window.dispatchEvent(
-      new MouseEvent('pointermove', {
-        clientX: 50,
-        clientY: 50,
-      })
-    );
-
-    window.dispatchEvent(
-      new MouseEvent('pointerup', {
-        clientX: 50,
-        clientY: 50,
-      })
-    );
+    clickLabel(label);
 
     await page.waitForChanges();
 
-    expect(el.querySelector(`#pin-label-${pin.id}`)).toEqualHtml(`
-      <input class="pin-label" id="pin-label-my-pin-id" type="text" value="My New Pin" style="top: 50px; left: 50px;">
+    expect(input).toEqualHtml(`
+      <textarea class="pin-label-input pin-label-text" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea>
     `);
-
-    const input = page.root?.querySelector(
-      `#pin-label-${pin?.id}`
-    ) as HTMLInputElement;
 
     input.value = 'Updated Text';
     input.dispatchEvent(new Event('input'));
@@ -189,46 +197,25 @@ describe('vertex-viewer-pin-label', () => {
 
     const el = page.root as HTMLVertexViewerPinLabelLineElement;
 
-    const labelLine = el.querySelector(`#pin-label-${pin.id}`);
+    const label = el.querySelector(`#pin-label-${pin.id}`) as HTMLDivElement;
+    const input = el.querySelector(
+      `#pin-label-input-${pin.id}`
+    ) as HTMLTextAreaElement;
 
-    expect(labelLine).toEqualHtml(`
-      <div class="pin-label" id="pin-label-my-pin-id" style="top: 50px; left: 50px;">
-        My New Pin
-      </div>
+    expect(input).toEqualHtml(`
+      <textarea class="pin-label-input pin-label-text readonly" disabled="" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea>
     `);
 
     const originalPin = pinModel.getPinById(pin.id) as TextPin;
     expect(originalPin.label.point).toEqual({ x: 0, y: 0 });
-    labelLine?.dispatchEvent(
-      new MouseEvent('pointerdown', {
-        clientX: 50,
-        clientY: 50,
-      })
-    );
 
-    window.dispatchEvent(
-      new MouseEvent('pointermove', {
-        clientX: 50,
-        clientY: 50,
-      })
-    );
-
-    window.dispatchEvent(
-      new MouseEvent('pointerup', {
-        clientX: 50,
-        clientY: 50,
-      })
-    );
+    clickLabel(label);
 
     await page.waitForChanges();
 
-    expect(el.querySelector(`#pin-label-${pin.id}`)).toEqualHtml(`
-      <input class="pin-label" id="pin-label-my-pin-id" type="text" value="My New Pin" style="top: 50px; left: 50px;">
+    expect(input).toEqualHtml(`
+      <textarea class="pin-label-input pin-label-text" id="pin-label-input-my-pin-id" rows="1" value="My New Pin"></textarea>
     `);
-
-    const input = page.root?.querySelector(
-      `#pin-label-${pin?.id}`
-    ) as HTMLInputElement;
 
     input.value = 'Updated Text With Enter';
     input.dispatchEvent(new Event('input'));
@@ -236,6 +223,7 @@ describe('vertex-viewer-pin-label', () => {
     input.dispatchEvent(
       new KeyboardEvent('keydown', {
         key: 'Enter',
+        metaKey: true,
       })
     );
 
@@ -247,5 +235,192 @@ describe('vertex-viewer-pin-label', () => {
       point: { x: 0, y: 0 },
       text: 'Updated Text With Enter',
     });
+  });
+
+  it('should set min/max width to constrain to the viewer dimensions', async () => {
+    const worldPosition = Vector3.create();
+
+    const pinModel = new PinModel();
+    const pinController = new PinController(pinModel, 'edit', 'pin-label');
+
+    const dimensions: Dimensions.Dimensions = { height: 100, width: 100 };
+    const relativePointRightScreen = Point.create(0.4, 0);
+    const pin = {
+      id: 'my-pin-id',
+      worldPosition,
+      label: {
+        point: relativePointRightScreen,
+        text: 'My New Pin',
+      },
+    };
+    pinController.addPin(pin);
+
+    const page = await newSpecPage({
+      components: [VertexPinLabel],
+      template: () => (
+        <vertex-viewer-pin-label
+          elementBounds={dimensions as DOMRect}
+          pin={pin}
+          pinController={pinController}
+        />
+      ),
+    });
+
+    const el = page.root as HTMLVertexViewerPinLabelElement;
+    const label = el.querySelector(`#pin-label-${pin.id}`) as HTMLDivElement;
+    const input = el.querySelector(
+      `#pin-label-input-${pin.id}`
+    ) as HTMLTextAreaElement;
+
+    clickLabel(label);
+
+    await page.waitForChanges();
+
+    input.value = 'Some really long text that will overflow';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', metaKey: true })
+    );
+
+    await page.waitForChanges();
+
+    triggerResizeObserver([
+      {
+        contentRect: { width: 10, height: 10 },
+      },
+    ]);
+
+    await page.waitForChanges();
+
+    expect(label.style.maxWidth).toBe(
+      'min(var(--viewer-annotations-pin-label-max-width), calc(100px - 90px))'
+    );
+    expect(label.style.minWidth).toBe(
+      'min(16px, min(var(--viewer-annotations-pin-label-max-width), calc(100px - 90px)))'
+    );
+  });
+
+  it('should set max height to constrain to the viewer dimensions', async () => {
+    const worldPosition = Vector3.create();
+
+    const pinModel = new PinModel();
+    const pinController = new PinController(pinModel, 'edit', 'pin-label');
+
+    const dimensions: Dimensions.Dimensions = { height: 100, width: 100 };
+    const relativePointRightScreen = Point.create(0, 0.4);
+    const pin = {
+      id: 'my-pin-id',
+      worldPosition,
+      label: {
+        point: relativePointRightScreen,
+        text: 'My New Pin',
+      },
+    };
+    pinController.addPin(pin);
+
+    const page = await newSpecPage({
+      components: [VertexPinLabel],
+      template: () => (
+        <vertex-viewer-pin-label
+          elementBounds={dimensions as DOMRect}
+          pin={pin}
+          pinController={pinController}
+        />
+      ),
+    });
+
+    const el = page.root as HTMLVertexViewerPinLabelElement;
+    const label = el.querySelector(`#pin-label-${pin.id}`) as HTMLDivElement;
+    const input = el.querySelector(
+      `#pin-label-input-${pin.id}`
+    ) as HTMLTextAreaElement;
+
+    clickLabel(label);
+
+    await page.waitForChanges();
+
+    input.value = 'Some really long text that will overflow';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', metaKey: true })
+    );
+
+    await page.waitForChanges();
+
+    triggerResizeObserver([
+      {
+        contentRect: { width: 10, height: 10 },
+      },
+    ]);
+
+    await page.waitForChanges();
+
+    expect(label.style.maxHeight).toBe(
+      'min(var(--viewer-annotations-pin-label-max-height), calc(100px - 90px))'
+    );
+  });
+
+  it('should compute the row count based on the hidden content element', async () => {
+    const worldPosition = Vector3.create();
+
+    const pinModel = new PinModel();
+    const pinController = new PinController(pinModel, 'edit', 'pin-label');
+
+    const dimensions: Dimensions.Dimensions = { height: 100, width: 100 };
+    const relativePointRightScreen = Point.create(0, 0.4);
+    const pin = {
+      id: 'my-pin-id',
+      worldPosition,
+      label: {
+        point: relativePointRightScreen,
+        text: 'My New Pin',
+      },
+    };
+    pinController.addPin(pin);
+
+    const page = await newSpecPage({
+      components: [VertexPinLabel],
+      template: () => (
+        <vertex-viewer-pin-label
+          elementBounds={dimensions as DOMRect}
+          pin={pin}
+          pinController={pinController}
+        />
+      ),
+    });
+
+    const el = page.root as HTMLVertexViewerPinLabelElement;
+    const label = el.querySelector(`#pin-label-${pin.id}`) as HTMLDivElement;
+    const input = el.querySelector(
+      `#pin-label-input-${pin.id}`
+    ) as HTMLTextAreaElement;
+
+    clickLabel(label);
+
+    await page.waitForChanges();
+
+    input.value = 'Some really long text that will overflow';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', metaKey: true })
+    );
+
+    await page.waitForChanges();
+
+    mockGetComputedStyle.mockReturnValue({
+      height: '48px',
+      borderWidth: '2px',
+      lineHeight: '16px',
+    });
+
+    triggerResizeObserver([
+      {
+        contentRect: { width: 10, height: 10 },
+      },
+    ]);
+
+    await page.waitForChanges();
+
+    expect(input.getAttribute('rows')).toBe('3');
   });
 });

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -185,6 +185,8 @@ export class VertexPinLabel {
             maxHeight: this.computeMaxHeight(),
           }}
         >
+          {/* This corrects for a behavior in Firefox where setting the `disabled` attribute to true */}
+          {/* prevents any events from propagating. */}
           {!this.focused && (
             <div
               class="pin-input-drag-target"
@@ -220,6 +222,9 @@ export class VertexPinLabel {
   }
 
   private hiddenContent(): Array<string | HTMLBRElement> {
+    // This corrects some inconsistencies in how a newline character
+    // is represented in a div. Leveraging `<br>`s results in a more
+    // consistent representation of the newlines in a textarea.
     return this.value.includes('\n')
       ? this.value
           .split('\n')

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -22,6 +22,7 @@ import {
   translatePointToRelative,
   translatePointToScreen,
 } from '../viewer-markup/utils';
+import { getComputedStyle } from './utils';
 
 @Component({
   tag: 'vertex-viewer-pin-label',
@@ -184,6 +185,12 @@ export class VertexPinLabel {
             maxHeight: this.computeMaxHeight(),
           }}
         >
+          {!this.focused && (
+            <div
+              class="pin-input-drag-target"
+              onPointerDown={this.handlePointerDown}
+            />
+          )}
           <textarea
             id={`pin-label-input-${this.pin?.id}`}
             class={classNames('pin-label-input', 'pin-label-text', {
@@ -206,22 +213,30 @@ export class VertexPinLabel {
             maxHeight: this.computeMaxHeight(),
           }}
         >
-          {this.value
-            .split('\n')
-            .reduce(
-              (res, str) => [...res, str, <br />],
-              [] as Array<string | HTMLBRElement>
-            )}
+          {this.hiddenContent()}
         </div>
       </Host>
     );
   }
 
-  private computeMinWidth(): string | undefined {
+  private hiddenContent(): Array<string | HTMLBRElement> {
+    return this.value.includes('\n')
+      ? this.value
+          .split('\n')
+          .reduce(
+            (res, str) => [...res, str, <br />],
+            [] as Array<string | HTMLBRElement>
+          )
+      : [this.value];
+  }
+
+  private computeMinWidth(): string {
     if (this.contentElBounds != null) {
       const expected = `${this.contentElBounds.width + 16}px`;
 
       return `min(${expected}, ${this.computeMaxWidth()})`;
+    } else {
+      return `var(--viewer-annotations-pin-label-min-width)`;
     }
   }
 
@@ -262,7 +277,7 @@ export class VertexPinLabel {
     readDOM(() => {
       if (this.contentEl != null) {
         this.contentElBounds = this.contentEl.getBoundingClientRect();
-        const computedStyles = window.getComputedStyle(this.contentEl);
+        const computedStyles = getComputedStyle(this.contentEl);
         this.textareaRows = Math.max(
           1,
           Math.ceil(

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -60,6 +60,20 @@ export class VertexPinLabel {
   @Event({ bubbles: true })
   public labelChanged!: EventEmitter<void>;
 
+  /**
+   * Emitted whenever the label is focused, with the ID of the
+   * associated pin (or undefined if no pin is provided).
+   */
+  @Event({ bubbles: true })
+  public labelFocused!: EventEmitter<string | undefined>;
+
+  /**
+   * Emitted whenever the label is blurred, with the ID of the
+   * associated pin (or undefined if no pin is provided).
+   */
+  @Event({ bubbles: true })
+  public labelBlurred!: EventEmitter<string | undefined>;
+
   @Element()
   private hostEl!: HTMLElement;
 
@@ -337,6 +351,7 @@ export class VertexPinLabel {
 
       if (distanceBetweenStartAndEndPoint <= 2) {
         this.focused = true;
+        this.labelFocused.emit(this.pin?.id);
       }
     }
 
@@ -353,6 +368,7 @@ export class VertexPinLabel {
 
   private submit(): void {
     this.focused = false;
+    this.labelBlurred.emit(this.pin?.id);
     if (this.pin != null) {
       this.pinController?.setPin({
         ...this.pin,

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -185,14 +185,6 @@ export class VertexPinLabel {
             maxHeight: this.computeMaxHeight(),
           }}
         >
-          {/* This corrects for a behavior in Firefox where setting the `disabled` attribute to true */}
-          {/* prevents any events from propagating. */}
-          {!this.focused && (
-            <div
-              class="pin-input-drag-target"
-              onPointerDown={this.handlePointerDown}
-            />
-          )}
           <textarea
             id={`pin-label-input-${this.pin?.id}`}
             class={classNames('pin-label-input', 'pin-label-text', {
@@ -206,6 +198,14 @@ export class VertexPinLabel {
             onInput={this.handleTextInput}
             onBlur={this.handleTextBlur}
           />
+          {/* This corrects for a behavior in Firefox where setting the `disabled` attribute to true */}
+          {/* prevents any events from propagating. */}
+          {!this.focused && (
+            <div
+              class="pin-input-drag-target"
+              onPointerDown={this.handlePointerDown}
+            />
+          )}
         </div>
         <div
           ref={(el) => (this.contentEl = el)}


### PR DESCRIPTION
## Summary

Makes a handful of improvements to the text pin label behavior:
- Dragging the label is now based off relative difference from the `pointerdown` event versus the label anchor, and will stay under the cursor when dragging from somewhere in the middle of the label
- Styles have been updated to be more consistent between the "readonly" state and the focused state
- The `input` element has been changed to a `textarea` along with auto resizing behavior to support multiline text content
- A max width + height have been added
- The labels are now constrained to the width and height of the viewer such that typing content will not go off-screen and shift the location of the overlay (and shift the 3D pin anchors)
- A `labelFocused` and a `labelBlurred` event have been added

## Test Plan

- Test text pins generally (single line + multiline)
- Test moving labels around starting from the center/end of the label
- Test typing content close to the edges of the viewer window
- Test the max width and height with large amounts of content

## Release Notes

N/A

## Possible Regressions

Text pins behavior, could be an impact due to the introduction of a `textarea`

## Dependencies

N/A
