### PR TITLE
[PLAT-1290] Support for draggable pins

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -1932,7 +1932,7 @@ declare namespace LocalJSX {
      */
     occlusionOff?: boolean;
     /**
-     * An event that is emitted any property on the dom group changes
+     * An event that is emitted when any property on the dom group changes
      */
     onPropertyChange?: (event: CustomEvent<void>) => void;
     /**
@@ -1974,7 +1974,7 @@ declare namespace LocalJSX {
      */
     matrix?: Matrix4.Matrix4;
     /**
-     * An event that is emitted any property on the dom group changes
+     * An event that is emitted when any property on the dom group changes
      */
     onPropertyChange?: (event: CustomEvent<void>) => void;
     /**

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -1932,6 +1932,10 @@ declare namespace LocalJSX {
      */
     occlusionOff?: boolean;
     /**
+     * An event that is emitted any property on the dom group changes
+     */
+    onPropertyChange?: (event: CustomEvent<void>) => void;
+    /**
      * The local 3D position of where this element is located.
      */
     position?: Vector3.Vector3;
@@ -1969,6 +1973,10 @@ declare namespace LocalJSX {
      * The local matrix of this element.
      */
     matrix?: Matrix4.Matrix4;
+    /**
+     * An event that is emitted any property on the dom group changes
+     */
+    onPropertyChange?: (event: CustomEvent<void>) => void;
     /**
      * The local 3D position of where this element is located.
      */

--- a/packages/viewer/src/components/viewer-dom-element/readme.md
+++ b/packages/viewer/src/components/viewer-dom-element/readme.md
@@ -35,9 +35,9 @@ information.
 
 ## Events
 
-| Event            | Description                                                    | Type                |
-| ---------------- | -------------------------------------------------------------- | ------------------- |
-| `propertyChange` | An event that is emitted any property on the dom group changes | `CustomEvent<void>` |
+| Event            | Description                                                         | Type                |
+| ---------------- | ------------------------------------------------------------------- | ------------------- |
+| `propertyChange` | An event that is emitted when any property on the dom group changes | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/packages/viewer/src/components/viewer-dom-element/readme.md
+++ b/packages/viewer/src/components/viewer-dom-element/readme.md
@@ -33,6 +33,13 @@ information.
 | `scaleJson`       | `scale`            | The local scale of this element, as a JSON string. JSON string representation can either be in the format of `[x, y, z]` or `{"x": 0, "y": 0, "z": 0}`.                                                                        | `string`                                                                                                                           | `''`                      |
 
 
+## Events
+
+| Event            | Description                                                    | Type                |
+| ---------------- | -------------------------------------------------------------- | ------------------- |
+| `propertyChange` | An event that is emitted any property on the dom group changes | `CustomEvent<void>` |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.spec.tsx
+++ b/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.spec.tsx
@@ -33,12 +33,15 @@ describe('vertex-viewer-dom-element', () => {
   });
 
   it('syncs properties when json attributes change', async () => {
+    const onPropertyChanged = jest.fn();
+
     const page = await newSpecPage({
       components: [ViewerDomElement],
       html: `<vertex-viewer-dom-element></vertex-viewer-dom-element>`,
     });
 
     const el = page.root as HTMLVertexViewerDomElementElement;
+    el.addEventListener('propertyChange', onPropertyChanged);
 
     const position = Vector3.create(1, 2, 3);
     const rotation = Euler.create({ x: 2, y: 3, z: 4 });
@@ -63,6 +66,7 @@ describe('vertex-viewer-dom-element', () => {
     expect(el.scale).toEqual(scale);
 
     expect(el.matrix).toEqual(matrix);
+    expect(onPropertyChanged).toHaveBeenCalledTimes(4);
   });
 
   it('updates quaternion when rotation changes', async () => {

--- a/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
+++ b/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
@@ -146,6 +146,9 @@ export class ViewerDomElement implements HTMLDomRendererPositionableElement {
     this.syncScale();
   }
 
+  /**
+   * @ignore
+   */
   @Watch('matrix')
   protected handleMatrixChanged(
     newMatrix: Matrix4.Matrix4,

--- a/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
+++ b/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
@@ -9,13 +9,7 @@ import {
   Prop,
   Watch,
 } from '@stencil/core';
-import {
-  Euler,
-  Matrix,
-  Matrix4,
-  Quaternion,
-  Vector3,
-} from '@vertexvis/geometry';
+import { Euler, Matrix4, Quaternion, Vector3 } from '@vertexvis/geometry';
 import { Objects } from '@vertexvis/utils';
 
 import { HTMLDomRendererPositionableElement } from '../../interfaces';

--- a/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
+++ b/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
@@ -1,7 +1,22 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 
-import { Component, h, Host, Prop, Watch } from '@stencil/core';
-import { Euler, Matrix4, Quaternion, Vector3 } from '@vertexvis/geometry';
+import {
+  Component,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+  Watch,
+} from '@stencil/core';
+import {
+  Euler,
+  Matrix,
+  Matrix4,
+  Quaternion,
+  Vector3,
+} from '@vertexvis/geometry';
+import { Objects } from '@vertexvis/utils';
 
 import { HTMLDomRendererPositionableElement } from '../../interfaces';
 
@@ -137,6 +152,16 @@ export class ViewerDomElement implements HTMLDomRendererPositionableElement {
     this.syncScale();
   }
 
+  @Watch('matrix')
+  protected handleMatrixChanged(
+    newMatrix: Matrix4.Matrix4,
+    oldMatrix: Matrix4.Matrix4
+  ): void {
+    if (!Objects.isEqual(newMatrix, oldMatrix)) {
+      this.propertyChange.emit();
+    }
+  }
+
   /**
    * The local matrix of this element.
    */
@@ -182,6 +207,12 @@ export class ViewerDomElement implements HTMLDomRendererPositionableElement {
    */
   @Prop({ reflect: true })
   public interactionsOff = false;
+
+  /**
+   * An event that is emitted any property on the dom group changes
+   */
+  @Event({ bubbles: true })
+  public propertyChange!: EventEmitter<void>;
 
   /**
    * @ignore

--- a/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
+++ b/packages/viewer/src/components/viewer-dom-element/viewer-dom-element.tsx
@@ -206,7 +206,7 @@ export class ViewerDomElement implements HTMLDomRendererPositionableElement {
   public interactionsOff = false;
 
   /**
-   * An event that is emitted any property on the dom group changes
+   * An event that is emitted when any property on the dom group changes
    */
   @Event({ bubbles: true })
   public propertyChange!: EventEmitter<void>;

--- a/packages/viewer/src/components/viewer-dom-group/readme.md
+++ b/packages/viewer/src/components/viewer-dom-group/readme.md
@@ -28,6 +28,13 @@ information.
 | `scaleJson`      | `scale`      | The local scale of this element, as a JSON string. JSON string representation can either be in the format of `[x, y, z]` or `{"x": 0, "y": 0, "z": 0}`.                   | `string`                                                                                                                           | `''`                      |
 
 
+## Events
+
+| Event            | Description                                                    | Type                |
+| ---------------- | -------------------------------------------------------------- | ------------------- |
+| `propertyChange` | An event that is emitted any property on the dom group changes | `CustomEvent<void>` |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/viewer/src/components/viewer-dom-group/readme.md
+++ b/packages/viewer/src/components/viewer-dom-group/readme.md
@@ -30,9 +30,9 @@ information.
 
 ## Events
 
-| Event            | Description                                                    | Type                |
-| ---------------- | -------------------------------------------------------------- | ------------------- |
-| `propertyChange` | An event that is emitted any property on the dom group changes | `CustomEvent<void>` |
+| Event            | Description                                                         | Type                |
+| ---------------- | ------------------------------------------------------------------- | ------------------- |
+| `propertyChange` | An event that is emitted when any property on the dom group changes | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.spec.tsx
+++ b/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.spec.tsx
@@ -31,12 +31,15 @@ describe('vertex-viewer-dom-group', () => {
   });
 
   it('syncs properties when json attributes change', async () => {
+    const onPropertyChanged = jest.fn();
     const page = await newSpecPage({
       components: [ViewerDomGroup],
       html: `<vertex-viewer-dom-group></vertex-viewer-dom-group>`,
     });
 
     const el = page.root as HTMLVertexViewerDomElementElement;
+
+    el.addEventListener('propertyChange', onPropertyChanged);
 
     const position = Vector3.create(1, 2, 3);
     const rotation = Euler.create({ x: 2, y: 3, z: 4 });
@@ -61,6 +64,8 @@ describe('vertex-viewer-dom-group', () => {
     expect(el.scale).toEqual(scale);
 
     expect(el.matrix).toEqual(matrix);
+
+    expect(onPropertyChanged).toHaveBeenCalledTimes(4);
   });
 
   it('updates quaternion when rotation changes', async () => {

--- a/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.tsx
+++ b/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.tsx
@@ -51,7 +51,7 @@ export class ViewerDomGroup implements HTMLDomRendererPositionableElement {
   }
 
   /**
-   * An event that is emitted any property on the dom group changes
+   * An event that is emitted when any property on the dom group changes
    */
   @Event({ bubbles: true })
   public propertyChange!: EventEmitter<void>;

--- a/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.tsx
+++ b/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.tsx
@@ -1,7 +1,16 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 
-import { Component, h, Host, Prop, Watch } from '@stencil/core';
+import {
+  Component,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+  Watch,
+} from '@stencil/core';
 import { Euler, Matrix4, Quaternion, Vector3 } from '@vertexvis/geometry';
+import { Objects } from '@vertexvis/utils';
 
 import { HTMLDomRendererPositionableElement } from '../../interfaces';
 
@@ -40,6 +49,12 @@ export class ViewerDomGroup implements HTMLDomRendererPositionableElement {
   protected handlePositionJsonChanged(): void {
     this.syncPosition();
   }
+
+  /**
+   * An event that is emitted any property on the dom group changes
+   */
+  @Event({ bubbles: true })
+  public propertyChange!: EventEmitter<void>;
 
   /**
    * The local rotation of this element in Euler angles.
@@ -129,6 +144,16 @@ export class ViewerDomGroup implements HTMLDomRendererPositionableElement {
   @Watch('scaleJson')
   protected handleScaleJsonChanged(): void {
     this.syncScale();
+  }
+
+  @Watch('matrix')
+  protected handleMatrixChanged(
+    newMatrix: Matrix4.Matrix4,
+    oldMatrix: Matrix4.Matrix4
+  ): void {
+    if (!Objects.isEqual(newMatrix, oldMatrix)) {
+      this.propertyChange.emit();
+    }
   }
 
   /**

--- a/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.tsx
+++ b/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.tsx
@@ -146,6 +146,9 @@ export class ViewerDomGroup implements HTMLDomRendererPositionableElement {
     this.syncScale();
   }
 
+  /**
+   * @ignore
+   */
   @Watch('matrix')
   protected handleMatrixChanged(
     newMatrix: Matrix4.Matrix4,

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.css
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.css
@@ -74,6 +74,7 @@
 
 .pin {
   color: var(--viewer-annotations-pin-color);
+  cursor: pointer;
 }
 
 .pin-selected {

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
@@ -1,25 +1,18 @@
 import {
   Component,
-  Event,
-  EventEmitter,
   Fragment,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   h,
   Prop,
   State,
-  Watch,
 } from '@stencil/core';
 import { Dimensions, Matrix4, Point, Vector3 } from '@vertexvis/geometry';
 
 import { Viewport } from '../..';
-import { getMouseClientPosition } from '../../lib/dom';
 import { PinController } from '../../lib/pins/controller';
 import { isTextPin, Pin, TextPin } from '../../lib/pins/model';
 import { PinModel } from '../../lib/pins/model';
-import {
-  translatePointToRelative,
-  translatePointToScreen,
-} from '../viewer-markup/utils';
+import { translatePointToScreen } from '../viewer-markup/utils';
 import { PinRenderer } from './pin-renderer';
 import { getClosestCenterToPoint } from './utils';
 

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
@@ -1,18 +1,25 @@
 import {
   Component,
+  Event,
+  EventEmitter,
   Fragment,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   h,
   Prop,
   State,
+  Watch,
 } from '@stencil/core';
 import { Dimensions, Matrix4, Point, Vector3 } from '@vertexvis/geometry';
 
 import { Viewport } from '../..';
+import { getMouseClientPosition } from '../../lib/dom';
 import { PinController } from '../../lib/pins/controller';
 import { isTextPin, Pin, TextPin } from '../../lib/pins/model';
 import { PinModel } from '../../lib/pins/model';
-import { translatePointToScreen } from '../viewer-markup/utils';
+import {
+  translatePointToRelative,
+  translatePointToScreen,
+} from '../viewer-markup/utils';
 import { PinRenderer } from './pin-renderer';
 import { getClosestCenterToPoint } from './utils';
 
@@ -110,8 +117,9 @@ export class ViewerPinGroup {
             if (e.buttons !== 2) {
               e.stopPropagation();
             }
-
             this.pinController?.setSelectedPinId(this.pin?.id);
+
+            this.handleAnchorPointerDown(e);
           }}
         >
           {this.leafNodesRendered && (
@@ -206,6 +214,18 @@ export class ViewerPinGroup {
       }),
     };
   }
+
+  private handleAnchorPointerDown = (event: PointerEvent): void => {
+    if (
+      this.elementBounds != null &&
+      this.pinController?.getToolMode() === 'edit' &&
+      this.pin != null
+    ) {
+      this.pinController?.setDraggable({
+        id: this.pin.id,
+      });
+    }
+  };
 
   private getFromWorldPosition(
     pt: Vector3.Vector3,

--- a/packages/viewer/src/lib/pins/__tests__/interactions.spec.ts
+++ b/packages/viewer/src/lib/pins/__tests__/interactions.spec.ts
@@ -1,0 +1,111 @@
+import { Point, Vector3 } from '@vertexvis/geometry';
+import { StreamApi } from '@vertexvis/stream-api';
+
+import { eventually } from '../../../testing';
+import { CursorManager, labelPinCursor, pinCursor } from '../../cursors';
+import { InteractionApiPerspective } from '../../interactions';
+import { EntityType } from '../../types';
+import { PinController } from '../controller';
+import { PinsInteractionHandler } from '../interactions';
+import { PinModel } from '../model';
+
+describe('PinsInteractionHandler', () => {
+  const model = new PinModel();
+  const controller = new PinController(model);
+
+  const api = new InteractionApiPerspective(
+    new StreamApi(),
+    new CursorManager(),
+    jest.fn(),
+    jest.fn(),
+    jest.fn(),
+    jest.fn(),
+    { emit: jest.fn() },
+    { emit: jest.fn() },
+    { emit: jest.fn() },
+    { emit: jest.fn() },
+    { emit: jest.fn() }
+  );
+
+  const pin = {
+    id: 'my-pin-id',
+    worldPosition: Vector3.create(),
+    label: {
+      point: Point.create(),
+      text: 'My New Pin',
+    },
+  };
+
+  const element = document.createElement('div');
+  const handler = new PinsInteractionHandler(controller);
+
+  beforeEach(() => {
+    handler.dispose();
+    handler.initialize(element, api);
+
+    controller.setDraggable(undefined);
+
+    controller.addPin(pin);
+    jest.resetAllMocks();
+  });
+
+  it('supports dragging pins', async () => {
+    controller.setDraggable({
+      id: pin.id,
+    });
+
+    mockDroppableSurface();
+    mockGetWorldPointFromViewport();
+    element.dispatchEvent(new MouseEvent('pointermove'));
+
+    await eventually(() => {
+      const updatedPoint = model.getPinById(pin.id);
+      expect(updatedPoint.worldPosition).toEqual({
+        x: 1,
+        y: 2,
+        z: 3,
+      });
+    });
+  });
+
+  it('supports switching the cursor when over geometry', async () => {
+    const addCursor = jest.spyOn(api, 'addCursor');
+    controller.setToolMode('edit');
+
+    function reset(): void {
+      addCursor.mockClear();
+    }
+
+    mockDroppableSurface();
+    element.dispatchEvent(new MouseEvent('pointermove'));
+
+    await eventually(() => {
+      expect(addCursor).toHaveBeenCalledWith(pinCursor);
+    });
+    reset();
+
+    controller.setToolType('pin-label');
+
+    element.dispatchEvent(new MouseEvent('pointermove'));
+
+    await eventually(() => {
+      expect(addCursor).toHaveBeenCalledWith(labelPinCursor);
+    });
+    reset();
+  });
+
+  function mockDroppableSurface(type = EntityType.GENERIC_GEOMETRY): void {
+    const getEntityTypeAtPoint = jest.spyOn(api, 'getEntityTypeAtPoint');
+    getEntityTypeAtPoint.mockResolvedValue(type);
+  }
+
+  function mockGetWorldPointFromViewport(
+    mockedPoint = Vector3.create(1, 2, 3)
+  ): void {
+    const getWorldPointFromViewport = jest.spyOn(
+      api,
+      'getWorldPointFromViewport'
+    );
+    getWorldPointFromViewport.mockResolvedValue(mockedPoint);
+  }
+});

--- a/packages/viewer/src/lib/pins/controller.ts
+++ b/packages/viewer/src/lib/pins/controller.ts
@@ -1,10 +1,18 @@
+import { Point, Vector3 } from '@vertexvis/geometry';
+
 import { Pin, PinModel, ViewerPinToolMode, ViewerPinToolType } from './model';
+
+export interface Draggable {
+  id: string;
+  lastPoint?: Point.Point;
+}
 
 /**
  * The `PinController` is responsible for adding pin entities to the viewer canvas
  */
 export class PinController {
-  private dragging?: boolean = false;
+  private draggable?: Draggable;
+
   public constructor(
     private model: PinModel,
     private mode: ViewerPinToolMode = 'view',
@@ -95,11 +103,29 @@ export class PinController {
     this.type = type;
   }
 
-  public getDragging(): boolean {
-    return this.dragging || false;
+  public getDraggable(): Draggable | undefined {
+    return this.draggable;
   }
 
-  public setDragging(dragging: boolean): void {
-    this.dragging = dragging;
+  public setDraggable(draggable: Draggable | undefined): void {
+    this.draggable = draggable;
+  }
+
+  public updateDraggable(
+    draggable: Draggable,
+    worldPosition: Vector3.Vector3,
+    partId?: string
+  ): void {
+    if (this.draggable != null) {
+      this.draggable = draggable;
+    }
+    const pin = this.model.getPinById(draggable.id);
+    if (pin != null) {
+      this.updatePin({
+        ...pin,
+        worldPosition,
+        partId,
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes introduce moving the world position on the pin. You can drag the anchor for a text label, as well as a regular simple pin while in edit mode. 

![draggable pins](https://user-images.githubusercontent.com/49169871/163278169-5fa5f4c6-af04-4edd-af25-7916a6d89a16.gif)


## Test Plan
<!-- How to test changes. -->

- Test that you can drag a text pin anchor and that it's always positioned on the model
- Verify you can do the same with a simple pin

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
