### PR TITLE
[PLAT-1528] Adding events for delta changed and interaction started

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2670,7 +2670,7 @@ declare namespace LocalJSX {
      */
     hovered?: Mesh;
     /**
-     * An event that is emitted when the delta changed
+     * An event that is emitted when the interaction has ended
      */
     onInteractionEnded?: (
       event: CustomEvent<Matrix4.Matrix4 | undefined>

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2674,7 +2674,7 @@ declare namespace LocalJSX {
      */
     onDeltaChanged?: (event: CustomEvent<Matrix4.Matrix4 | undefined>) => void;
     /**
-     * An event that is emitted when the delta changed
+     * An event that is emitted an interaction with the widget has started
      */
     onInteractionStarted?: (event: CustomEvent<void>) => void;
     /**

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2670,6 +2670,14 @@ declare namespace LocalJSX {
      */
     hovered?: Mesh;
     /**
+     * An event that is emitted when the delta changed
+     */
+    onDeltaChanged?: (event: CustomEvent<Matrix4.Matrix4 | undefined>) => void;
+    /**
+     * An event that is emitted when the delta changed
+     */
+    onInteractionStarted?: (event: CustomEvent<void>) => void;
+    /**
      * An event that is emitted when the position of the widget changes.
      */
     onPositionChanged?: (

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2672,7 +2672,9 @@ declare namespace LocalJSX {
     /**
      * An event that is emitted when the delta changed
      */
-    onDeltaChanged?: (event: CustomEvent<Matrix4.Matrix4 | undefined>) => void;
+    onInteractionEnded?: (
+      event: CustomEvent<Matrix4.Matrix4 | undefined>
+    ) => void;
     /**
      * An event that is emitted an interaction with the widget has started
      */

--- a/packages/viewer/src/components/viewer-transform-widget/readme.md
+++ b/packages/viewer/src/components/viewer-transform-widget/readme.md
@@ -16,9 +16,11 @@
 
 ## Events
 
-| Event             | Description                                                       | Type                                |
-| ----------------- | ----------------------------------------------------------------- | ----------------------------------- |
-| `positionChanged` | An event that is emitted when the position of the widget changes. | `CustomEvent<Vector3 \| undefined>` |
+| Event                | Description                                                       | Type                                                                                                                                                         |
+| -------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `deltaChanged`       | An event that is emitted when the delta changed                   | `CustomEvent<[number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number] \| undefined>` |
+| `interactionStarted` | An event that is emitted when the delta changed                   | `CustomEvent<void>`                                                                                                                                          |
+| `positionChanged`    | An event that is emitted when the position of the widget changes. | `CustomEvent<Vector3 \| undefined>`                                                                                                                          |
 
 
 ## CSS Custom Properties

--- a/packages/viewer/src/components/viewer-transform-widget/readme.md
+++ b/packages/viewer/src/components/viewer-transform-widget/readme.md
@@ -16,11 +16,11 @@
 
 ## Events
 
-| Event                | Description                                                       | Type                                                                                                                                                         |
-| -------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `deltaChanged`       | An event that is emitted when the delta changed                   | `CustomEvent<[number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number] \| undefined>` |
-| `interactionStarted` | An event that is emitted when the delta changed                   | `CustomEvent<void>`                                                                                                                                          |
-| `positionChanged`    | An event that is emitted when the position of the widget changes. | `CustomEvent<Vector3 \| undefined>`                                                                                                                          |
+| Event                | Description                                                         | Type                                                                                                                                                         |
+| -------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `deltaChanged`       | An event that is emitted when the delta changed                     | `CustomEvent<[number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number] \| undefined>` |
+| `interactionStarted` | An event that is emitted an interaction with the widget has started | `CustomEvent<void>`                                                                                                                                          |
+| `positionChanged`    | An event that is emitted when the position of the widget changes.   | `CustomEvent<Vector3 \| undefined>`                                                                                                                          |
 
 
 ## CSS Custom Properties

--- a/packages/viewer/src/components/viewer-transform-widget/readme.md
+++ b/packages/viewer/src/components/viewer-transform-widget/readme.md
@@ -18,7 +18,7 @@
 
 | Event                | Description                                                         | Type                                                                                                                                                         |
 | -------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `deltaChanged`       | An event that is emitted when the delta changed                     | `CustomEvent<[number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number] \| undefined>` |
+| `interactionEnded`   | An event that is emitted when the delta changed                     | `CustomEvent<[number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number] \| undefined>` |
 | `interactionStarted` | An event that is emitted an interaction with the widget has started | `CustomEvent<void>`                                                                                                                                          |
 | `positionChanged`    | An event that is emitted when the position of the widget changes.   | `CustomEvent<Vector3 \| undefined>`                                                                                                                          |
 

--- a/packages/viewer/src/components/viewer-transform-widget/readme.md
+++ b/packages/viewer/src/components/viewer-transform-widget/readme.md
@@ -18,7 +18,7 @@
 
 | Event                | Description                                                         | Type                                                                                                                                                         |
 | -------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `interactionEnded`   | An event that is emitted when the delta changed                     | `CustomEvent<[number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number] \| undefined>` |
+| `interactionEnded`   | An event that is emitted when the interaction has ended             | `CustomEvent<[number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number] \| undefined>` |
 | `interactionStarted` | An event that is emitted an interaction with the widget has started | `CustomEvent<void>`                                                                                                                                          |
 | `positionChanged`    | An event that is emitted when the position of the widget changes.   | `CustomEvent<Vector3 \| undefined>`                                                                                                                          |
 

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
@@ -172,10 +172,15 @@ describe('vertex-viewer-transform-widget', () => {
     await page.waitForChanges();
     await page.waitForChanges();
 
+    const onDeltaChange = jest.fn();
+    const onInteractionStarted = jest.fn();
+
     const frame = makePerspectiveFrame();
     viewer.dispatchFrameDrawn(frame);
 
     widget.position = Vector3.create(1, 1, 1);
+    widget.addEventListener('deltaChanged', onDeltaChange);
+    widget.addEventListener('interactionStarted', onInteractionStarted);
 
     await page.waitForChanges();
 
@@ -196,10 +201,11 @@ describe('vertex-viewer-transform-widget', () => {
       '#000000',
       '#000000'
     );
-
     const beginSpy = jest.spyOn(stream, 'beginInteraction');
     const updateSpy = jest.spyOn(stream, 'updateInteraction');
-    const endSpy = jest.spyOn(stream, 'endInteraction');
+    const endSpy = jest
+      .spyOn(stream, 'endInteraction')
+      .mockReturnValue(Promise.resolve({}));
 
     (convertCanvasPointToWorld as jest.Mock).mockImplementation(() =>
       Vector3.create(1, 1, 1)
@@ -244,6 +250,10 @@ describe('vertex-viewer-transform-widget', () => {
         },
       })
     );
+
+    await page.waitForChanges();
+    expect(onDeltaChange).toHaveBeenCalled();
+    expect(onInteractionStarted).toHaveBeenCalled();
   });
 
   it('updates widget bounds when the viewer dimensions change', async () => {

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
@@ -172,14 +172,14 @@ describe('vertex-viewer-transform-widget', () => {
     await page.waitForChanges();
     await page.waitForChanges();
 
-    const onDeltaChange = jest.fn();
+    const onInteractionEnded = jest.fn();
     const onInteractionStarted = jest.fn();
 
     const frame = makePerspectiveFrame();
     viewer.dispatchFrameDrawn(frame);
 
     widget.position = Vector3.create(1, 1, 1);
-    widget.addEventListener('deltaChanged', onDeltaChange);
+    widget.addEventListener('interactionEnded', onInteractionEnded);
     widget.addEventListener('interactionStarted', onInteractionStarted);
 
     await page.waitForChanges();
@@ -252,7 +252,7 @@ describe('vertex-viewer-transform-widget', () => {
     );
 
     await page.waitForChanges();
-    expect(onDeltaChange).toHaveBeenCalled();
+    expect(onInteractionEnded).toHaveBeenCalled();
     expect(onInteractionStarted).toHaveBeenCalled();
   });
 

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -35,7 +35,7 @@ export class ViewerTransformWidget {
   public positionChanged!: EventEmitter<Vector3.Vector3 | undefined>;
 
   /**
-   * An event that is emitted when the delta changed
+   * An event that is emitted when the interaction has ended
    */
   @Event({ bubbles: true })
   public interactionEnded!: EventEmitter<Matrix4.Matrix4 | undefined>;

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -8,7 +8,7 @@ import {
   Prop,
   Watch,
 } from '@stencil/core';
-import { Point, Vector3 } from '@vertexvis/geometry';
+import { Matrix4, Point, Vector3 } from '@vertexvis/geometry';
 import { Color, Disposable } from '@vertexvis/utils';
 import classNames from 'classnames';
 
@@ -33,6 +33,18 @@ export class ViewerTransformWidget {
    */
   @Event({ bubbles: true })
   public positionChanged!: EventEmitter<Vector3.Vector3 | undefined>;
+
+  /**
+   * An event that is emitted when the delta changed
+   */
+  @Event({ bubbles: true })
+  public deltaChanged!: EventEmitter<Matrix4.Matrix4 | undefined>;
+
+  /**
+   * An event that is emitted when the delta changed
+   */
+  @Event({ bubbles: true })
+  public interactionStarted!: EventEmitter<void>;
 
   /**
    * The viewer to connect to transforms. If nested within a <vertex-viewer>,
@@ -233,6 +245,7 @@ export class ViewerTransformWidget {
       );
 
       this.controller?.beginTransform();
+      this.interactionStarted.emit();
 
       window.removeEventListener('pointermove', this.handlePointerMove);
       window.addEventListener('pointermove', this.handleDrag);
@@ -284,7 +297,11 @@ export class ViewerTransformWidget {
     window.removeEventListener('pointerup', this.handleEndTransform);
 
     try {
+      const delta = this.controller?.getCurrentDelta();
+
       await this.controller?.endTransform();
+
+      this.deltaChanged.emit(delta);
     } catch (e) {
       console.error('Failed to end transform interaction', e);
     }

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -38,7 +38,7 @@ export class ViewerTransformWidget {
    * An event that is emitted when the delta changed
    */
   @Event({ bubbles: true })
-  public deltaChanged!: EventEmitter<Matrix4.Matrix4 | undefined>;
+  public interactionEnded!: EventEmitter<Matrix4.Matrix4 | undefined>;
 
   /**
    * An event that is emitted an interaction with the widget has started
@@ -301,7 +301,7 @@ export class ViewerTransformWidget {
 
       await this.controller?.endTransform();
 
-      this.deltaChanged.emit(delta);
+      this.interactionEnded.emit(delta);
     } catch (e) {
       console.error('Failed to end transform interaction', e);
     }

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -41,7 +41,7 @@ export class ViewerTransformWidget {
   public deltaChanged!: EventEmitter<Matrix4.Matrix4 | undefined>;
 
   /**
-   * An event that is emitted when the delta changed
+   * An event that is emitted an interaction with the widget has started
    */
   @Event({ bubbles: true })
   public interactionStarted!: EventEmitter<void>;

--- a/packages/viewer/src/lib/transforms/controller.ts
+++ b/packages/viewer/src/lib/transforms/controller.ts
@@ -41,6 +41,10 @@ export class TransformController {
     });
   }
 
+  public getCurrentDelta(): Matrix4.Matrix4 | undefined {
+    return this.currentDelta;
+  }
+
   public async endTransform(): Promise<void> {
     if (this.isTransforming) {
       console.debug(


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes introduce two new events. Events emitted when the widget delta position changes, as well as an event for when the widget has begin an interaction.

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
