### PR TITLE
[PLAT-1477] Dispose of measurement interaction when component removed

### DIFF
--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
@@ -307,6 +307,8 @@ export class ViewerMeasurementDistance {
 
   private isUserInteractingWithModel = false;
 
+  private newInteractionHandler?: Disposable;
+
   /**
    * Computes the bounding boxes of the anchors and label. **Note:** invoking
    * this function uses `getBoundingClientRect` internally and will cause a
@@ -337,6 +339,7 @@ export class ViewerMeasurementDistance {
    */
   protected disconnectedCallback(): void {
     this.stateMap.hoverCursor?.dispose();
+    this.newInteractionHandler?.dispose();
   }
 
   /**
@@ -743,6 +746,8 @@ export class ViewerMeasurementDistance {
         };
 
         this.beginEditing('replace', 'end');
+        this.newInteractionHandler = { dispose };
+
         window.addEventListener('pointermove', pointerMove);
         window.addEventListener('pointerup', pointerUp);
       };


### PR DESCRIPTION
## Summary

If the pt-to-pt measurement component is removed mid-interaction, the interaction was not being disposed. This causes any `editEnd` events to be fired the next time a user performs a mouse interaction, and was causing state to get updated in Connect.

https://vertexvis.atlassian.net/browse/PLAT-1477

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
