### PR TITLE
[PLAT-1533] Support clear transform scene item operations

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.7.0"
+    "@vertexvis/frame-streaming-protos": "^0.8.0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.7.0",
+    "@vertexvis/frame-streaming-protos": "^0.8.0",
     "@vertexvis/geometry": "0.14.0",
     "@vertexvis/html-templates": "0.14.0",
     "@vertexvis/scene-tree-protos": "^0.1.15",

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -1,0 +1,20 @@
+import { Dimensions } from '@vertexvis/geometry';
+
+import { buildSceneOperation } from '../mapper';
+
+describe(buildSceneOperation, () => {
+  it('maps a clear transform operation', () => {
+    expect(
+      buildSceneOperation({ type: 'all' }, [{ type: 'clear-transform' }], {
+        dimensions: Dimensions.create(100, 100),
+      })
+    ).toMatchObject({
+      all: {},
+      operationTypes: [
+        {
+          changeTransform: {},
+        },
+      ],
+    });
+  });
+});

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -5,14 +5,20 @@ import { buildSceneOperation } from '../mapper';
 describe(buildSceneOperation, () => {
   it('maps a clear transform operation', () => {
     expect(
-      buildSceneOperation({ type: 'all' }, [{ type: 'clear-transform' }], {
-        dimensions: Dimensions.create(100, 100),
-      })
+      buildSceneOperation(
+        { type: 'all' },
+        [{ type: 'clear-transform', cascade: true }],
+        {
+          dimensions: Dimensions.create(100, 100),
+        }
+      )
     ).toMatchObject({
       all: {},
       operationTypes: [
         {
-          changeTransform: {},
+          clearTransform: {
+            cascade: true,
+          },
         },
       ],
     });

--- a/packages/viewer/src/lib/scenes/__tests__/operations.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/operations.spec.ts
@@ -56,4 +56,11 @@ describe(SceneOperationBuilder, () => {
 
     expect(definitions).toEqual([{ type: 'deselect' }]);
   });
+
+  it('creates a clear transform operation', () => {
+    const builder = new SceneOperationBuilder();
+    const definitions = builder.clearTransforms().build();
+
+    expect(definitions).toEqual([{ type: 'clear-transform' }]);
+  });
 });

--- a/packages/viewer/src/lib/scenes/__tests__/operations.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/operations.spec.ts
@@ -61,6 +61,6 @@ describe(SceneOperationBuilder, () => {
     const builder = new SceneOperationBuilder();
     const definitions = builder.clearTransforms().build();
 
-    expect(definitions).toEqual([{ type: 'clear-transform' }]);
+    expect(definitions).toEqual([{ type: 'clear-transform', cascade: true }]);
   });
 });

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -184,7 +184,9 @@ function buildOperationTypes(
         };
       case 'clear-transform':
         return {
-          changeTransform: {},
+          clearTransform: {
+            cascade: op.cascade,
+          },
         };
       case 'hide':
         return {

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -182,6 +182,10 @@ function buildOperationTypes(
             transform: { ...op.transform },
           },
         };
+      case 'clear-transform':
+        return {
+          changeTransform: {},
+        };
       case 'hide':
         return {
           changeVisibility: {

--- a/packages/viewer/src/lib/scenes/operations.ts
+++ b/packages/viewer/src/lib/scenes/operations.ts
@@ -35,6 +35,7 @@ export interface TransformOperation {
 
 export interface ClearTransformOperation {
   type: 'clear-transform';
+  cascade?: boolean;
 }
 
 export type ItemOperation =
@@ -117,9 +118,9 @@ export class SceneOperationBuilder
     );
   }
 
-  public clearTransforms(): SceneOperationBuilder {
+  public clearTransforms(cascade = true): SceneOperationBuilder {
     return new SceneOperationBuilder(
-      this.operations.concat([{ type: 'clear-transform' }])
+      this.operations.concat([{ type: 'clear-transform', cascade }])
     );
   }
 }

--- a/packages/viewer/src/lib/scenes/operations.ts
+++ b/packages/viewer/src/lib/scenes/operations.ts
@@ -33,6 +33,10 @@ export interface TransformOperation {
   transform: vertexvis.protobuf.core.IMatrix4x4f;
 }
 
+export interface ClearTransformOperation {
+  type: 'clear-transform';
+}
+
 export type ItemOperation =
   | ShowItemOperation
   | HideItemOperation
@@ -40,7 +44,8 @@ export type ItemOperation =
   | DeselectItemOperation
   | ChangeMaterialOperation
   | ClearItemOperation
-  | TransformOperation;
+  | TransformOperation
+  | ClearTransformOperation;
 
 export interface SceneItemOperations<T> {
   materialOverride(color: ColorMaterial): T;
@@ -49,6 +54,7 @@ export interface SceneItemOperations<T> {
   select(color: ColorMaterial): T;
   deselect(): T;
   clearMaterialOverrides(): T;
+  clearTransforms(): T;
 }
 
 /**
@@ -108,6 +114,12 @@ export class SceneOperationBuilder
   ): SceneOperationBuilder {
     return new SceneOperationBuilder(
       this.operations.concat([{ type: 'change-transform', transform: matrix }])
+    );
+  }
+
+  public clearTransforms(): SceneOperationBuilder {
+    return new SceneOperationBuilder(
+      this.operations.concat([{ type: 'clear-transform' }])
     );
   }
 }

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -163,6 +163,14 @@ export class SceneItemOperationsBuilder
     }
   }
 
+  public clearTransforms(): SceneItemOperationsBuilder {
+    return new SceneItemOperationsBuilder(
+      this.query,
+      this.defaultSelectionMaterial,
+      this.builder.clearTransforms()
+    );
+  }
+
   public build(): QueryOperation {
     return {
       query: this.query,

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -163,11 +163,11 @@ export class SceneItemOperationsBuilder
     }
   }
 
-  public clearTransforms(): SceneItemOperationsBuilder {
+  public clearTransforms(cascade = true): SceneItemOperationsBuilder {
     return new SceneItemOperationsBuilder(
       this.query,
       this.defaultSelectionMaterial,
-      this.builder.clearTransforms()
+      this.builder.clearTransforms(cascade)
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2125,10 +2125,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.7.0.tgz#7a070c86e6e45d9d0e9932f2682b4f1887c0e28c"
-  integrity sha512-H60m169UreO/D5k9y8B7kYNz6pZvfDa3SH6NNj308zCUXACpCATlMmb9zLj8+JwpHZLQyx304N+RoQIfzU2O9w==
+"@vertexvis/frame-streaming-protos@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.8.0.tgz#7f7028b4e4269ae66012b56c4594f71542e4e847"
+  integrity sha512-jQssMEKZ/Ji4TCt/QnPX1xi1Fdyu38qeTi8/7ywAQuAZ7gfCZy6vbSJeRlNQ8ITRiHFanKdrehaHaQefJ5+E+w==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary

Adds support for a `clearTransforms(...)` operation, which optionally takes a `cascade` flag indicating whether the operation should clear all transform overrides of child elements of those that match the provided query. (note: this is the only way the `all()` query will work for clearing any transforms lower than the root node).

## Test Plan

- Test performing a transform using `transform(...)` alteration, and then performing a `clearTransforms()` alteration for the same node
  - The transform override should be removed
- Test performing a transform of an assembly item and a child of that assembly using the `transform(...)` alteration, then performing a `clearTransforms()` alteration for the assembly
  - Both the assembly and child transforms should be removed
- Test performing a transform of an assembly item and a child of that assembly using the `transform(...)` alteration, then performing a `clearTransforms(false)` alteration for the assembly
  - Only the assembly transform should be removed
- Test performing a handful of `transform(...)` alterations, then performing a `clearTransforms()` alteration with the `all()` query
  - All transform overrides should be removed

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

https://github.com/Vertexvis/frame-streaming-service/pull/297
https://github.com/Vertexvis/scene-service/pull/408
