### PR TITLE
[PLAT-1638] Support for sending correlation ids to scene tree events

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -218,7 +218,10 @@ export namespace Components {
      * @param term The filter term.
      * @returns A promise that completes when the request has completed.
      */
-    selectFilteredItems: (term: string) => Promise<void>;
+    selectFilteredItems: (
+      term: string,
+      options?: SceneTreeOperationOptions | undefined
+    ) => Promise<void>;
     /**
      * Performs an API call that will select the item associated to the given row or row index.  This method supports a `recurseParent` option that allows for recursively selecting the next unselected parent node. This behavior is considered stateful. Each call to `selectItem` will track the ancestry of the passed in `rowArg`. If calling `selectItem` with a row not belonging to the ancestry of a previous selection, then this method will perform a standard selection.
      * @param row The row, row index or node to select.

--- a/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
+++ b/packages/viewer/src/components/scene-tree/lib/viewer-ops.ts
@@ -1,35 +1,40 @@
 import { ColorMaterial } from '../../..';
 
-export interface ViewerSelectItemOptions {
+export interface ViewerItemOptions {
   material?: string | ColorMaterial.ColorMaterial;
   append?: boolean;
   range?: boolean;
+  suppliedCorrelationId?: string;
 }
 
 export async function showItem(
   viewer: HTMLVertexViewerElement,
-  id: string
+  id: string,
+  { suppliedCorrelationId }: ViewerItemOptions = {}
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene
     .items((op) => op.where((q) => q.withItemId(id)).show())
-    .execute();
+    .execute({ suppliedCorrelationId });
 }
 
 export async function hideItem(
   viewer: HTMLVertexViewerElement,
-  id: string
+  id: string,
+  { suppliedCorrelationId }: ViewerItemOptions = {}
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene
     .items((op) => op.where((q) => q.withItemId(id)).hide())
-    .execute();
+    .execute({
+      suppliedCorrelationId,
+    });
 }
 
 export async function selectItem(
   viewer: HTMLVertexViewerElement,
   id: string,
-  { material, append = false }: ViewerSelectItemOptions
+  { material, append = false, suppliedCorrelationId }: ViewerItemOptions
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene
@@ -37,14 +42,14 @@ export async function selectItem(
       ...(append ? [] : [op.where((q) => q.all()).deselect()]),
       op.where((q) => q.withItemId(id)).select(material),
     ])
-    .execute();
+    .execute({ suppliedCorrelationId });
 }
 
 export async function selectRangeInSceneTree(
   viewer: HTMLVertexViewerElement,
   start: number,
   end: number,
-  { material, append = true }: ViewerSelectItemOptions
+  { material, append = true, suppliedCorrelationId }: ViewerItemOptions
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene
@@ -52,7 +57,9 @@ export async function selectRangeInSceneTree(
       ...(append ? [] : [op.where((q) => q.all()).deselect()]),
       op.where((q) => q.withSceneTreeRange({ start, end })).select(material),
     ])
-    .execute();
+    .execute({
+      suppliedCorrelationId,
+    });
 }
 
 export async function selectFilterResults(
@@ -60,7 +67,11 @@ export async function selectFilterResults(
   filter: string,
   keys: string[],
   exactMatch: boolean,
-  { material = undefined, append = false }: ViewerSelectItemOptions
+  {
+    material = undefined,
+    append = false,
+    suppliedCorrelationId,
+  }: ViewerItemOptions
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene
@@ -70,15 +81,20 @@ export async function selectFilterResults(
         .where((q) => q.withMetadata(filter, keys, exactMatch))
         .select(material),
     ])
-    .execute();
+    .execute({
+      suppliedCorrelationId,
+    });
 }
 
 export async function deselectItem(
   viewer: HTMLVertexViewerElement,
-  id: string
+  id: string,
+  { suppliedCorrelationId }: ViewerItemOptions = {}
 ): Promise<void> {
   const scene = await viewer.scene();
   return scene
     .items((op) => op.where((q) => q.withItemId(id)).deselect())
-    .execute();
+    .execute({
+      suppliedCorrelationId,
+    });
 }

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -414,7 +414,7 @@ Type: `Promise<void>`
 
 A promise that resolves when the operation is finished.
 
-### `selectFilteredItems(term: string) => Promise<void>`
+### `selectFilteredItems(term: string, options?: SceneTreeOperationOptions | undefined) => Promise<void>`
 
 Performs an async request that will select the filtered items in the tree
 that match the given term.

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -39,7 +39,7 @@ import {
   selectItem,
   selectRangeInSceneTree,
   showItem,
-  ViewerSelectItemOptions,
+  ViewerItemOptions,
 } from './lib/viewer-ops';
 
 export type RowDataProvider = (row: Row) => Record<string, unknown>;
@@ -95,10 +95,14 @@ export interface ScrollToOptions {
   position?: 'start' | 'middle' | 'end';
 }
 
+interface SceneTreeOperationOptions {
+  suppliedCorrelationId?: string;
+}
+
 /**
  * A set of options to configure selection behavior.
  */
-export interface SelectItemOptions extends ViewerSelectItemOptions {
+export interface SelectItemOptions extends ViewerItemOptions {
   /**
    * Specifies that the next deselected ancestor node should be selected.
    */
@@ -563,7 +567,10 @@ export class SceneTree {
    * @returns A promise that completes when the request has completed.
    */
   @Method()
-  public async selectFilteredItems(term: string): Promise<void> {
+  public async selectFilteredItems(
+    term: string,
+    options?: SceneTreeOperationOptions
+  ): Promise<void> {
     if (this.viewer != null) {
       const columnsToSearch =
         this.metadataSearchKeys.length > 0
@@ -577,6 +584,7 @@ export class SceneTree {
         this.metadataSearchExactMatch,
         {
           append: false,
+          ...options,
         }
       );
     }


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->

We want to expose the suppliedCorrelationId on scene tree operations here. 

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
