### PR TITLE
[PLAT-1683] Fix path to typings definition file

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -16,7 +16,7 @@
   "module": "dist/custom-elements/index.js",
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
-  "types": "dist/custom-elements/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/viewer/viewer.esm.js",


### PR DESCRIPTION
## Summary

This fixes the path that should be used for the typings definition file.

https://vertexvis.atlassian.net/browse/PLAT-1683