### PR TITLE
[PLAT-1501] Scene tree performance improvements

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -22,6 +22,7 @@ import { MetadataKey } from './components/scene-tree/interfaces';
 import { SceneTreeErrorDetails } from './components/scene-tree/lib/errors';
 import { Row } from './components/scene-tree/lib/row';
 import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
+import { SceneTreeTableHoverController } from './components/scene-tree-table-layout/lib/hover-controller';
 import { SceneTreeTableCellEventDetails } from './components/scene-tree-table-cell/scene-tree-table-cell';
 import { RowDataProvider as RowDataProvider1 } from './components/scene-tree/scene-tree';
 import { DomScrollToOptions } from './components/scene-tree-table-layout/lib/dom';
@@ -287,7 +288,8 @@ export namespace Components {
      * Indicates whether to display a button for toggling the expanded state of the node associated with this cell.
      */
     expandToggle?: boolean;
-    hoveredNodeId?: string;
+    hoverController?: SceneTreeTableHoverController;
+    hovered: boolean;
     /**
      * A flag that disables the default interactions of this component. If disabled, you can use the event handlers to be notified when certain operations are performed by the user.
      */
@@ -1666,7 +1668,8 @@ declare namespace LocalJSX {
      * Indicates whether to display a button for toggling the expanded state of the node associated with this cell.
      */
     expandToggle?: boolean;
-    hoveredNodeId?: string;
+    hoverController?: SceneTreeTableHoverController;
+    hovered?: boolean;
     /**
      * A flag that disables the default interactions of this component. If disabled, you can use the event handlers to be notified when certain operations are performed by the user.
      */
@@ -1681,11 +1684,6 @@ declare namespace LocalJSX {
      */
     onExpandToggled?: (
       event: VertexSceneTreeTableCellCustomEvent<SceneTreeTableCellEventDetails>
-    ) => void;
-    onHovered?: (
-      event: VertexSceneTreeTableCellCustomEvent<
-        SceneTreeTableCellEventDetails | undefined
-      >
     ) => void;
     /**
      * An event that is emitted when a user requests to change the node's selection state. This event is emitted even if interactions are disabled.

--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.ts
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.ts
@@ -2,7 +2,7 @@ import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
 import Chance from 'chance';
 
-import { SceneTreeTableHoverController } from '../scene-tree-table-layout/lib/hover-controller';
+import { SceneTreeCellHoverController } from '../scene-tree-table-layout/lib/hover-controller';
 import { SceneTreeTableCell } from './scene-tree-table-cell';
 
 const random = new Chance();
@@ -429,7 +429,7 @@ describe('<vertex-scene-tree-table-cell>', () => {
       node,
     });
 
-    const hoverController = new SceneTreeTableHoverController();
+    const hoverController = new SceneTreeCellHoverController();
     const hovered = jest.fn();
     const disposable = hoverController.stateChanged(hovered);
     cell.hoverController = hoverController;
@@ -450,7 +450,7 @@ describe('<vertex-scene-tree-table-cell>', () => {
       node,
     });
 
-    const hoverController = new SceneTreeTableHoverController();
+    const hoverController = new SceneTreeCellHoverController();
     const hovered = jest.fn();
     const disposable = hoverController.stateChanged(hovered);
     cell.hoverController = hoverController;

--- a/packages/viewer/src/components/scene-tree-table-layout/lib/hover-controller.ts
+++ b/packages/viewer/src/components/scene-tree-table-layout/lib/hover-controller.ts
@@ -1,0 +1,13 @@
+import { Disposable, EventDispatcher, Listener } from '@vertexvis/utils';
+
+export class SceneTreeTableHoverController {
+  public onStateChange = new EventDispatcher<string | undefined>();
+
+  public setHovered(id?: string): void {
+    this.onStateChange.emit(id);
+  }
+
+  public stateChanged(listener: Listener<string | undefined>): Disposable {
+    return this.onStateChange.on(listener);
+  }
+}

--- a/packages/viewer/src/components/scene-tree-table-layout/lib/hover-controller.ts
+++ b/packages/viewer/src/components/scene-tree-table-layout/lib/hover-controller.ts
@@ -1,6 +1,6 @@
 import { Disposable, EventDispatcher, Listener } from '@vertexvis/utils';
 
-export class SceneTreeTableHoverController {
+export class SceneTreeCellHoverController {
   public onStateChange = new EventDispatcher<string | undefined>();
 
   public setHovered(id?: string): void {

--- a/packages/viewer/src/components/scene-tree-table-layout/lib/window.ts
+++ b/packages/viewer/src/components/scene-tree-table-layout/lib/window.ts
@@ -1,0 +1,8 @@
+export function restartTimeout(
+  fn: VoidFunction,
+  existingTimeout?: number,
+  delay = 200
+): number {
+  window.clearTimeout(existingTimeout);
+  return window.setTimeout(fn, delay);
+}

--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.spec.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.spec.tsx
@@ -34,7 +34,7 @@ import {
   getSceneTreeTableOffsetTop,
   getSceneTreeTableViewportWidth,
 } from './lib/dom';
-import { SceneTreeTableHoverController } from './lib/hover-controller';
+import { SceneTreeCellHoverController } from './lib/hover-controller';
 import { restartTimeout } from './lib/window';
 import { SceneTreeTableLayout } from './scene-tree-table-layout';
 
@@ -126,7 +126,7 @@ describe('<vertex-scene-tree-table-layout>', () => {
     await page.waitForChanges();
 
     const hovered = jest.fn();
-    const hoverController = new SceneTreeTableHoverController();
+    const hoverController = new SceneTreeCellHoverController();
     const disposable = hoverController.stateChanged(hovered);
     const cell = table.querySelector(
       'vertex-scene-tree-table-cell'

--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.spec.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.spec.tsx
@@ -32,6 +32,7 @@ import {
   getSceneTreeTableOffsetTop,
   getSceneTreeTableViewportWidth,
 } from './lib/dom';
+import { SceneTreeTableHoverController } from './lib/hover-controller';
 import { SceneTreeTableLayout } from './scene-tree-table-layout';
 
 describe('<vertex-scene-tree-table-layout>', () => {
@@ -121,15 +122,21 @@ describe('<vertex-scene-tree-table-layout>', () => {
 
     await page.waitForChanges();
 
-    const cell = table.querySelector('vertex-scene-tree-table-cell');
+    const hovered = jest.fn();
+    const hoverController = new SceneTreeTableHoverController();
+    const disposable = hoverController.stateChanged(hovered);
+    const cell = table.querySelector(
+      'vertex-scene-tree-table-cell'
+    ) as HTMLVertexSceneTreeTableCellElement;
+    cell.hoverController = hoverController;
 
     cell?.dispatchEvent(new MouseEvent('pointerenter'));
 
     await page.waitForChanges();
 
-    expect(
-      table.querySelector('vertex-scene-tree-table-cell')?.hoveredNodeId
-    ).toBe(mockRow.node.id?.hex);
+    disposable.dispose();
+
+    expect(hovered).toHaveBeenCalledWith(mockRow.node.id?.hex);
   });
 
   it('creates headers from header template', async () => {

--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
@@ -30,6 +30,7 @@ import {
   scrollToTop,
 } from './lib/dom';
 import { SceneTreeTableHoverController } from './lib/hover-controller';
+import { restartTimeout } from './lib/window';
 
 interface StateMap {
   columnElementPools?: WeakMap<
@@ -852,10 +853,9 @@ export class SceneTreeTableLayout {
   private handleScrollChanged = (event: Event): void => {
     this.isScrolling = true;
 
-    window.clearTimeout(this.scrollTimer);
-    this.scrollTimer = window.setTimeout(() => {
+    this.scrollTimer = restartTimeout(() => {
       this.isScrolling = false;
-    }, 200);
+    }, this.scrollTimer);
 
     this.scrollOffset = (event.target as HTMLElement).scrollTop;
     this.computeAndUpdateViewportRows();

--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
@@ -29,6 +29,7 @@ import {
   getSceneTreeTableViewportWidth,
   scrollToTop,
 } from './lib/dom';
+import { SceneTreeTableHoverController } from './lib/hover-controller';
 
 interface StateMap {
   columnElementPools?: WeakMap<
@@ -215,6 +216,8 @@ export class SceneTreeTableLayout {
   private headerElement?: HTMLDivElement;
   private columnElements: HTMLVertexSceneTreeTableColumnElement[] = [];
 
+  private cellHoverController = new SceneTreeTableHoverController();
+
   public componentWillLoad(): void {
     this.updateColumnElements();
     this.createPools();
@@ -392,15 +395,13 @@ export class SceneTreeTableLayout {
           ? (depth: number) => `calc(${depth} * 0.5rem)`
           : () => `0`;
 
-      if (!this.isScrolling) {
-        pool.iterateElements((el, binding, rowIndex) => {
-          const row = this.stateMap.viewportRows[rowIndex];
+      pool.iterateElements((el, binding, rowIndex) => {
+        const row = this.stateMap.viewportRows[rowIndex];
 
-          if (isLoadedRow(row)) {
-            this.updateCell(row, el, binding, rowIndex, cellPaddingLeft);
-          }
-        });
-      }
+        if (isLoadedRow(row)) {
+          this.updateCell(row, el, binding, rowIndex, cellPaddingLeft);
+        }
+      });
     });
   };
 
@@ -423,7 +424,7 @@ export class SceneTreeTableLayout {
     /* eslint-disable @typescript-eslint/no-explicit-any */
     (cell as any).tree = this.tree;
     (cell as any).node = row.node;
-    (cell as any).hoveredNodeId = this.hoveredNodeId;
+    (cell as any).hoverController = this.cellHoverController;
     (cell as any).isScrolling = this.isScrolling;
     /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -852,7 +853,7 @@ export class SceneTreeTableLayout {
     this.isScrolling = true;
 
     window.clearTimeout(this.scrollTimer);
-    window.setTimeout(() => {
+    this.scrollTimer = window.setTimeout(() => {
       this.isScrolling = false;
     }, 200);
 

--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
@@ -29,7 +29,7 @@ import {
   getSceneTreeTableViewportWidth,
   scrollToTop,
 } from './lib/dom';
-import { SceneTreeTableHoverController } from './lib/hover-controller';
+import { SceneTreeCellHoverController } from './lib/hover-controller';
 import { restartTimeout } from './lib/window';
 
 interface StateMap {
@@ -217,7 +217,7 @@ export class SceneTreeTableLayout {
   private headerElement?: HTMLDivElement;
   private columnElements: HTMLVertexSceneTreeTableColumnElement[] = [];
 
-  private cellHoverController = new SceneTreeTableHoverController();
+  private cellHoverController = new SceneTreeCellHoverController();
 
   public componentWillLoad(): void {
     this.updateColumnElements();


### PR DESCRIPTION
## Summary

Makes a couple improvements performance-wise to the `<vertex-scene-tree>` component:
- Hovered state is now tracked using a `SceneTreeTableHoverController`, which is created initially in the `<vertex-scene-tree-table-layout>` and passed as a property to each cell. The cells then subscribe to hovered ID changes, and handle hovered state updates independent of the layout
  - This reduces the number of cells that need to be re-rendered each time the cursor enters a new row, previously this would re-render each cell in the viewport - now this will re-render only the cells in the hovered row + the cells in the previously hovered row (if applicable)
- Changing of the `isScrolling` property on `<vertex-scene-tree-table-cell>`s is now debounced (we weren't setting `this.scrollTimer = window.setTimeout(...)` before, which meant it wasn't properly cleared as new scroll events came in. Now as the user scrolls, this property will remain `true` until they pause or stop, and will not flip back and forth and cause additional re-renders of cells

## Test Plan

- Test scrolling through the scene tree
- Test hovering of rows in the scene tree

## Release Notes

N/A

## Possible Regressions

Scene tree hover behavior

## Dependencies

N/A
