### PR TITLE
[PLAT-1570] -- opaque selection material

### DIFF
--- a/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
@@ -269,7 +269,7 @@ describe(Scene, () => {
               {
                 changeMaterial: {
                   material: {
-                    d: 100,
+                    d: 255,
                     ka: {
                       a: 0,
                       b: 0,
@@ -294,7 +294,7 @@ describe(Scene, () => {
                       g: 0,
                       r: 0,
                     },
-                    ns: 10,
+                    ns: 50,
                   },
                 },
               },

--- a/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
@@ -294,7 +294,7 @@ describe(Scene, () => {
                       g: 0,
                       r: 0,
                     },
-                    ns: 50,
+                    ns: ColorMaterial.defaultColor.glossiness,
                   },
                 },
               },

--- a/packages/viewer/src/lib/scenes/colorMaterial.ts
+++ b/packages/viewer/src/lib/scenes/colorMaterial.ts
@@ -13,8 +13,8 @@ export interface ColorMaterial {
 }
 
 const defaultColor: ColorMaterial = {
-  opacity: 100,
-  glossiness: 10,
+  opacity: 255,
+  glossiness: 50,
   diffuse: {
     r: 0,
     g: 0,
@@ -55,8 +55,8 @@ export const create = (
 ): ColorMaterial => {
   return {
     ...defaultColor,
-    opacity: opacity || 100,
-    glossiness: opacity || 10,
+    opacity: opacity || 255,
+    glossiness: 50,
     diffuse: {
       r,
       g,
@@ -76,8 +76,8 @@ export const fromHex = (hex: string, opacity?: number): ColorMaterial => {
 
   return {
     ...defaultColor,
-    opacity: opacity || 100,
-    glossiness: opacity || 10,
+    opacity: opacity || 255,
+    glossiness: 50,
     diffuse: color != null ? { ...color } : { ...defaultColor.diffuse },
   };
 };
@@ -86,8 +86,8 @@ export const fromHex = (hex: string, opacity?: number): ColorMaterial => {
  * The default material that is used for selected items.
  */
 export const defaultSelectionMaterial: ColorMaterial = {
-  opacity: 100,
-  glossiness: 4,
+  opacity: 255,
+  glossiness: 50,
   diffuse: {
     r: 255,
     g: 255,

--- a/packages/viewer/src/lib/scenes/colorMaterial.ts
+++ b/packages/viewer/src/lib/scenes/colorMaterial.ts
@@ -55,7 +55,7 @@ export const create = (
 ): ColorMaterial => {
   return {
     ...defaultColor,
-    opacity: opacity || defaultColor.opacity,
+    opacity: opacity ?? defaultColor.opacity,
     diffuse: {
       r,
       g,

--- a/packages/viewer/src/lib/scenes/colorMaterial.ts
+++ b/packages/viewer/src/lib/scenes/colorMaterial.ts
@@ -12,9 +12,9 @@ export interface ColorMaterial {
   emissive: Color.Color;
 }
 
-const defaultColor: ColorMaterial = {
+export const defaultColor: ColorMaterial = {
   opacity: 255,
-  glossiness: 50,
+  glossiness: 4,
   diffuse: {
     r: 0,
     g: 0,
@@ -55,8 +55,7 @@ export const create = (
 ): ColorMaterial => {
   return {
     ...defaultColor,
-    opacity: opacity || 255,
-    glossiness: 50,
+    opacity: opacity || defaultColor.opacity,
     diffuse: {
       r,
       g,
@@ -76,8 +75,7 @@ export const fromHex = (hex: string, opacity?: number): ColorMaterial => {
 
   return {
     ...defaultColor,
-    opacity: opacity || 255,
-    glossiness: 50,
+    opacity: opacity ?? defaultColor.opacity,
     diffuse: color != null ? { ...color } : { ...defaultColor.diffuse },
   };
 };
@@ -86,8 +84,8 @@ export const fromHex = (hex: string, opacity?: number): ColorMaterial => {
  * The default material that is used for selected items.
  */
 export const defaultSelectionMaterial: ColorMaterial = {
-  opacity: 255,
-  glossiness: 50,
+  opacity: defaultColor.opacity,
+  glossiness: defaultColor.glossiness,
   diffuse: {
     r: 255,
     g: 255,


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
Set opacity on default materials to 255
Set glossiness, ie specular exponent, to 50 (is this too glossy?)

## Test Plan
<!-- How to test changes. -->
Verified in a test app
Will need to be picked up by Connect+ 

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
[Ticket](https://vertexvis.atlassian.net/browse/PLAT-1570)

## NOTES
- [x] ~~Is 50 too high?~~ Set to 4
- [x] Does the version get bumped automatically or does it need to be specified in this PR
- [ ] Need to pick this up in Connect+