### PR TITLE
[PLAT-1792] Prevent additional updateDimensions requests

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -972,8 +972,9 @@ export class Viewer {
       this.calculateComponentDimensions();
       this.isResizing = false;
 
-      this.stream?.update({ dimensions: this.dimensions });
-      this.dimensionschange.emit(this.dimensions);
+      if (this.stream?.getState().type === 'connected') {
+        this.updateDimensions(this.dimensions);
+      }
     }
   }
 
@@ -1043,6 +1044,8 @@ export class Viewer {
     if (this.frame !== state.frame) {
       this.updateFrame(state.frame);
     }
+
+    this.updateDimensions(this.dimensions);
   }
 
   private handleConnectionFailed(
@@ -1064,6 +1067,11 @@ export class Viewer {
       this.errorMessage = undefined;
       this.emitConnectionChange({ status: 'disconnected' });
     }
+  }
+
+  private updateDimensions(dimensions?: Dimensions.Dimensions): void {
+    this.stream?.update({ dimensions });
+    this.dimensionschange.emit(dimensions);
   }
 
   private async updateFrame(frame: Frame): Promise<void> {

--- a/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
+++ b/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
@@ -444,37 +444,6 @@ describe(ViewerStream, () => {
       stream.update({ dimensions: Dimensions.create(100, 100) });
       expect(updateDimensions).toHaveBeenCalled();
     });
-
-    it('updates dimensions once the stream is connected', async () => {
-      const { stream, ws } = makeStream();
-
-      jest
-        .spyOn(stream, 'startStream')
-        .mockResolvedValue(Fixtures.Responses.startStream().response);
-      jest
-        .spyOn(stream, 'syncTime')
-        .mockResolvedValue(Fixtures.Responses.syncTime().response);
-
-      const updateDimensions = jest.spyOn(stream, 'updateDimensions');
-      const connecting = stream.stateChanged.onceWhen(
-        (s) => s.type === 'connecting' && s.resource.resource.id === '123'
-      );
-      stream.load(urn123, clientId, deviceId, config);
-      await simulateFrame(ws);
-      await connecting;
-
-      stream.update({ dimensions: Dimensions.create(100, 100) });
-      expect(updateDimensions).not.toHaveBeenCalled();
-
-      const connected = stream.stateChanged.onceWhen(
-        (s) => s.type === 'connected' && s.resource.resource.id === '123'
-      );
-
-      await connected;
-
-      await simulateFrame(ws);
-      expect(updateDimensions).toHaveBeenCalled();
-    });
   });
 
   function makeStream(): { stream: ViewerStream; ws: WebSocketClientMock } {

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -321,10 +321,6 @@ export class ViewerStream extends StreamApi {
 
         if (this.state.type === 'connected') {
           this.updateState({ ...this.state, frame });
-
-          if (!Dimensions.isEqual(this.dimensions, frame.dimensions)) {
-            this.updateDimensions({ dimensions: this.dimensions });
-          }
         }
       }
     });

--- a/packages/viewer/src/testing/viewer.ts
+++ b/packages/viewer/src/testing/viewer.ts
@@ -18,6 +18,7 @@ interface LoadViewerStreamKeyCtx {
 
 interface LoadViewerStreamKeyOptions {
   token?: string;
+  beforeConnected?: VoidFunction;
 }
 
 export const key1 = 'urn:vertexvis:stream-key:123';
@@ -36,7 +37,10 @@ export function makeViewerStream(): {
 export async function loadViewerStreamKey(
   urn: string,
   { viewer, stream, ws }: LoadViewerStreamKeyCtx,
-  { token = random.string({ alpha: true }) }: LoadViewerStreamKeyOptions = {}
+  {
+    token = random.string({ alpha: true }),
+    beforeConnected,
+  }: LoadViewerStreamKeyOptions = {}
 ): Promise<void> {
   jest.spyOn(stream, 'startStream').mockResolvedValue(
     StreamFixtures.Responses.startStream({
@@ -60,6 +64,7 @@ export async function loadViewerStreamKey(
   // Emit frame drawn on next event loop
   await connecting;
   await Async.delay(10);
+  beforeConnected?.();
   ws.receiveMessage(
     encode(
       StreamFixtures.Requests.drawFrame({


### PR DESCRIPTION
## Summary

Changes the behavior of the sync of dimensions of the `vertex-viewer` element and the underlying stream. Previously, after each frame request we would send an `updateDimensions` request if the stream dimensions did not match the frame dimensions to correct an issue where the dimensions were out of sync on initial load. When interacting, this would cause an `updateDimensions` to be sent after every frame, as the frame that came back would have a reduced size that did not match the viewer/stream's expected dimensions.

This change updates the resize handling to check whether the stream is actually in the `connected` state before attempting to update the stream dimensions, then in the `handleConnected` callback, we'll always send an update to the stream to verify that we have the same dimensions between the viewer element and stream.

## Test Plan

- Verify that `updateDimensions` requests are not made after every frame comes back when interacting
- Verify that `updateDimensions` requests are sent when resizing the viewer
- Verify that this still fixes the initial issue in https://vertexvis.atlassian.net/browse/PLAT-1724
- Verify that flickering does not occur when transforming parts using the widget (with the backing changes from https://github.com/Vertexvis/frame-streaming-service/pull/301)

## Release Notes

N/A

## Possible Regressions

Updating of dimensions when the stream is connected

## Dependencies

N/A
