### PR TITLE
[PLAT-645] Select scene tree search results

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -214,7 +214,7 @@ export namespace Components {
      * @param term The filter term.
      * @returns A promise that resolves with the selected rows.
      */
-    selectFilteredItems: (term: string) => Promise<Row[]>;
+    selectFilteredItems: (term: string) => Promise<Row[] | void>;
     /**
      * Performs an API call that will select the item associated to the given row or row index.  This method supports a `recurseParent` option that allows for recursively selecting the next unselected parent node. This behavior is considered stateful. Each call to `selectItem` will track the ancestry of the passed in `rowArg`. If calling `selectItem` with a row not belonging to the ancestry of a previous selection, then this method will perform a standard selection.
      * @param row The row, row index or node to select.

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -210,6 +210,12 @@ export namespace Components {
      */
     scrollToItem: (itemId: string, options?: ScrollToOptions) => Promise<void>;
     /**
+     * Performs an async request that will select the filtered items in the tree that match the given term.
+     * @param term The filter term.
+     * @returns A promise that resolves with the selected rows.
+     */
+    selectFilteredItems: (term: string) => Promise<Row[]>;
+    /**
      * Performs an API call that will select the item associated to the given row or row index.  This method supports a `recurseParent` option that allows for recursively selecting the next unselected parent node. This behavior is considered stateful. Each call to `selectItem` will track the ancestry of the passed in `rowArg`. If calling `selectItem` with a row not belonging to the ancestry of a previous selection, then this method will perform a standard selection.
      * @param row The row, row index or node to select.
      * @param options A set of options to configure selection behavior.

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -212,9 +212,9 @@ export namespace Components {
     /**
      * Performs an async request that will select the filtered items in the tree that match the given term.
      * @param term The filter term.
-     * @returns A promise that resolves with the selected rows.
+     * @returns A promise that completes when the request has completed.
      */
-    selectFilteredItems: (term: string) => Promise<Row[] | void>;
+    selectFilteredItems: (term: string) => Promise<void>;
     /**
      * Performs an API call that will select the item associated to the given row or row index.  This method supports a `recurseParent` option that allows for recursively selecting the next unselected parent node. This behavior is considered stateful. Each call to `selectItem` will track the ancestry of the passed in `rowArg`. If calling `selectItem` with a row not belonging to the ancestry of a previous selection, then this method will perform a standard selection.
      * @param row The row, row index or node to select.

--- a/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
+++ b/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
@@ -55,6 +55,21 @@ export async function selectRangeInSceneTree(
     .execute();
 }
 
+export async function selectFilterResults(
+  viewer: HTMLVertexViewerElement,
+  filter: string,
+  keys: string[],
+  { material = undefined, append = false }: ViewerSelectItemOptions
+): Promise<void> {
+  const scene = await viewer.scene();
+  return scene
+    .items((op) => [
+      ...(append ? [] : [op.where((q) => q.all()).deselect()]),
+      op.where((q) => q.withMetadata(filter, keys)).select(material),
+    ])
+    .execute();
+}
+
 export async function deselectItem(
   viewer: HTMLVertexViewerElement,
   id: string

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -413,6 +413,17 @@ Type: `Promise<void>`
 
 A promise that resolves when the operation is finished.
 
+### `selectFilteredItems(term: string) => Promise<Row[]>`
+
+Performs an async request that will select the filtered items in the tree
+that match the given term.
+
+#### Returns
+
+Type: `Promise<Row[]>`
+
+A promise that resolves with the selected rows.
+
 ### `selectItem(row: RowArg, { recurseParent, ...options }?: SelectItemOptions) => Promise<void>`
 
 Performs an API call that will select the item associated to the given row

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -413,14 +413,14 @@ Type: `Promise<void>`
 
 A promise that resolves when the operation is finished.
 
-### `selectFilteredItems(term: string) => Promise<Row[]>`
+### `selectFilteredItems(term: string) => Promise<Row[] | void>`
 
 Performs an async request that will select the filtered items in the tree
 that match the given term.
 
 #### Returns
 
-Type: `Promise<Row[]>`
+Type: `Promise<void | Row[]>`
 
 A promise that resolves with the selected rows.
 

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -413,16 +413,16 @@ Type: `Promise<void>`
 
 A promise that resolves when the operation is finished.
 
-### `selectFilteredItems(term: string) => Promise<Row[] | void>`
+### `selectFilteredItems(term: string) => Promise<void>`
 
 Performs an async request that will select the filtered items in the tree
 that match the given term.
 
 #### Returns
 
-Type: `Promise<void | Row[]>`
+Type: `Promise<void>`
 
-A promise that resolves with the selected rows.
+A promise that completes when the request has completed.
 
 ### `selectItem(row: RowArg, { recurseParent, ...options }?: SelectItemOptions) => Promise<void>`
 

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -554,12 +554,9 @@ export class SceneTree {
   @Method()
   public async selectFilteredItems(term: string): Promise<Row[] | void> {
     if (this.viewer != null) {
-      await selectFilterResults(
-        this.viewer,
-        term,
-        this.metadataKeys,
-        { append: false }
-      );
+      await selectFilterResults(this.viewer, term, this.metadataKeys, {
+        append: false,
+      });
       return this.rows.filter((row) => row?.node.filterHit);
     } else {
       return;

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -552,14 +552,18 @@ export class SceneTree {
    * @returns A promise that resolves with the selected rows.
    */
   @Method()
-  public async selectFilteredItems(term: string): Promise<Row[]> {
-    await selectFilterResults(
-      this.viewer,
-      term,
-      this.filterOnMetadata ? this.metadataKeys : undefined,
-      { append: false }
-    );
-    return this.rows.filter((row) => row?.node.filterHit);
+  public async selectFilteredItems(term: string): Promise<Row[] | void> {
+    if (this.viewer != null) {
+      await selectFilterResults(
+        this.viewer,
+        term,
+        this.filterOnMetadata ? this.metadataKeys : undefined,
+        { append: false }
+      );
+      return this.rows.filter((row) => row?.node.filterHit);
+    } else {
+      return;
+    }
   }
 
   /**

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -557,7 +557,7 @@ export class SceneTree {
       await selectFilterResults(
         this.viewer,
         term,
-        this.filterOnMetadata ? this.metadataKeys : undefined,
+        this.metadataKeys,
         { append: false }
       );
       return this.rows.filter((row) => row?.node.filterHit);

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -35,6 +35,7 @@ import { isLoadedRow, Row } from './lib/row';
 import {
   deselectItem,
   hideItem,
+  selectFilterResults,
   selectItem,
   selectRangeInSceneTree,
   showItem,
@@ -541,6 +542,24 @@ export class SceneTree {
     options: FilterTreeOptions = {}
   ): Promise<void> {
     return this.controller?.filter(term, options);
+  }
+
+  /**
+   * Performs an async request that will select the filtered items in the tree
+   * that match the given term.
+   *
+   * @param term The filter term.
+   * @returns A promise that resolves with the selected rows.
+   */
+  @Method()
+  public async selectFilteredItems(term: string): Promise<Row[]> {
+    await selectFilterResults(
+      this.viewer,
+      term,
+      this.filterOnMetadata ? this.metadataKeys : undefined,
+      { append: false }
+    );
+    return this.rows.filter((row) => row?.node.filterHit);
   }
 
   /**

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -549,17 +549,14 @@ export class SceneTree {
    * that match the given term.
    *
    * @param term The filter term.
-   * @returns A promise that resolves with the selected rows.
+   * @returns A promise that completes when the request has completed.
    */
   @Method()
-  public async selectFilteredItems(term: string): Promise<Row[] | void> {
+  public async selectFilteredItems(term: string): Promise<void> {
     if (this.viewer != null) {
       await selectFilterResults(this.viewer, term, this.metadataKeys, {
         append: false,
       });
-      return this.rows.filter((row) => row?.node.filterHit);
-    } else {
-      return;
     }
   }
 


### PR DESCRIPTION
## Summary
We want the ability to select all of the matches for a given metadata search. 

## Test Plan
Tested with connect-app

## Release Notes
None

## Possible Regressions
None

## Dependencies
None