### PR TITLE
[PLAT-1624] Skip drawing older frames to the canvas

### DIFF
--- a/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
@@ -84,7 +84,7 @@ describe('<vertex-scene-tree>', () => {
   // Scene tree mocks
   (getSceneTreeViewportHeight as jest.Mock).mockReturnValue(1000);
   (getSceneTreeOffsetTop as jest.Mock).mockReturnValue(0);
-  (loadImageBytes as jest.Mock).mockReturnValue({
+  (loadImageBytes as jest.Mock).mockResolvedValue({
     width: 100,
     height: 100,
     dispose: () => undefined,

--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.spec.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.spec.tsx
@@ -74,7 +74,7 @@ describe('vertex-viewer-measurement-distance', () => {
     height: 100,
   });
 
-  (loadImageBytes as jest.Mock).mockReturnValue({
+  (loadImageBytes as jest.Mock).mockResolvedValue({
     width: 100,
     height: 100,
     dispose: () => undefined,

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
@@ -40,7 +40,7 @@ describe('vertex-viewer-transform-widget', () => {
     document.createElement('canvas')
   );
 
-  (loadImageBytes as jest.Mock).mockReturnValue({
+  (loadImageBytes as jest.Mock).mockResolvedValue({
     width: 200,
     height: 150,
     dispose: () => undefined,

--- a/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.spec.tsx
+++ b/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.spec.tsx
@@ -21,7 +21,7 @@ import { ViewerDomRenderer } from '../viewer-dom-renderer/viewer-dom-renderer';
 import { ViewerViewCube } from './viewer-view-cube';
 
 describe('vertex-viewer-view-cube', () => {
-  (loadImageBytes as jest.Mock).mockReturnValue({
+  (loadImageBytes as jest.Mock).mockResolvedValue({
     width: 200,
     height: 150,
     dispose: () => undefined,

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -30,11 +30,11 @@ import {
 import { Viewer } from './viewer';
 
 describe('vertex-viewer', () => {
-  (loadImageBytes as jest.Mock).mockReturnValue({
+  (loadImageBytes as jest.Mock).mockImplementation(async () => ({
     width: 200,
     height: 150,
     dispose: () => undefined,
-  });
+  }));
   (getElementBoundingClientRect as jest.Mock).mockReturnValue({
     left: 0,
     top: 0,
@@ -638,11 +638,11 @@ describe('vertex-viewer', () => {
 
       await Async.delay(1);
 
-      (loadImageBytes as jest.Mock).mockReturnValue({
+      (loadImageBytes as jest.Mock).mockImplementation(async () => ({
         width: 200,
         height: 150,
         dispose: () => undefined,
-      });
+      }));
 
       receiveFrame(ws, (payload) => ({
         ...payload,

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -553,6 +553,15 @@ describe('vertex-viewer', () => {
 
       await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
 
+      (getElementBoundingClientRect as jest.Mock).mockReturnValue({
+        left: 0,
+        top: 0,
+        bottom: 150,
+        right: 200,
+        width: 500,
+        height: 500,
+      });
+
       jest.useFakeTimers();
       triggerResizeObserver([
         {
@@ -647,17 +656,8 @@ describe('vertex-viewer', () => {
 
       await Async.delay(10);
 
-      expect(onFrameDrawn).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          detail: expect.objectContaining({
-            dimensions: Dimensions.create(500, 500),
-          }),
-        })
-      );
-
-      expect(onFrameDrawn).toHaveBeenNthCalledWith(
-        2,
+      expect(onFrameDrawn).toHaveBeenCalledTimes(1);
+      expect(onFrameDrawn).toHaveBeenCalledWith(
         expect.objectContaining({
           detail: expect.objectContaining({
             dimensions: Dimensions.create(1, 1),

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -30,11 +30,11 @@ import {
 import { Viewer } from './viewer';
 
 describe('vertex-viewer', () => {
-  (loadImageBytes as jest.Mock).mockImplementation(async () => ({
+  (loadImageBytes as jest.Mock).mockResolvedValue({
     width: 200,
     height: 150,
     dispose: () => undefined,
-  }));
+  });
   (getElementBoundingClientRect as jest.Mock).mockReturnValue({
     left: 0,
     top: 0,
@@ -157,6 +157,8 @@ describe('vertex-viewer', () => {
       viewer.addEventListener('frameReceived', onFrameReceived);
       viewer.addEventListener('frameDrawn', onFrameDrawn);
       await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
+
+      await Async.delay(1);
 
       expect(onConnectionChange).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -611,6 +613,8 @@ describe('vertex-viewer', () => {
       });
 
       await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
+
+      await Async.delay(1);
 
       const onFrameDrawn = jest.fn();
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1091,7 +1091,7 @@ export class Viewer {
             this.updateCanvasDimensions(canvasDimensions);
             this.isResizeUpdate = false;
           },
-          loadPredicate: () => {
+          predicate: () => {
             if (this.isResizeUpdate) {
               return (
                 this.dimensions == null ||
@@ -1103,9 +1103,6 @@ export class Viewer {
             }
             return true;
           },
-          drawPredicate: () =>
-            this.frame == null ||
-            this.frame?.sequenceNumber <= frame.sequenceNumber,
         };
 
         this.frameReceived.emit(this.frame);

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -406,7 +406,7 @@ export class Viewer {
   private canvasElement?: HTMLCanvasElement;
 
   private canvasRenderer!: CanvasRenderer;
-  private resizeRenderer!: CanvasRenderer;
+  private canvasRenderPromise?: Promise<Frame>;
 
   private mutationObserver?: MutationObserver;
   private resizeObserver?: ResizeObserver;
@@ -1112,7 +1112,13 @@ export class Viewer {
           this.sceneChanged.emit();
         }
 
-        const drawnFrame = await this.canvasRenderer(data);
+        // Wait for any frame being actively drawn
+        await this.canvasRenderPromise;
+
+        this.canvasRenderPromise = this.canvasRenderer(data);
+        const drawnFrame = await this.canvasRenderPromise;
+        this.canvasRenderPromise = undefined;
+
         this.dispatchFrameDrawn(drawnFrame);
       }
     }

--- a/packages/viewer/src/lib/rendering/__tests__/canvas.spec.ts
+++ b/packages/viewer/src/lib/rendering/__tests__/canvas.spec.ts
@@ -48,7 +48,16 @@ const drawFrame4: DrawFrame = {
   frame: Fixtures.makePerspectiveFrame(),
   viewport: new Viewport(100, 50),
   beforeDraw: jest.fn(),
-  predicate: jest.fn(() => false),
+  loadPredicate: jest.fn(() => false),
+};
+
+const drawFrame5: DrawFrame = {
+  canvas,
+  canvasDimensions: Dimensions.create(100, 50),
+  frame: Fixtures.makePerspectiveFrame(),
+  viewport: new Viewport(100, 50),
+  beforeDraw: jest.fn(),
+  drawPredicate: jest.fn(() => false),
 };
 
 describe(createCanvasRenderer, () => {
@@ -86,11 +95,21 @@ describe(createCanvasRenderer, () => {
     expect(drawFrame3.beforeDraw).toHaveBeenCalledTimes(1);
   });
 
-  it('skips drawing if predicate fails', async () => {
+  it('skips loading and drawing if the load predicate fails', async () => {
     const renderer = createCanvasRenderer();
     const drawImage = jest.spyOn(canvas, 'drawImage');
 
     await renderer(drawFrame4);
+
+    expect(loadImageBytes).not.toHaveBeenCalled();
+    expect(drawImage).not.toHaveBeenCalled();
+  });
+
+  it('skips drawing if the draw predicate fails', async () => {
+    const renderer = createCanvasRenderer();
+    const drawImage = jest.spyOn(canvas, 'drawImage');
+
+    await renderer(drawFrame5);
 
     expect(drawImage).not.toHaveBeenCalled();
   });
@@ -98,6 +117,12 @@ describe(createCanvasRenderer, () => {
   it('disposes loaded image', async () => {
     const renderer = createCanvasRenderer();
     await renderer(drawFrame1);
+    expect(image.dispose).toHaveBeenCalled();
+  });
+
+  it('disposes of the loaded image if draw predicate fails', async () => {
+    const renderer = createCanvasRenderer();
+    await renderer(drawFrame5);
     expect(image.dispose).toHaveBeenCalled();
   });
 });

--- a/packages/viewer/src/lib/rendering/canvas.ts
+++ b/packages/viewer/src/lib/rendering/canvas.ts
@@ -118,16 +118,18 @@ export function createCanvasRenderer(): CanvasRenderer {
     const frameNumber = data.frame.sequenceNumber;
     const frameIsNewer =
       lastFrameNumber == null || frameNumber > lastFrameNumber;
-    const image = await loadImageBytes(data.frame.image.imageBytes);
     const predicatePassing = data.predicate?.() ?? true;
 
     if (frameIsNewer && predicatePassing) {
+      const image = await loadImageBytes(data.frame.image.imageBytes);
+
       lastFrameNumber = frameNumber;
       data.beforeDraw?.();
       drawImage(image, data);
+
+      image.dispose();
     }
 
-    image.dispose();
     return data.frame;
   };
 }

--- a/packages/viewer/src/lib/rendering/canvas.ts
+++ b/packages/viewer/src/lib/rendering/canvas.ts
@@ -112,28 +112,51 @@ export function measureCanvasRenderer(
 }
 
 export function createCanvasRenderer(): CanvasRenderer {
-  let lastFrameNumber: number | undefined;
+  function loadFrame(): (data: DrawFrame) => Promise<HtmlImage | undefined> {
+    let lastLoadedFrameNumber = -1;
+
+    return async (data: DrawFrame): Promise<HtmlImage | undefined> => {
+      if (data.frame.sequenceNumber > lastLoadedFrameNumber) {
+        const image = await loadImageBytes(data.frame.image.imageBytes);
+
+        lastLoadedFrameNumber = data.frame.sequenceNumber;
+
+        return image;
+      }
+    };
+  }
+
+  function drawFrame(): (
+    data: DrawFrame,
+    image?: HtmlImage
+  ) => Promise<Frame | undefined> {
+    let lastDrawnFrameNumber = -1;
+
+    return async (
+      data: DrawFrame,
+      image?: HtmlImage
+    ): Promise<Frame | undefined> => {
+      if (image != null && data.frame.sequenceNumber > lastDrawnFrameNumber) {
+        lastDrawnFrameNumber = data.frame.sequenceNumber;
+
+        data.beforeDraw?.();
+        drawImage(image, data);
+
+        image.dispose();
+        return data.frame;
+      }
+      image?.dispose();
+    };
+  }
+
+  const load = loadFrame();
+  const draw = drawFrame();
 
   return async (data) => {
-    const frameNumber = data.frame.sequenceNumber;
-    const frameIsNewer =
-      lastFrameNumber == null || frameNumber > lastFrameNumber;
     const predicatePassing = data.predicate?.() ?? true;
 
-    if (frameIsNewer && predicatePassing) {
-      lastFrameNumber = frameNumber;
-      return loadImageBytes(data.frame.image.imageBytes).then((image) => {
-        if (
-          lastFrameNumber == null ||
-          data.frame.sequenceNumber >= lastFrameNumber
-        ) {
-          data.beforeDraw?.();
-          drawImage(image, data);
-          image.dispose();
-
-          return data.frame;
-        }
-      });
+    if (predicatePassing) {
+      return load(data).then((image) => draw(data, image));
     }
   };
 }

--- a/packages/viewer/src/testing/fixtures.ts
+++ b/packages/viewer/src/testing/fixtures.ts
@@ -75,10 +75,10 @@ export const drawFramePayloadOrthographic: DrawFramePayload = {
   },
 };
 
-export function makePerspectiveFrame(): Frame {
-  return Mapper.ifInvalidThrow(fromPbFrame(Orientation.DEFAULT))(
-    drawFramePayloadPerspective
-  );
+export function makePerspectiveFrame(
+  payload: DrawFramePayload = drawFramePayloadPerspective
+): Frame {
+  return Mapper.ifInvalidThrow(fromPbFrame(Orientation.DEFAULT))(payload);
 }
 
 export function makeOrthographicFrame(): Frame {


### PR DESCRIPTION
## Summary

This change adds a `drawPredicate` to the `canvasRenderer` in the viewer to determine whether frames should be drawn to the canvas after completing the `loadImageBytes` call. This corrects a race condition between smaller and larger frames that come in at close to identical times, such as when all parts are hidden in the viewer.

## Test Plan

- Load a (large-ish) model, and zoom in such that the image takes up the entire viewer (also, the larger the viewer window the more reproducible this bug is), then toggle visibility from the scene tree repeatedly
  - The image should always update with empty frames when the root node is hidden

## Release Notes

N/A

## Possible Regressions

Frame drawing behavior

## Dependencies

N/A
