### PR TITLE
[PLAT-1226] Select filtered items with key parameters

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -42,7 +42,7 @@ export type JwtProvider = () => string | undefined;
 
 export interface SceneTreeState {
   totalRows: number;
-  totalFilteredRows: number;
+  totalFilteredRows?: number;
   rows: Row[];
   connection: ConnectionState;
 }
@@ -125,7 +125,6 @@ export class SceneTreeController {
 
   private state: SceneTreeState = {
     totalRows: 0,
-    totalFilteredRows: 0,
 
     rows: [],
     connection: { type: 'disconnected' },
@@ -306,7 +305,6 @@ export class SceneTreeController {
         sceneViewId: connection.sceneViewId,
       },
       totalRows: reset ? 0 : this.state.totalRows,
-      totalFilteredRows: reset ? 0 : this.state.totalFilteredRows,
       rows: reset ? [] : this.state.rows,
     });
   }

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -560,7 +560,12 @@ export class SceneTree {
   @Method()
   public async selectFilteredItems(term: string): Promise<void> {
     if (this.viewer != null) {
-      await selectFilterResults(this.viewer, term, this.metadataKeys, {
+      const columnsToSearch =
+        this.metadataSearchKeys.length > 0
+          ? this.metadataSearchKeys
+          : this.metadataKeys;
+
+      await selectFilterResults(this.viewer, term, columnsToSearch, {
         append: false,
       });
     }


### PR DESCRIPTION
## Summary
In a filtered scene tree, we want the "Select Matches" button to respect the metadataSearchKeys setting, which restricts which columns match the value. 

Further, this removes the default value for totalFilteredRows such that it is only set when a filter takes place. In the current implementation, when a user closed and reopened the scene tree with an active filter, the scene tree reported the default "0 results."

## Test Plan
Click "Select Matches" when searching on only some of the columns. Also, close and reopen the scene tree with an active search and verify that the number of results reported is correct.

## Release Notes
None

## Possible Regressions
Scene tree search

## Dependencies
None