### PR TITLE
[PLAT-1193] Correct transform widget first time load w/ a position

### DIFF
--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -64,7 +64,7 @@ export class ViewerTransformWidget {
   private lastWorldPosition?: Vector3.Vector3;
 
   private canvasBounds?: DOMRect;
-  private canvasResizeObserver!: ResizeObserver;
+  private canvasResizeObserver?: ResizeObserver;
   private canvasRef?: HTMLCanvasElement;
 
   private hoveredChangeDisposable?: Disposable;
@@ -106,7 +106,7 @@ export class ViewerTransformWidget {
   protected disconnectedCallback(): void {
     window.removeEventListener('pointermove', this.handlePointerMove);
 
-    this.canvasResizeObserver.disconnect();
+    this.canvasResizeObserver?.disconnect();
 
     this.hoveredChangeDisposable?.dispose();
     this.widget?.dispose();
@@ -146,7 +146,7 @@ export class ViewerTransformWidget {
         newPosition
       )}, current=${JSON.stringify(oldPosition)}]`
     );
-    this.getTransformWidget().updatePosition(this.currentPosition);
+    this.widget?.updatePosition(this.currentPosition);
 
     if (newPosition == null) {
       this.controller?.clearTransform();
@@ -330,6 +330,7 @@ export class ViewerTransformWidget {
     });
 
     if (this.position != null) {
+      this.currentPosition = this.position;
       this.widget.updatePosition(this.position);
     }
     if (this.viewer?.frame != null) {


### PR DESCRIPTION
## Summary

Corrects an issue with initializing the transform widget with a `position`, where the current position would not be correctly initialized. Also corrects an issue where some errors were being logged unnecessarily when changing the position.

## Test Plan

- Test loading the widget from connect-app

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
