### PR TITLE
[PLAT-2189] Apply partial SceneViewState

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.8.2"
+    "@vertexvis/frame-streaming-protos": "^0.8.4"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.8.2",
+    "@vertexvis/frame-streaming-protos": "^0.8.4",
     "@vertexvis/geometry": "0.15.1",
     "@vertexvis/html-templates": "0.15.1",
     "@vertexvis/scene-tree-protos": "^0.1.15",

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -1,6 +1,7 @@
+import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { Dimensions } from '@vertexvis/geometry';
 
-import { buildSceneOperation } from '../mapper';
+import { buildSceneOperation, toPbSceneViewStateFacets } from '../mapper';
 
 describe(buildSceneOperation, () => {
   it('maps a clear transform operation', () => {
@@ -22,5 +23,18 @@ describe(buildSceneOperation, () => {
         },
       ],
     });
+  });
+});
+
+describe(toPbSceneViewStateFeatures, () => {
+  it('maps to SceneViewStateFeature', () => {
+    expect(
+      toPbSceneViewStateFacets(['camera', 'material_override'])
+    ).toMatchObject([
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_CAMERA,
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_MATERIAL_OVERRIDE,
+    ]);
   });
 });

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -1,7 +1,7 @@
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { Dimensions } from '@vertexvis/geometry';
 
-import { buildSceneOperation, toPbSceneViewStateFacets } from '../mapper';
+import { buildSceneOperation, toPbSceneViewStateFeatures } from '../mapper';
 
 describe(buildSceneOperation, () => {
   it('maps a clear transform operation', () => {
@@ -29,12 +29,34 @@ describe(buildSceneOperation, () => {
 describe(toPbSceneViewStateFeatures, () => {
   it('maps to SceneViewStateFeature', () => {
     expect(
-      toPbSceneViewStateFacets(['camera', 'material_override'])
+      toPbSceneViewStateFeatures([
+        'Camera',
+        'Material Overrides',
+        'Selection',
+        'Visibility',
+        'Transforms',
+        'Cross Section',
+      ])
     ).toMatchObject([
       vertexvis.protobuf.stream.SceneViewStateFeature
         .SCENE_VIEW_STATE_FEATURE_CAMERA,
       vertexvis.protobuf.stream.SceneViewStateFeature
         .SCENE_VIEW_STATE_FEATURE_MATERIAL_OVERRIDE,
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_SELECTION,
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_VISIBILITY,
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_TRANSFORM,
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_CROSS_SECTION,
+    ]);
+  });
+
+  it('maps to invalid when unknown feature given', () => {
+    expect(toPbSceneViewStateFeatures(['Not a feature'])).toMatchObject([
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_INVALID,
     ]);
   });
 });

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -30,12 +30,12 @@ describe(toPbSceneViewStateFeatures, () => {
   it('maps to SceneViewStateFeature', () => {
     expect(
       toPbSceneViewStateFeatures([
-        'Camera',
-        'Material Overrides',
-        'Selection',
-        'Visibility',
-        'Transforms',
-        'Cross Section',
+        'camera',
+        'material_overrides',
+        'selection',
+        'visibility',
+        'transforms',
+        'cross_section',
       ])
     ).toMatchObject([
       vertexvis.protobuf.stream.SceneViewStateFeature

--- a/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
@@ -465,7 +465,7 @@ describe(Scene, () => {
   describe(Scene.prototype.applyPartialSceneViewState, () => {
     it('should applyPartialSceneViewState', async () => {
       const mockSceneViewStateId = new Uuid();
-      await scene.applyPartialSceneViewState(mockSceneViewStateId, ['Camera'], {
+      await scene.applyPartialSceneViewState(mockSceneViewStateId, ['camera'], {
         suppliedCorrelationId: 'foo',
       });
 

--- a/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
@@ -1,6 +1,8 @@
 jest.mock('@vertexvis/stream-api');
 
+import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { Dimensions, Point } from '@vertexvis/geometry';
+import { Uuid } from '@vertexvis/scene-tree-protos/core/protos/uuid_pb';
 import { StreamApi } from '@vertexvis/stream-api';
 
 import { random } from '../../../testing';
@@ -437,6 +439,44 @@ describe(Scene, () => {
         {
           frameCorrelationId: { value: 'foo' },
           includeCamera: true,
+        },
+        true
+      );
+    });
+  });
+
+  describe(Scene.prototype.applySceneViewState, () => {
+    it('should applySceneViewState', async () => {
+      const mockSceneViewStateId = new Uuid();
+      await scene.applySceneViewState(mockSceneViewStateId, {
+        suppliedCorrelationId: 'foo',
+      });
+
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        {
+          sceneViewStateId: { hex: mockSceneViewStateId },
+          frameCorrelationId: { value: 'foo' },
+        },
+        true
+      );
+    });
+  });
+
+  describe(Scene.prototype.applyPartialSceneViewState, () => {
+    it('should applyPartialSceneViewState', async () => {
+      const mockSceneViewStateId = new Uuid();
+      await scene.applyPartialSceneViewState(mockSceneViewStateId, ['Camera'], {
+        suppliedCorrelationId: 'foo',
+      });
+
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        {
+          sceneViewStateId: { hex: mockSceneViewStateId },
+          frameCorrelationId: { value: 'foo' },
+          sceneViewStateFeatureSubset: [
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_CAMERA,
+          ],
         },
         true
       );

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -6,6 +6,7 @@ import { UUID } from '@vertexvis/utils';
 import { Animation, FlyTo, FrameCamera } from '../types';
 import { ItemOperation } from './operations';
 import { QueryExpression } from './queries';
+import { SceneViewStateFeature } from './scene';
 
 export interface BuildSceneOperationContext {
   dimensions: Dimensions.Dimensions;
@@ -235,26 +236,26 @@ function buildOperationTypes(
 }
 
 export function toPbSceneViewStateFeatures(
-  features: string[]
+  features: SceneViewStateFeature[]
 ): vertexvis.protobuf.stream.SceneViewStateFeature[] {
   return features.map((feature) => {
     switch (feature) {
-      case 'Camera':
+      case 'camera':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_CAMERA;
-      case 'Material Overrides':
+      case 'material_overrides':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_MATERIAL_OVERRIDE;
-      case 'Selection':
+      case 'selection':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_SELECTION;
-      case 'Visibility':
+      case 'visibility':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_VISIBILITY;
-      case 'Transforms':
+      case 'transforms':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_TRANSFORM;
-      case 'Cross Section':
+      case 'cross_section':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_CROSS_SECTION;
       default:

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -233,3 +233,33 @@ function buildOperationTypes(
     }
   });
 }
+
+export function toPbSceneViewStateFeatures(
+  features: string[]
+): vertexvis.protobuf.stream.SceneViewStateFeature[] {
+  return features.map((feature) => {
+    switch (feature) {
+      case 'Camera':
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_CAMERA;
+      case 'Material Overrides':
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_MATERIAL_OVERRIDE;
+      case 'Selection':
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_SELECTION;
+      case 'Visibility':
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_VISIBILITY;
+      case 'Transforms':
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_TRANSFORM;
+      case 'Cross Section':
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_CROSS_SECTION;
+      default:
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_INVALID;
+    }
+  });
+}

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -224,6 +224,17 @@ export type TerminalItemOperationBuilder =
 export type ImageScaleProvider = () => Point.Point | undefined;
 
 /**
+ * The features of a scene view state that can be applied to the current scene
+ */
+export type SceneViewStateFeature =
+  | 'camera'
+  | 'cross_section'
+  | 'material_overrides'
+  | 'selection'
+  | 'transforms'
+  | 'visibility';
+
+/**
  * A class that represents the `Scene` that has been loaded into the viewer. On
  * it, you can retrieve attributes of the scene, such as the camera. It also
  * contains methods for updating the scene and performing requests to rerender
@@ -264,7 +275,7 @@ export class Scene {
    */
   public async applyPartialSceneViewState(
     sceneViewStateId: UUID.UUID,
-    featuresToApply: string[],
+    featuresToApply: SceneViewStateFeature[],
     opts: SceneExecutionOptions = {}
   ): Promise<vertexvis.protobuf.stream.ILoadSceneViewStateResult | undefined> {
     const pbFeatures = toPbSceneViewStateFeatures(featuresToApply);

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -9,7 +9,7 @@ import { Frame } from '../types/frame';
 import { Camera, OrthographicCamera, PerspectiveCamera } from '.';
 import { ColorMaterial, fromHex } from './colorMaterial';
 import { CrossSectioner } from './crossSectioner';
-import { buildSceneOperation } from './mapper';
+import { buildSceneOperation, toPbSceneViewStateFeatures } from './mapper';
 import {
   ItemOperation,
   SceneItemOperations,
@@ -254,6 +254,28 @@ export class Scene {
         frameCorrelationId: opts.suppliedCorrelationId
           ? { value: opts.suppliedCorrelationId }
           : undefined,
+      },
+      true
+    );
+  }
+
+  /**
+   * Applies the specified features of the provided scene view state to the scene.
+   */
+  public async applyPartialSceneViewState(
+    sceneViewStateId: UUID.UUID,
+    featuresToApply: string[],
+    opts: SceneExecutionOptions = {}
+  ): Promise<vertexvis.protobuf.stream.ILoadSceneViewStateResult | undefined> {
+    const pbFeatures = toPbSceneViewStateFeatures(featuresToApply);
+
+    return await this.stream.loadSceneViewState(
+      {
+        sceneViewStateId: { hex: sceneViewStateId },
+        frameCorrelationId: opts.suppliedCorrelationId
+          ? { value: opts.suppliedCorrelationId }
+          : undefined,
+        sceneViewStateFeatureSubset: pbFeatures,
       },
       true
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,10 +2138,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.8.2.tgz#a4c16d38a3b6147e2936f90712f351149efee8ef"
-  integrity sha512-+Y09iqa7Lsmpa2m3uD3CtZZMrTNjAmt1CEGDN1S2sId/MpqD/w3FT/ZNs1M8qh0nGe/DJQ89z/oQsc+CHeXO4Q==
+"@vertexvis/frame-streaming-protos@^0.8.4":
+  version "0.8.4"
+  resolved "https://registry.npmjs.org/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.8.4.tgz#37d9b90e4d931f78c7dba150e6b3eba13843431c"
+  integrity sha512-tQ60Al5bAGUYz476pUWeszdnCy4GC9dTNLpeQYsnyc0T0X+fwwcvJSzIVLUwGacgmpoD1ULvm1wATTvBik3ayw==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary
We want to support the ability to apply a subset of a SceneViewState's features to the current scene, instead of the full SceneViewState.

## Test Plan
Verify that a user can apply a partial SceneViewState

## Release Notes
None

## Possible Regressions
Viewing snapshots

## Dependencies
None