### PR TITLE
[PLAT-1035] Improved Scene Tree error states

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -142,13 +142,6 @@ export class SceneTreeController {
     return this.state.connection.type === 'connected';
   }
 
-  /**
-   * Returns the connection state of the controller
-   */
-  public get connectionState(): ConnectionState {
-    return this.state.connection;
-  }
-
   public constructor(
     private client: SceneTreeAPIClient,
     private rowLimit: number,

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -142,6 +142,13 @@ export class SceneTreeController {
     return this.state.connection.type === 'connected';
   }
 
+  /**
+   * Returns the connection state of the controller
+   */
+  public get connectionState(): ConnectionState {
+    return this.state.connection;
+  }
+
   public constructor(
     private client: SceneTreeAPIClient,
     private rowLimit: number,

--- a/packages/viewer/src/components/scene-tree/lib/errors.ts
+++ b/packages/viewer/src/components/scene-tree/lib/errors.ts
@@ -1,7 +1,7 @@
 export enum SceneTreeErrorCode {
   UNKNOWN = 0,
   SCENE_TREE_DISABLED = 1,
-  UNINITIALIZED_VIEWER = 2,
+  MISSING_VIEWER = 2,
   DISCONNECTED = 3,
 }
 
@@ -22,7 +22,7 @@ function getSceneTreeErrorMessage(code: SceneTreeErrorCode): string {
       return 'An unknown error occurred.';
     case SceneTreeErrorCode.SCENE_TREE_DISABLED:
       return 'The tree for this scene is not enabled. Enable the tree for this scene to interact with the tree.';
-    case SceneTreeErrorCode.UNINITIALIZED_VIEWER:
+    case SceneTreeErrorCode.MISSING_VIEWER:
       return 'Could not find reference to the viewer';
     case SceneTreeErrorCode.DISCONNECTED:
       return 'Disconnected from server.';

--- a/packages/viewer/src/components/scene-tree/lib/errors.ts
+++ b/packages/viewer/src/components/scene-tree/lib/errors.ts
@@ -1,6 +1,8 @@
 export enum SceneTreeErrorCode {
   UNKNOWN = 0,
   SCENE_TREE_DISABLED = 1,
+  UNINITIALIZED_VIEWER = 2,
+  DISCONNECTED = 3,
 }
 
 export class SceneTreeErrorDetails {
@@ -20,5 +22,9 @@ function getSceneTreeErrorMessage(code: SceneTreeErrorCode): string {
       return 'An unknown error occurred.';
     case SceneTreeErrorCode.SCENE_TREE_DISABLED:
       return 'The tree for this scene is not enabled. Enable the tree for this scene to interact with the tree.';
+    case SceneTreeErrorCode.UNINITIALIZED_VIEWER:
+      return 'Could not find reference to the viewer';
+    case SceneTreeErrorCode.DISCONNECTED:
+      return 'Disconnected from server.';
   }
 }

--- a/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
@@ -225,8 +225,6 @@ describe('<vertex-scene-tree>', () => {
 
       await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
 
-      tree.viewerSelector = '#invalid';
-
       await page.waitForChanges();
 
       const errorEl = tree.shadowRoot?.querySelector('.error');

--- a/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
@@ -210,6 +210,37 @@ describe('<vertex-scene-tree>', () => {
       const errorEl = tree.shadowRoot?.querySelector('.error');
       expect(errorEl).toBeDefined();
     });
+
+    it('renders message if viewer not found', async () => {
+      const client = mockSceneTreeClient();
+      mockGetTree({ client });
+
+      const { stream, ws } = makeViewerStream();
+      const controller = new SceneTreeController(client, 100);
+      const { tree, viewer, page } = await newSceneTreeSpec({
+        controller,
+        stream,
+        viewerSelector: '#invalid-viewer',
+      });
+
+      await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
+
+      tree.viewerSelector = '#invalid';
+
+      await page.waitForChanges();
+
+      const errorEl = tree.shadowRoot?.querySelector('.error');
+
+      expect(errorEl).not.toBeNull();
+
+      const errorMessage = tree.shadowRoot?.querySelector('.error-message');
+
+      expect(errorMessage).not.toBeNull();
+
+      expect(errorMessage?.firstChild?.firstChild?.nodeValue).toEqual(
+        'Could not find reference to the viewer'
+      );
+    });
   });
 
   describe('disconnecting', () => {
@@ -966,6 +997,7 @@ describe('<vertex-scene-tree>', () => {
 async function newSceneTreeSpec(data: {
   controller: SceneTreeController;
   stream: ViewerStream;
+  viewerSelector?: string;
   template?: () => unknown;
   setup?: (data: { client: SceneTreeAPIClient }) => void;
 }): Promise<{
@@ -982,7 +1014,7 @@ async function newSceneTreeSpec(data: {
           <div>
             <vertex-scene-tree
               controller={data.controller}
-              viewerSelector="#viewer"
+              viewerSelector={data.viewerSelector || '#viewer'}
             />
             <vertex-viewer
               id="viewer"

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -723,11 +723,9 @@ export class SceneTree {
     this.stateMap.viewerDisposable?.dispose();
 
     if (this.viewer == null && this.viewerSelector != null) {
-      if (this.viewerSelector != null) {
-        this.viewer = document.querySelector(this.viewerSelector) as
-          | HTMLVertexViewerElement
-          | undefined;
-      }
+      this.viewer = document.querySelector(this.viewerSelector) as
+        | HTMLVertexViewerElement
+        | undefined;
     }
 
     if (this.viewer != null) {

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -634,12 +634,12 @@ export class SceneTree {
     if (this.connectionErrorDetails != null) {
       return this.connectionErrorDetails;
     } else if (this.stateMap.componentLoaded && this.viewer == null) {
-      return new SceneTreeErrorDetails(SceneTreeErrorCode.UNINITIALIZED_VIEWER);
+      return new SceneTreeErrorDetails(SceneTreeErrorCode.MISSING_VIEWER);
     } else if (
       this.stateMap.componentLoaded &&
       this.controller?.connectionState.type === 'disconnected'
     ) {
-      return new SceneTreeErrorDetails(SceneTreeErrorCode.UNKNOWN);
+      return new SceneTreeErrorDetails(SceneTreeErrorCode.DISCONNECTED);
     }
 
     return undefined;


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes introduce some improvements to the messaging & retry-ability of a non loaded scene tree. Below are two things I think might be happening, both of them are error states, but the second could be a symptom of the first. Since this has been historically hard to reproduce, I am proposing to add custom error messages in either of these two conditions. 

1. Upon investigation, I found that when using the `viewer-selector`, the scene tree does not try to look up the viewer again in the dom. A potential longer term fix here could be to check if the viewer-selector is not null, and the viewer _is_ null, and re-assign that on a post-render event. For now I'd prefer to gather additional information, as well as display to the user what's really happening. This case specifically happens when the scene tree loads, but the reference to the viewer is either incorrect, or not yet in the dom. I added a unique error message for this case, and it should only show if the scene tree has registered that it has loaded, but the viewer reference is still null. Here is an example of what I've seen a few times, and the proposed error state:

https://user-images.githubusercontent.com/49169871/166744515-261fc736-602b-4e03-96e0-e01aff7ff576.mp4

2. Additionally, I found some cases where the scene-tree controller was in a `disconnected` state, but the viewer was not present. This, too, I believe we could remedy but for now I'd prefer to show a message to the user with a basic "retry" similar to the scene tree 'failure' conditions. This was not simple to reproduce, but I believe I saw it one time. This could be a symptom of the first issue, but I'd like this to be captured in case there is some scenario that the viewer is not null, but a connection to the controller has never been initiated. 


## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
