### PR TITLE
[PLAT-2093] onPinAdded listener

### DIFF
--- a/packages/viewer/src/lib/pins/__tests__/model.spec.ts
+++ b/packages/viewer/src/lib/pins/__tests__/model.spec.ts
@@ -1,0 +1,55 @@
+import { Point, Vector3 } from '@vertexvis/geometry';
+
+import { PinModel, TextPin } from '../model';
+
+describe('PinModel', () => {
+  describe(PinModel.prototype.setPin, () => {
+    it('adds pin to the supplied set', () => {
+      const model = new PinModel();
+      const onChange = jest.fn();
+      const onAdd = jest.fn();
+      model.onEntitiesChanged(onChange);
+      model.onPinAdded(onAdd);
+
+      const pin: TextPin = {
+        type: 'text',
+        id: 'my-pin-id',
+        worldPosition: Vector3.create(),
+        label: {
+          point: Point.create(),
+          text: 'My New Pin',
+        },
+      };
+
+      model.setPin(pin);
+      expect(model.getPins()).toEqual([pin]);
+      expect(onChange).toHaveBeenCalledWith([pin]);
+      expect(onAdd).toHaveBeenCalledWith([pin]);
+    });
+  });
+
+  describe(PinModel.prototype.addPin, () => {
+    it('adds pin to the supplied set', () => {
+      const model = new PinModel();
+      const onChange = jest.fn();
+      const onAdd = jest.fn();
+      model.onEntitiesChanged(onChange);
+      model.onPinAdded(onAdd);
+
+      const pin: TextPin = {
+        type: 'text',
+        id: 'my-pin-id',
+        worldPosition: Vector3.create(),
+        label: {
+          point: Point.create(),
+          text: 'My New Pin',
+        },
+      };
+
+      model.addPin(pin, false);
+      expect(model.getPins()).toEqual([pin]);
+      expect(onChange).toHaveBeenCalledWith([pin]);
+      expect(onAdd).toHaveBeenCalledWith([pin]);
+    });
+  });
+});

--- a/packages/viewer/src/lib/pins/model.ts
+++ b/packages/viewer/src/lib/pins/model.ts
@@ -82,6 +82,7 @@ export class PinModel {
   private selectedPinId?: string;
 
   private entitiesChanged = new EventDispatcher<Pin[]>();
+  private pinAdded = new EventDispatcher<Pin[]>();
   private selectionChanged = new EventDispatcher<string | undefined>();
 
   /**
@@ -99,6 +100,7 @@ export class PinModel {
 
       if (!surpressEvent) {
         this.entitiesChanged.emit(this.getPins());
+        this.pinAdded.emit(this.getPins());
       }
       return true;
     } else {
@@ -173,6 +175,7 @@ export class PinModel {
       [pin.id]: pin,
     };
     this.entitiesChanged.emit(this.getPins());
+    this.pinAdded.emit(this.getPins());
 
     return true;
   }
@@ -206,6 +209,16 @@ export class PinModel {
    */
   public onEntitiesChanged(listener: Listener<Pin[]>): Disposable {
     return this.entitiesChanged.on(listener);
+  }
+
+  /**
+   * Registers an event listener that will be invoked when a pin is added to the model.
+   *
+   * @param listener The listener to add.
+   * @returns A disposable that can be used to remove the listener.
+   */
+  public onPinAdded(listener: Listener<Pin[]>): Disposable {
+    return this.pinAdded.on(listener);
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR adds a listener to our pin model specifically for when a pin is added.  This allows us to accurately track the number of pins added in our analytics, as we were previously using the _onEntitiesChanged_ listener, which is called in several cases other than adding a pin, such as when saving a snapshot or loading an existing snapshot, and resulted in a higher number of 'pin added' events in mixpanel than actually occurred. 

## Test Plan
After the connect-app PR, verify that the number of 'pin added' events in mixpanel is equal to the number of pins you added

## Release Notes
None

## Possible Regressions
Adding pins and the analytics around them

## Dependencies
None