### PR TITLE
[PLAT-1035] Load layout on render

### DIFF
--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -602,9 +602,11 @@ export class SceneTree {
         SceneTreeErrorCode.MISSING_VIEWER
       );
     }
+  }
 
+  public componentWillRender(): void {
     // The controller can load data prior to the first render
-    // ensure that this renders the row.
+    // ensure that this renders any time the state changes.
     this.updateLayoutElement();
   }
 
@@ -755,7 +757,6 @@ export class SceneTree {
   private handleControllerStateChange(state: SceneTreeState): void {
     this.rows = state.rows;
     this.totalRows = state.totalRows;
-    this.updateLayoutElement();
 
     if (state.connection.type === 'failure') {
       this.errorDetails = state.connection.details;

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -702,6 +702,7 @@ export class SceneTree {
 
   private retryConnectToViewer(): void {
     this.attemptingRetry = true;
+    this.errorDetails = undefined;
     this.connectToViewer();
   }
 

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -602,6 +602,10 @@ export class SceneTree {
         SceneTreeErrorCode.MISSING_VIEWER
       );
     }
+
+    // The controller can load data prior to the first render
+    // ensure that this renders the row.
+    this.updateLayoutElement();
   }
 
   /**
@@ -854,6 +858,10 @@ export class SceneTree {
       layout.totalRows = this.totalRows;
       layout.controller = this.controller;
       layout.rowData = this.rowData;
+    } else if (!this.stateMap.componentLoaded && this.totalRows > 0) {
+      console.debug(
+        'Scene tree has rows, but the component has not yet rendered'
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->

These changes introduce a resolution to a long standing bug. Here were my steps to reproduce the issue, although it was still intermittent:

1. In a developer console in Chrome, set the CPU slowdown to 4x or 6x. 
2. Open the Scene tree (Ideally if you're on a fast network)
3. The scene tree intermittently does not load. 

The nature of this bug is that the scene tree controller is dispatching updates from the network responses, prior to the scene tree component rendering for the first time. The first time render is where we ensure that the scene-tree-layout is defined:
```ts
  public componentWillRender(): void {
    this.ensureLayoutDefined(); // <-- here
    ...
  }
```

The `updateLayoutElements` only gets called on a state change, and within that function is the following:
```ts
  if (layout != null) {
      layout.rows = this.rows;
      layout.tree = this.el as HTMLVertexSceneTreeElement;
      layout.totalRows = this.totalRows;
      layout.controller = this.controller;
      layout.rowData = this.rowData;
    }
```

Currently we are eating any updates from the controller if the layout is not yet defined. My proposed solution here is to call this function `updateLayoutElement()` _after_ we have ensured that the template is defined in the above function `componentWillRender()`

Additionally, I have added a debug statement within the updateLayoutElements under the following condition: `else if (componentNotLoaded && this.rows > 0)`

## Test Plan
<!-- How to test changes. -->

- See repro steps defined above. Expect the scene tree to _always_ load if the user is getting frames.

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
