### PR TITLE
[PLAT-1724] Dimensions should be updated to whatever was set in the client after connection is successful

### DIFF
--- a/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
+++ b/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
@@ -444,6 +444,37 @@ describe(ViewerStream, () => {
       stream.update({ dimensions: Dimensions.create(100, 100) });
       expect(updateDimensions).toHaveBeenCalled();
     });
+
+    it('updates dimensions once the stream is connected', async () => {
+      const { stream, ws } = makeStream();
+
+      jest
+        .spyOn(stream, 'startStream')
+        .mockResolvedValue(Fixtures.Responses.startStream().response);
+      jest
+        .spyOn(stream, 'syncTime')
+        .mockResolvedValue(Fixtures.Responses.syncTime().response);
+
+      const updateDimensions = jest.spyOn(stream, 'updateDimensions');
+      const connecting = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connecting' && s.resource.resource.id === '123'
+      );
+      stream.load(urn123, clientId, deviceId, config);
+      await simulateFrame(ws);
+      await connecting;
+
+      stream.update({ dimensions: Dimensions.create(100, 100) });
+      expect(updateDimensions).not.toHaveBeenCalled();
+
+      const connected = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connected' && s.resource.resource.id === '123'
+      );
+
+      await connected;
+
+      await simulateFrame(ws);
+      expect(updateDimensions).toHaveBeenCalled();
+    });
   });
 
   function makeStream(): { stream: ViewerStream; ws: WebSocketClientMock } {

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -163,9 +163,9 @@ export class ViewerStream extends StreamApi {
 
     if (fields.dimensions != null && fields.dimensions !== this.dimensions) {
       this.dimensions = fields.dimensions;
-      this.ifState('connected', () =>
-        this.updateDimensions({ dimensions: this.dimensions })
-      );
+      this.ifState('connected', () => {
+        this.updateDimensions({ dimensions: this.dimensions });
+      });
     }
 
     if (
@@ -321,6 +321,13 @@ export class ViewerStream extends StreamApi {
 
         if (this.state.type === 'connected') {
           this.updateState({ ...this.state, frame });
+
+          if (
+            this.dimensions &&
+            !Dimensions.isEqual(this.dimensions, frame.dimensions)
+          ) {
+            this.updateDimensions({ dimensions: this.dimensions });
+          }
         }
       }
     });

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -163,9 +163,9 @@ export class ViewerStream extends StreamApi {
 
     if (fields.dimensions != null && fields.dimensions !== this.dimensions) {
       this.dimensions = fields.dimensions;
-      this.ifState('connected', () => {
-        this.updateDimensions({ dimensions: this.dimensions });
-      });
+      this.ifState('connected', () =>
+        this.updateDimensions({ dimensions: this.dimensions })
+      );
     }
 
     if (
@@ -322,10 +322,7 @@ export class ViewerStream extends StreamApi {
         if (this.state.type === 'connected') {
           this.updateState({ ...this.state, frame });
 
-          if (
-            this.dimensions &&
-            !Dimensions.isEqual(this.dimensions, frame.dimensions)
-          ) {
+          if (!Dimensions.isEqual(this.dimensions, frame.dimensions)) {
             this.updateDimensions({ dimensions: this.dimensions });
           }
         }


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
The repro steps are defined in the ticket [PLAT-1724](https://vertexvis.atlassian.net/browse/PLAT-1724).

This can be reproduced any time that the client side stream model gets an updated dimension while not in the `connected` state. This is easily reproducible by resizing the viewer window, while the frame stream was reconnecting. 

Prior to these changes, the method `updateDimensions` was only invoked when the stream was in a connecting state:
```ts
      this.dimensions = fields.dimensions;

      this.ifState('connected', () => {
        this.updateDimensions({ dimensions: this.dimensions });
      });
```

This led to the dimensions in the `ViewerStream` to be mismatched with what the server side frame stream was reporting. 

The change here, detects this situation, and updates the dimensions correctly. 




## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
