### PR TITLE
[PLAT-2009] Fix initial pin-tool load behavior

### DIFF
--- a/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.spec.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.spec.tsx
@@ -234,4 +234,53 @@ describe('<vertex-viewer-dom-renderer>', () => {
       expect(el.getAttribute('occluded')).toBeNull();
     });
   });
+
+  describe('initialization', () => {
+    it('initializes the current camera when loaded with a populated viewer.frame', async () => {
+      const addEventListener = jest.fn();
+      /* eslint-disable prettier/prettier */
+      const matrix = [
+        0, 0.5, 0.5, 0,
+        0, 1, 0, 0,
+        0.5, 0.5, 0, 0,
+        0, 0, 0, 1
+      ];
+      /* eslint-enable prettier/prettier */
+
+      const camera = {
+        viewMatrix: matrix,
+        projectionMatrix: matrix,
+        far: 100,
+        near: 1,
+
+        isOrthographic: jest.fn().mockReturnValue(false),
+      };
+
+      const page = await newSpecPage({
+        components: [ViewerDomRenderer, ViewerDomElement],
+        template: () => (
+          <vertex-viewer-dom-renderer
+            viewer={
+              {
+                addEventListener,
+                frame: {
+                  scene: {
+                    camera,
+                  },
+                },
+              } as unknown as HTMLVertexViewerElement
+            }
+          ></vertex-viewer-dom-renderer>
+        ),
+      });
+
+      const el = page.root as HTMLVertexViewerDomRendererElement;
+
+      expect(addEventListener).toHaveBeenCalledWith(
+        'frameDrawn',
+        expect.any(Function)
+      );
+      expect(el.camera).toMatchObject(camera);
+    });
+  });
 });

--- a/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
@@ -83,6 +83,10 @@ export class ViewerDomRenderer {
     mutation.observe(this.hostEl, { childList: true });
 
     this.handleViewerChange(this.viewer, undefined);
+
+    if (this.viewer?.frame != null) {
+      this.handleViewerFrameDrawn();
+    }
   }
 
   /**

--- a/packages/viewer/src/components/viewer-pin-tool/viewer-pin-tool.spec.tsx
+++ b/packages/viewer/src/components/viewer-pin-tool/viewer-pin-tool.spec.tsx
@@ -64,4 +64,64 @@ describe('vertex-viewer-pin-tool', () => {
       </vertex-viewer-dom-renderer>
     `);
   });
+
+  it('should setup the projectionViewMatrix when loading with an initialized viewer', async () => {
+    const pin: TextPin = {
+      type: 'text',
+      id: 'my-pin-id',
+      worldPosition: Vector3.create(),
+      label: {
+        point: Point.create(0, 0),
+        text: 'My New Pin',
+      },
+    };
+    const addEventListener = jest.fn();
+    /* eslint-disable prettier/prettier */
+    const matrix = [
+      0, 0.5, 0.5, 0,
+      0, 1, 0, 0,
+      0.5, 0.5, 0, 0,
+      0, 0, 0, 1
+    ];
+    /* eslint-enable prettier/prettier */
+
+    const page = await newSpecPage({
+      components: [ViewerPinTool, ViewerPinGroup],
+      template: () => (
+        <vertex-viewer-pin-tool
+          id="vertex-viewer-pin-tool"
+          mode="edit"
+          tool="pin-text"
+          viewer={
+            {
+              ...viewer,
+              addEventListener,
+              frame: {
+                scene: {
+                  camera: {
+                    projectionViewMatrix: matrix,
+                  },
+                },
+              },
+            } as unknown as HTMLVertexViewerElement
+          }
+        ></vertex-viewer-pin-tool>
+      ),
+    });
+    const toolEl = page.root as HTMLVertexViewerPinToolElement;
+
+    toolEl.pinController?.addPin(pin);
+
+    await page.waitForChanges();
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      'frameDrawn',
+      expect.any(Function)
+    );
+
+    expect(
+      toolEl.shadowRoot?.querySelector('vertex-viewer-pin-group')
+        ?.projectionViewMatrix
+    ).toMatchObject(matrix);
+  });
 });

--- a/packages/viewer/src/components/viewer-pin-tool/viewer-pin-tool.tsx
+++ b/packages/viewer/src/components/viewer-pin-tool/viewer-pin-tool.tsx
@@ -152,6 +152,8 @@ export class ViewerPinTool {
     this.pinModel.onSelectionChange((selectedId) => {
       this.selectedPinId = selectedId;
     });
+
+    this.handleViewerChanged(this.viewer, undefined);
   }
 
   protected componentDidLoad(): void {


### PR DESCRIPTION
## Summary

Fixes an issue where the `projectionViewMatrix` of the `vertex-viewer-pin-tool` element and the `camera` of the underlying `vertex-viewer-dom-renderer` would not properly be populated when added as a child to a `vertex-viewer` element after an initial load. This would then result in text-pins being improperly positioned, and would cause them not to appear until the camera was rotated.

## Test Plan

- Programmatically add a `vertex-viewer-pin-tool` as a child of a `vertex-viewer` element after a button click in edit + text-pin mode
  - Verify that text pins appear when a click occurs, and that the leader line + anchor point visually appear in the correct location

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
