### PR TITLE
[PLAT-1528] Emit Position Changing for the transform widget

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2670,6 +2670,10 @@ declare namespace LocalJSX {
      */
     hovered?: Mesh;
     /**
+     * An event that is emitted when the position of the widget changes.
+     */
+    onPositionChanged?: (event: CustomEvent<Vector3.Vector3>) => void;
+    /**
      * The starting position of this transform widget. This position will be updated as transforms occur. Setting this value to `undefined` will remove the widget.
      */
     position?: Vector3.Vector3;

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2672,7 +2672,9 @@ declare namespace LocalJSX {
     /**
      * An event that is emitted when the position of the widget changes.
      */
-    onPositionChanged?: (event: CustomEvent<Vector3.Vector3>) => void;
+    onPositionChanged?: (
+      event: CustomEvent<Vector3.Vector3 | undefined>
+    ) => void;
     /**
      * The starting position of this transform widget. This position will be updated as transforms occur. Setting this value to `undefined` will remove the widget.
      */

--- a/packages/viewer/src/components/viewer-transform-widget/readme.md
+++ b/packages/viewer/src/components/viewer-transform-widget/readme.md
@@ -14,6 +14,13 @@
 | `viewer`     | --        | The viewer to connect to transforms. If nested within a <vertex-viewer>, this property will be populated automatically.                                      | `HTMLVertexViewerElement \| undefined` | `undefined` |
 
 
+## Events
+
+| Event             | Description                                                       | Type                   |
+| ----------------- | ----------------------------------------------------------------- | ---------------------- |
+| `positionChanged` | An event that is emitted when the position of the widget changes. | `CustomEvent<Vector3>` |
+
+
 ## CSS Custom Properties
 
 | Name                                             | Description                                                                               |

--- a/packages/viewer/src/components/viewer-transform-widget/readme.md
+++ b/packages/viewer/src/components/viewer-transform-widget/readme.md
@@ -16,9 +16,9 @@
 
 ## Events
 
-| Event             | Description                                                       | Type                   |
-| ----------------- | ----------------------------------------------------------------- | ---------------------- |
-| `positionChanged` | An event that is emitted when the position of the widget changes. | `CustomEvent<Vector3>` |
+| Event             | Description                                                       | Type                                |
+| ----------------- | ----------------------------------------------------------------- | ----------------------------------- |
+| `positionChanged` | An event that is emitted when the position of the widget changes. | `CustomEvent<Vector3 \| undefined>` |
 
 
 ## CSS Custom Properties

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
@@ -391,7 +391,7 @@ describe('vertex-viewer-transform-widget', () => {
 
     await page.waitForChanges();
 
-    const position2 = Vector3.create(1, 1, 1);
+    const position2 = Vector3.create(2, 2, 2);
     widget.position = position2;
 
     await page.waitForChanges();

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
@@ -14,6 +14,7 @@ jest.mock('./util', () => ({
 import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { Point, Vector3 } from '@vertexvis/geometry';
+import { position } from '@vertexvis/geometry/dist/matrix4';
 
 import { loadImageBytes } from '../../lib/rendering/imageLoaders';
 import { TriangleMesh, TriangleMeshPoints } from '../../lib/transforms/mesh';
@@ -360,5 +361,52 @@ describe('vertex-viewer-transform-widget', () => {
 
     expect(endSpy).toHaveBeenCalled();
     expect(mockTransformWidget.updatePosition).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should dispatch an event when the position of the widget changes', async () => {
+    const { stream, ws } = makeViewerStream();
+
+    const page = await newSpecPage({
+      components: [Viewer, ViewerTransformWidget],
+      template: () => (
+        <vertex-viewer stream={stream}>
+          <vertex-viewer-transform-widget></vertex-viewer-transform-widget>
+        </vertex-viewer>
+      ),
+    });
+
+    const viewer = page.body.querySelector(
+      'vertex-viewer'
+    ) as HTMLVertexViewerElement;
+    const widget = page.body.querySelector(
+      'vertex-viewer-transform-widget'
+    ) as HTMLVertexViewerTransformWidgetElement;
+
+    await loadViewerStreamKey(key1, { viewer, stream, ws });
+
+    const onPositionChanged = jest.fn();
+    widget.addEventListener('positionChanged', onPositionChanged);
+
+    const position1 = Vector3.create(1, 1, 1);
+    widget.position = position1;
+
+    await page.waitForChanges();
+
+    const position2 = Vector3.create(1, 1, 1);
+    widget.position = position2;
+
+    await page.waitForChanges();
+
+    expect(onPositionChanged).toHaveBeenCalledTimes(2);
+    expect(onPositionChanged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: position1,
+      })
+    );
+    expect(onPositionChanged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: position2,
+      })
+    );
   });
 });

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
@@ -14,7 +14,6 @@ jest.mock('./util', () => ({
 import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { Point, Vector3 } from '@vertexvis/geometry';
-import { position } from '@vertexvis/geometry/dist/matrix4';
 
 import { loadImageBytes } from '../../lib/rendering/imageLoaders';
 import { TriangleMesh, TriangleMeshPoints } from '../../lib/transforms/mesh';

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -1,4 +1,13 @@
-import { Component, Element, h, Host, Prop, Watch } from '@stencil/core';
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+  Watch,
+} from '@stencil/core';
 import { Point, Vector3 } from '@vertexvis/geometry';
 import { Color, Disposable } from '@vertexvis/utils';
 import classNames from 'classnames';
@@ -19,6 +28,12 @@ import { TransformWidget } from './widget';
   shadow: true,
 })
 export class ViewerTransformWidget {
+  /**
+   * An event that is emitted when the position of the widget changes.
+   */
+  @Event({ bubbles: true })
+  public positionChanged!: EventEmitter<Vector3.Vector3>;
+
   /**
    * The viewer to connect to transforms. If nested within a <vertex-viewer>,
    * this property will be populated automatically.
@@ -151,6 +166,8 @@ export class ViewerTransformWidget {
     if (newPosition == null) {
       this.controller?.clearTransform();
     }
+
+    this.positionChanged.emit(newPosition);
   }
 
   public render(): h.JSX.IntrinsicElements {

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -32,7 +32,7 @@ export class ViewerTransformWidget {
    * An event that is emitted when the position of the widget changes.
    */
   @Event({ bubbles: true })
-  public positionChanged!: EventEmitter<Vector3.Vector3>;
+  public positionChanged!: EventEmitter<Vector3.Vector3 | undefined>;
 
   /**
    * The viewer to connect to transforms. If nested within a <vertex-viewer>,


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
Introduces a new event to be emitted each time the position of the widget changes.

```ts
      const widget = document.getElementById('widget');
      widget.addEventListener('positionChanged', (e) => {
        console.log('position: ', e.detail);
      })
```

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
