### PR TITLE
[PLAT-1799] Allow toggling of cameraControls and keyboardControls

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -458,6 +458,10 @@ export namespace Components {
      */
     getJwt: () => Promise<string | undefined>;
     /**
+     * @ignore
+     */
+    getKeyInteractions: () => Promise<KeyInteraction<TapEventDetails>[]>;
+    /**
      * Returns `true` indicating that the scene is ready to be interacted with.
      */
     isSceneReady: () => Promise<boolean>;

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -4,7 +4,7 @@ jest.mock('../../workers/png-decoder-pool');
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { h } from '@stencil/core';
-import { NewSpecPageOptions } from '@stencil/core/internal';
+import { NewSpecPageOptions, SpecPage } from '@stencil/core/internal';
 import { newSpecPage } from '@stencil/core/testing';
 import { Dimensions } from '@vertexvis/geometry';
 import { Async, Color } from '@vertexvis/utils';
@@ -482,6 +482,62 @@ describe('vertex-viewer', () => {
     });
   });
 
+  describe('interaction handlers', () => {
+    it('handles toggling cameraControls off', async () => {
+      const { stream, ws } = makeViewerStream();
+      const { page, viewer } = await newViewerSpecWithPage({
+        template: () => (
+          <vertex-viewer
+            clientId={clientId}
+            stream={stream}
+            resizeDebounce={1000}
+          />
+        ),
+      });
+
+      await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
+
+      expect(await viewer.getInteractionHandlers()).toHaveLength(3);
+
+      viewer.cameraControls = false;
+      await page.waitForChanges();
+
+      expect(await viewer.getInteractionHandlers()).toHaveLength(0);
+
+      viewer.cameraControls = true;
+      await page.waitForChanges();
+
+      expect(await viewer.getInteractionHandlers()).toHaveLength(3);
+    });
+
+    it('handles toggling keyboardControls off', async () => {
+      const { stream, ws } = makeViewerStream();
+      const { page, viewer } = await newViewerSpecWithPage({
+        template: () => (
+          <vertex-viewer
+            clientId={clientId}
+            stream={stream}
+            resizeDebounce={1000}
+          />
+        ),
+      });
+
+      await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
+
+      expect(await viewer.getKeyInteractions()).toHaveLength(2);
+
+      viewer.keyboardControls = false;
+      await page.waitForChanges();
+
+      expect(await viewer.getKeyInteractions()).toHaveLength(0);
+
+      viewer.keyboardControls = true;
+      await page.waitForChanges();
+
+      expect(await viewer.getKeyInteractions()).toHaveLength(2);
+    });
+  });
+
   describe('resizing', () => {
     it('handles resizes', async () => {
       const { stream, ws } = makeViewerStream();
@@ -537,5 +593,12 @@ describe('vertex-viewer', () => {
   ): Promise<HTMLVertexViewerElement> {
     const page = await newSpecPage({ components: [Viewer], ...opts });
     return page.root as HTMLVertexViewerElement;
+  }
+
+  async function newViewerSpecWithPage(
+    opts: Pick<NewSpecPageOptions, 'template' | 'html'>
+  ): Promise<{ page: SpecPage; viewer: HTMLVertexViewerElement }> {
+    const page = await newSpecPage({ components: [Viewer], ...opts });
+    return { page, viewer: page.root as HTMLVertexViewerElement };
   }
 });

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -655,6 +655,17 @@ export class Viewer {
     return this.interactionHandlers;
   }
 
+  /**
+   * @internal
+   * @ignore
+   */
+  @Method()
+  public async getKeyInteractions(): Promise<
+    KeyInteraction<TapEventDetails>[]
+  > {
+    return this.tapKeyInteractions;
+  }
+
   @Method()
   public async getBaseInteractionHandler(): Promise<
     BaseInteractionHandler | undefined

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1156,9 +1156,9 @@ export class Viewer {
           'pointermove',
           () => this.getResolvedConfig()
         );
-        this.baseInteractionHandler = new PointerInteractionHandler(() =>
-          this.getResolvedConfig()
-        );
+        this.baseInteractionHandler =
+          this.baseInteractionHandler ??
+          new PointerInteractionHandler(() => this.getResolvedConfig());
         const baseDisposable = await this.registerInteractionHandler(
           this.baseInteractionHandler
         );
@@ -1183,9 +1183,9 @@ export class Viewer {
         );
 
         // fallback to touch events and mouse events as a default
-        this.baseInteractionHandler = new MouseInteractionHandler(() =>
-          this.getResolvedConfig()
-        );
+        this.baseInteractionHandler =
+          this.baseInteractionHandler ??
+          new MouseInteractionHandler(() => this.getResolvedConfig());
         const baseDisposable = await this.registerInteractionHandler(
           this.baseInteractionHandler
         );

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -416,8 +416,10 @@ export class Viewer {
   private resizeTimer?: NodeJS.Timeout;
 
   private interactionHandlers: InteractionHandler[] = [];
+  private defaultInteractionHandlerDisposables: Array<Disposable> = [];
   private interactionApi!: InteractionApi;
   private tapKeyInteractions: KeyInteraction<TapEventDetails>[] = [];
+  private defaultTapKeyInteractions: KeyInteraction<TapEventDetails>[] = [];
   private baseInteractionHandler?: BaseInteractionHandler;
 
   private internalFrameDrawnDispatcher = new EventDispatcher<Frame>();
@@ -466,65 +468,7 @@ export class Viewer {
       }
     }
 
-    if (this.cameraControls) {
-      // default to pointer events if allowed by browser.
-      if (window.PointerEvent != null) {
-        const tapInteractionHandler = new TapInteractionHandler(
-          'pointerdown',
-          'pointerup',
-          'pointermove',
-          () => this.getResolvedConfig()
-        );
-        this.baseInteractionHandler = new PointerInteractionHandler(() =>
-          this.getResolvedConfig()
-        );
-        this.registerInteractionHandler(this.baseInteractionHandler);
-        this.registerInteractionHandler(new MultiPointerInteractionHandler());
-        this.registerInteractionHandler(tapInteractionHandler);
-      } else {
-        const tapInteractionHandler = new TapInteractionHandler(
-          'mousedown',
-          'mouseup',
-          'mousemove',
-          () => this.getResolvedConfig()
-        );
-
-        // fallback to touch events and mouse events as a default
-        this.baseInteractionHandler = new MouseInteractionHandler(() =>
-          this.getResolvedConfig()
-        );
-        this.registerInteractionHandler(this.baseInteractionHandler);
-        this.registerInteractionHandler(new TouchInteractionHandler());
-        this.registerInteractionHandler(tapInteractionHandler);
-      }
-    }
-
-    if (this.keyboardControls && this.stream != null) {
-      this.baseInteractionHandler?.setDefaultKeyboardControls(
-        this.keyboardControls
-      );
-
-      this.registerTapKeyInteraction(
-        new FlyToPartKeyInteraction(
-          this.stream,
-          () => this.getResolvedConfig(),
-          () => this.getImageScale()
-        )
-      );
-      this.registerTapKeyInteraction(
-        new FlyToPositionKeyInteraction(
-          this.stream,
-          () => this.getResolvedConfig(),
-          () => this.getImageScale(),
-          () => this.createScene()
-        )
-      );
-    }
-
-    if (this.rotateAroundTapPoint) {
-      this.baseInteractionHandler?.setPrimaryInteractionType('rotate-point');
-    }
-
+    this.initializeDefaultInteractionHandlers();
     this.injectViewerApi();
   }
 
@@ -733,6 +677,22 @@ export class Viewer {
     } else {
       this.unload();
     }
+  }
+
+  /**
+   * @ignore
+   */
+  @Watch('cameraControls')
+  protected handleCameraControlsChanged(): void {
+    this.initializeDefaultCameraInteractionHandlers();
+  }
+
+  /**
+   * @ignore
+   */
+  @Watch('keyboardControls')
+  protected handleKeyboardControlsChanged(): void {
+    this.initializeDefaultKeyboardInteractionHandlers();
   }
 
   /**
@@ -1144,6 +1104,120 @@ export class Viewer {
         const drawnFrame = await this.canvasRenderer(data);
         this.dispatchFrameDrawn(drawnFrame);
       }
+    }
+  }
+
+  private async initializeDefaultInteractionHandlers(): Promise<void> {
+    await this.initializeDefaultCameraInteractionHandlers();
+    this.initializeDefaultKeyboardInteractionHandlers();
+
+    if (this.rotateAroundTapPoint) {
+      this.baseInteractionHandler?.setPrimaryInteractionType('rotate-point');
+    }
+  }
+
+  private clearDefaultCameraInteractionHandlers(): void {
+    this.defaultInteractionHandlerDisposables.forEach((disposable) =>
+      disposable.dispose()
+    );
+    this.defaultInteractionHandlerDisposables = [];
+  }
+
+  private clearDefaultKeyboardInteractions(): void {
+    this.defaultTapKeyInteractions.forEach((interaction) => {
+      const index = this.tapKeyInteractions.indexOf(interaction);
+      if (index !== -1) {
+        this.tapKeyInteractions.splice(index, 1);
+      }
+    });
+    this.tapKeyInteractions = [];
+  }
+
+  private async initializeDefaultCameraInteractionHandlers(): Promise<void> {
+    this.clearDefaultCameraInteractionHandlers();
+
+    if (this.cameraControls) {
+      // default to pointer events if allowed by browser.
+      if (window.PointerEvent != null) {
+        const tapInteractionHandler = new TapInteractionHandler(
+          'pointerdown',
+          'pointerup',
+          'pointermove',
+          () => this.getResolvedConfig()
+        );
+        this.baseInteractionHandler = new PointerInteractionHandler(() =>
+          this.getResolvedConfig()
+        );
+        const baseDisposable = await this.registerInteractionHandler(
+          this.baseInteractionHandler
+        );
+        const multiPointerDisposable = await this.registerInteractionHandler(
+          new MultiPointerInteractionHandler()
+        );
+        const tapDisposable = await this.registerInteractionHandler(
+          tapInteractionHandler
+        );
+
+        this.defaultInteractionHandlerDisposables = [
+          baseDisposable,
+          multiPointerDisposable,
+          tapDisposable,
+        ];
+      } else {
+        const tapInteractionHandler = new TapInteractionHandler(
+          'mousedown',
+          'mouseup',
+          'mousemove',
+          () => this.getResolvedConfig()
+        );
+
+        // fallback to touch events and mouse events as a default
+        this.baseInteractionHandler = new MouseInteractionHandler(() =>
+          this.getResolvedConfig()
+        );
+        const baseDisposable = await this.registerInteractionHandler(
+          this.baseInteractionHandler
+        );
+        const touchDisposable = await this.registerInteractionHandler(
+          new TouchInteractionHandler()
+        );
+        const tapDisposable = await this.registerInteractionHandler(
+          tapInteractionHandler
+        );
+
+        this.defaultInteractionHandlerDisposables = [
+          baseDisposable,
+          touchDisposable,
+          tapDisposable,
+        ];
+      }
+    }
+  }
+
+  private initializeDefaultKeyboardInteractionHandlers(): void {
+    this.clearDefaultKeyboardInteractions();
+
+    if (this.keyboardControls && this.stream != null) {
+      this.baseInteractionHandler?.setDefaultKeyboardControls(
+        this.keyboardControls
+      );
+
+      const flyToPart = new FlyToPartKeyInteraction(
+        this.stream,
+        () => this.getResolvedConfig(),
+        () => this.getImageScale()
+      );
+      const flyToPosition = new FlyToPositionKeyInteraction(
+        this.stream,
+        () => this.getResolvedConfig(),
+        () => this.getImageScale(),
+        () => this.createScene()
+      );
+
+      this.registerTapKeyInteraction(flyToPart);
+      this.registerTapKeyInteraction(flyToPosition);
+
+      this.defaultTapKeyInteractions = [flyToPart, flyToPosition];
     }
   }
 


### PR DESCRIPTION
## Summary

Adds support for changing the values of `cameraControls` and `keyboardControls` on the viewer after it has loaded.

## Test Plan

- Test loading a model in the viewer, then changing `cameraControls` to false, then back to true
- Test loading a model in the viewer, then changing `keyboardControls` to false, then back to true

## Release Notes

N/A

## Possible Regressions

Camera and keyboard controls on initial load

## Dependencies

N/A
