### PR TITLE
[PLAT-1785] Update layout offset when header changes

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
@@ -222,6 +222,7 @@ export class SceneTreeTableLayout {
     this.headerResizeObserver = new ResizeObserver(() => {
       this.stateMap.headerHeight = undefined;
       this.computeHeaderHeight();
+      this.updateLayoutPosition();
     });
 
     this.resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
## Summary

Corrects an issue with `getRowAtClientY` when the header changes and does not trigger a table resize.

## Test Plan

- Test the scene tree context menu in Connect on initial load with columns (see https://vertexvis.atlassian.net/browse/PLAT-1785 for specific repro steps)

## Release Notes

N/A

## Possible Regressions

Layout offset when the header resizes

## Dependencies

N/A
