### PR TITLE
[PLAT-1814] Add filter for canary in version name

### DIFF
--- a/scripts/publish_canary.sh
+++ b/scripts/publish_canary.sh
@@ -11,7 +11,7 @@ dist_tag="canary"
 next_bump=`jq -r '.nextVersionBump' package.json`
 version=`jq -r '.version' lerna.json`
 next_version=`npx semver "$version" --increment "$next_bump"`
-published_canary_versions=`npm view @vertexvis/viewer --json versions | jq --arg version "$next_version-" -r '.[] | select(contains($version))'`
+published_canary_versions=`npm view @vertexvis/viewer --json versions | jq --arg version "$next_version-" -r '.[] | select(contains($version) and contains("canary"))'`
 
 if test -n "$published_canary_versions"
 then


### PR DESCRIPTION
## Summary

Adds a `and contains("canary")` condition to the `publish_canary` script. This resolves an issue where packages published under the `testing` tag could be picked up as the latest canary version due to appearing lower in the `npm view` list.

## Test Plan

- Verify this PR publishes a new canary version with the proper `.canary` text in the version name

## Release Notes

N/A

## Possible Regressions

Canary releases

## Dependencies

N/A
