### PR TITLE
[PLAT-1560] Correct orthographic depth

### DIFF
--- a/packages/viewer/src/components/viewer-measurement-distance/__tests__/hitTest.spec.ts
+++ b/packages/viewer/src/components/viewer-measurement-distance/__tests__/hitTest.spec.ts
@@ -14,7 +14,7 @@ describe(PointToPointHitTester, () => {
 
     const viewport = new Viewport(100, 100);
     const depthBuffer = makeDepthBuffer(100, 100, undefined, camera);
-    const depth = camera.far - camera.near + camera.near / 2;
+    const depth = camera.far - camera.near;
     const ray = viewport.transformPointToOrthographicRay(
       Point.create(10, 10),
       depthBuffer,

--- a/packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts
@@ -152,10 +152,10 @@ describe(DepthBuffer, () => {
 
     describe('with orthographic camera', () => {
       const camera = new FrameOrthographicCamera(
-        { x: 0, y: 0, z: -5 },
+        { x: 0, y: 0, z: 100 },
         Vector3.origin(),
         Vector3.up(),
-        1,
+        -100,
         100,
         1,
         1
@@ -178,31 +178,35 @@ describe(DepthBuffer, () => {
 
         const viewport = new Viewport(100, 100);
         const pt = Point.create(50, 50);
-        const ray = viewport.transformPointToRay(pt, depthBuffer, camera);
+        const ray = viewport.transformPointToOrthographicRay(
+          pt,
+          depthBuffer,
+          camera
+        );
 
         return { ray, depthBuffer, pt };
       }
 
       it('returns correct world position for near plane', () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(0);
-        const pos = depthBuffer.getWorldPoint(pt, ray);
-        expect(pos.z).toBe(4);
+        const pos = depthBuffer.getOrthographicWorldPoint(pt, ray);
+        expect(pos.z).toBe(-100);
       });
 
       it('returns correct world position for far plane', () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
           DepthBuffer.MAX_DEPTH_VALUE
         );
-        const pos = depthBuffer.getWorldPoint(pt, ray);
-        expect(pos.z).toBe(-95);
+        const pos = depthBuffer.getOrthographicWorldPoint(pt, ray);
+        expect(pos.z).toBe(100);
       });
 
       it('returns correct world position between near and far plane', () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
           DepthBuffer.MAX_DEPTH_VALUE / 2
         );
-        const pos = depthBuffer.getWorldPoint(pt, ray);
-        expect(pos.z).toBeCloseTo(-45.5);
+        const pos = depthBuffer.getOrthographicWorldPoint(pt, ray);
+        expect(pos.z).toBeCloseTo(0);
       });
     });
   });

--- a/packages/viewer/src/lib/types/__tests__/viewport.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/viewport.spec.ts
@@ -41,10 +41,7 @@ describe('viewport utilities', () => {
       const viewport = new Viewport(100, 100);
 
       const buffer = makeDepthBuffer(100, 100, undefined, orthographic);
-      const depth =
-        (0.5 / DepthBuffer.MAX_DEPTH_VALUE) *
-          (orthographic.far - orthographic.near) +
-        orthographic.near / 2;
+      const depth = 0.5 * (orthographic.far - orthographic.near);
       const ray = viewport.transformPointToOrthographicRay(
         Point.create(10, 10),
         buffer,
@@ -55,7 +52,7 @@ describe('viewport utilities', () => {
         viewport.transformPointToOrthographicWorldSpace(
           Point.create(10, 10),
           buffer,
-          0.5
+          0.5 * DepthBuffer.MAX_DEPTH_VALUE
         )
       ).toMatchObject(Ray.at(ray, depth));
     });

--- a/packages/viewer/src/lib/types/depthBuffer.ts
+++ b/packages/viewer/src/lib/types/depthBuffer.ts
@@ -102,7 +102,7 @@ export class DepthBuffer implements FrameImageLike {
       fallbackNormalizedDepth
     );
 
-    return depth * (far - near) + near / 2;
+    return depth * (far - near);
   }
 
   /**


### PR DESCRIPTION
## Summary

Corrects the math for orthographic depth calculation. Previously, this math was attempting to account for a ray generated at `z = 0.5`, which is no longer generated by the `Viewport.transformPointToOrthographicRay` method. Additionally, this PR updates a couple tests that should have caught this bug (in packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts), as they were not using the correct ray generation/world point generation methods.

## Test Plan

- Test rotate around tap point in orthographic mode
- Unit tests

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
