### PR TITLE
[PLAT-2161] Scene tree error improvements

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
+++ b/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
@@ -276,6 +276,7 @@ describe(SceneTreeController, () => {
           connection: expect.objectContaining({
             type: 'failure',
             details: new SceneTreeErrorDetails(
+              'SUBSCRIPTION_FAILURE',
               SceneTreeErrorCode.SUBSCRIPTION_FAILURE
             ),
           }),
@@ -315,6 +316,7 @@ describe(SceneTreeController, () => {
           connection: expect.objectContaining({
             type: 'failure',
             details: new SceneTreeErrorDetails(
+              'SUBSCRIPTION_FAILURE',
               SceneTreeErrorCode.SUBSCRIPTION_FAILURE
             ),
           }),

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -319,7 +319,7 @@ export class SceneTreeController {
         );
 
         try {
-          await this.connect(() => `${viewer.token}a`);
+          await this.connect(() => viewer.token);
         } catch (e) {
           this.ifErrorIsFatal(e, () => {
             console.error('Scene tree controller erred connecting.', e);

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -325,10 +325,6 @@ export class SceneTreeController {
             console.error('Scene tree controller erred connecting.', e);
           });
         }
-      } else {
-        throw new SceneTreeUnauthorizedError(
-          'Cannot connect scene tree to viewer, JWT is undefined.'
-        );
       }
     };
 

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -1125,8 +1125,7 @@ export class SceneTreeController {
   }
 
   private log(message?: string, ...optionalParams: unknown[]): void {
-    // if (this.debugLogs) {
-    if (true) {
+    if (this.debugLogs) {
       console.debug(message, optionalParams);
     }
   }

--- a/packages/viewer/src/components/scene-tree/lib/errors.ts
+++ b/packages/viewer/src/components/scene-tree/lib/errors.ts
@@ -1,15 +1,19 @@
+import { CustomError } from '../../../lib/errors';
+
 export enum SceneTreeErrorCode {
   UNKNOWN = 0,
   SCENE_TREE_DISABLED = 1,
   MISSING_VIEWER = 2,
   DISCONNECTED = 3,
   SUBSCRIPTION_FAILURE = 4,
+  UNAUTHORIZED = 5,
 }
 
 export class SceneTreeErrorDetails {
   public readonly message: string;
 
   public constructor(
+    public readonly name: keyof typeof SceneTreeErrorCode,
     public readonly code: SceneTreeErrorCode,
     public readonly link?: string
   ) {
@@ -29,5 +33,43 @@ function getSceneTreeErrorMessage(code: SceneTreeErrorCode): string {
       return 'Disconnected from server.';
     case SceneTreeErrorCode.SUBSCRIPTION_FAILURE:
       return 'The tree was not able to receive subscription events';
+    case SceneTreeErrorCode.UNAUTHORIZED:
+      return 'The tree was unauthorized to connect to the server. The associated Viewer may not be connected.';
+  }
+}
+
+export class SceneTreeError extends CustomError {
+  public constructor(message: string, e?: Error) {
+    super(message, e);
+
+    // Allows for `instanceof` checks.
+    Object.setPrototypeOf(this, SceneTreeError.prototype);
+  }
+}
+
+export class SceneTreeUnauthorizedError extends SceneTreeError {
+  public constructor(message: string, e?: Error) {
+    super(message, e);
+
+    // Allows for `instanceof` checks.
+    Object.setPrototypeOf(this, SceneTreeUnauthorizedError.prototype);
+  }
+}
+
+export class SceneTreeConnectionCancelledError extends SceneTreeError {
+  public constructor(message: string, e?: Error) {
+    super(message, e);
+
+    // Allows for `instanceof` checks.
+    Object.setPrototypeOf(this, SceneTreeConnectionCancelledError.prototype);
+  }
+}
+
+export class SceneTreeOperationFailedError extends SceneTreeError {
+  public constructor(message: string, e?: Error) {
+    super(message, e);
+
+    // Allows for `instanceof` checks.
+    Object.setPrototypeOf(this, SceneTreeOperationFailedError.prototype);
   }
 }

--- a/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
@@ -247,6 +247,29 @@ describe('<vertex-scene-tree>', () => {
       );
     });
 
+    it('cancels the controller when the component is disconnected', async () => {
+      const client = mockSceneTreeClient();
+      mockGetTree({ client });
+
+      const { stream, ws } = makeViewerStream();
+      const controller = new SceneTreeController(client, 100);
+      const { tree, viewer, page } = await newSceneTreeSpec({
+        controller,
+        stream,
+        viewerSelector: '#viewer',
+      });
+
+      await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
+
+      await page.waitForChanges();
+
+      const cancelSpy = jest.spyOn(controller, 'cancel');
+
+      tree.remove();
+
+      expect(cancelSpy).toHaveBeenCalled();
+    });
+
     it('initializes the default controller with a custom transport for subscriptions by default', async () => {
       await newSpecPage({
         components: [SceneTree],

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -606,6 +606,7 @@ export class SceneTree {
    */
   protected disconnectedCallback(): void {
     this.stateMap.viewerDisposable?.dispose();
+    this.controller?.cancel();
   }
 
   /**
@@ -652,6 +653,7 @@ export class SceneTree {
 
     if (this.viewer == null) {
       this.errorDetails = new SceneTreeErrorDetails(
+        'MISSING_VIEWER',
         SceneTreeErrorCode.MISSING_VIEWER
       );
     }
@@ -822,6 +824,7 @@ export class SceneTree {
       this.connectionError.emit(state.connection.details);
     } else if (state.connection.type === 'disconnected') {
       this.errorDetails = new SceneTreeErrorDetails(
+        'DISCONNECTED',
         SceneTreeErrorCode.DISCONNECTED
       );
     } else {


### PR DESCRIPTION
## Summary

Makes a few small adjustments to the error handling and errors emitted by the scene-tree component, specifically:
- "Cancelled" controller connections will no longer throw an error
  - This is the case when the component is disconnected very quickly after being initially connected
- Unauthenticated gRPC responses will now map to an `UNAUTHORIZED` error code, rather than `UNKNOWN`
- The name of the `SceneTreeErrorCode` enum value is now included with the error details

## Test Plan

- Verify that quickly unloading and loading the scene-tree does not throw errors
- Verify that errors include additional detail

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
