### PR TITLE
[PLAT-1773] preventDefault when dragging transform widget

### DIFF
--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -294,6 +294,9 @@ export class ViewerTransformWidget {
   };
 
   private handleDrag = async (event: PointerEvent): Promise<void> => {
+    // Prevent selection of text and interaction with view cube while dragging the widget
+    event.preventDefault();
+
     const canvasBounds = this.getCanvasBounds();
 
     if (


### PR DESCRIPTION
## Summary
When dragging the transform widget outside of the viewer, the sidebar and header text became selected.  Further, if a Windows user dragged the transform widget, interacted with the view cube, and then attempted to drag the transform widget again, the widget continued to move after lifting the mouse button.

## Test Plan
Interact with the transform widget.  Verify that text is not selected when the widget is dragged outside of the viewer and the widget continues to work after interacting with the view cube.

## Release Notes
None

## Possible Regressions
Dragging the transform widget

## Dependencies
None