### PR TITLE
[PLAT-2273] Allow tap interactions without camera controls

### DIFF
--- a/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.css
+++ b/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.css
@@ -43,7 +43,9 @@
 }
 
 .outline {
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
@@ -59,10 +61,13 @@
 }
 
 .fill {
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   opacity: var(--viewer-box-query-outline-fill-opacity);
+  border-radius: var(--viewer-box-query-outline-border-radius);
 }
 
 :host([exclusive="true"]) .fill {

--- a/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.tsx
+++ b/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.tsx
@@ -200,9 +200,8 @@ export class ViewerBoxQueryTool {
               }}
             >
               <slot name="bounds">
-                <div class="outline">
-                  <div class="fill" />
-                </div>
+                <div class="outline"></div>
+                <div class="fill"></div>
               </slot>
             </div>
           )}

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -10,6 +10,7 @@ import { Dimensions } from '@vertexvis/geometry';
 import { Async, Color } from '@vertexvis/utils';
 
 import { MouseInteractionHandler } from '../../lib/interactions/mouseInteractionHandler';
+import { TapInteractionHandler } from '../../lib/interactions/tapInteractionHandler';
 import { TouchInteractionHandler } from '../../lib/interactions/touchInteractionHandler';
 import { loadImageBytes } from '../../lib/rendering/imageLoaders';
 import * as Storage from '../../lib/storage';
@@ -136,7 +137,8 @@ describe('vertex-viewer', () => {
       expect(handler.dispose).toHaveBeenCalled();
 
       const handlers = await viewer.getInteractionHandlers();
-      expect(handlers).toHaveLength(0);
+      expect(handlers).toHaveLength(1);
+      expect(handlers[0]).toBeInstanceOf(TapInteractionHandler);
     });
   });
 
@@ -504,7 +506,10 @@ describe('vertex-viewer', () => {
       viewer.cameraControls = false;
       await page.waitForChanges();
 
-      expect(await viewer.getInteractionHandlers()).toHaveLength(0);
+      expect(await viewer.getInteractionHandlers()).toHaveLength(1);
+      expect((await viewer.getInteractionHandlers())[0]).toBeInstanceOf(
+        TapInteractionHandler
+      );
 
       viewer.cameraControls = true;
       await page.waitForChanges();

--- a/packages/viewer/src/lib/interactions/__tests__/mouseInteractionHandler.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/mouseInteractionHandler.spec.ts
@@ -46,6 +46,12 @@ describe(MouseInteractionHandler, () => {
     buttons: 2,
     bubbles: true,
   });
+  const mouseMoveAuxiliaryButton = new MouseEvent('mousemove', {
+    screenX: 110,
+    screenY: 60,
+    buttons: 4,
+    bubbles: true,
+  });
   const mouseUp = new MouseEvent('mouseup', {
     screenX: 100,
     screenY: 50,
@@ -173,6 +179,23 @@ describe(MouseInteractionHandler, () => {
     expect(panInteraction.endDrag).toHaveBeenCalledTimes(1);
   });
 
+  it('begins a drag of rotate interaction if the secondary mouse has moved more than 2 pixels', async () => {
+    await simulateAuxiliaryInteractions(50);
+
+    expect(rotateInteraction.beginDrag).toHaveBeenCalledTimes(1);
+    expect(rotateInteraction.drag).toHaveBeenCalledTimes(1);
+    expect(rotateInteraction.endDrag).toHaveBeenCalledTimes(1);
+  });
+
+  it('begins a drag of rotate-point interaction if the secondary mouse has moved more than 2 pixels and it was last used', async () => {
+    handler.setPrimaryInteractionType('rotate-point');
+    await simulateAuxiliaryInteractions(50);
+
+    expect(rotatePointInteraction.beginDrag).toHaveBeenCalledTimes(1);
+    expect(rotatePointInteraction.drag).toHaveBeenCalledTimes(1);
+    expect(rotatePointInteraction.endDrag).toHaveBeenCalledTimes(1);
+  });
+
   it('removes window listeners on mouse up', async () => {
     await simulatePrimaryInteractions(50);
     window.dispatchEvent(mouseMovePrimaryButton);
@@ -266,6 +289,15 @@ describe(MouseInteractionHandler, () => {
   ): Promise<void> {
     div.dispatchEvent(mouseDown);
     window.dispatchEvent(mouseMoveSecondaryButton);
+    await delay(interactionDelay || 0);
+    window.dispatchEvent(mouseUp);
+  }
+
+  async function simulateAuxiliaryInteractions(
+    interactionDelay?: number
+  ): Promise<void> {
+    div.dispatchEvent(mouseDown);
+    window.dispatchEvent(mouseMoveAuxiliaryButton);
     await delay(interactionDelay || 0);
     window.dispatchEvent(mouseUp);
   }

--- a/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
@@ -36,6 +36,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   private primaryInteraction: MouseInteraction = this.rotateInteraction;
   private currentInteraction?: MouseInteraction;
   private draggingInteraction: MouseInteraction | undefined;
+  private lastPrimaryRotateInteraction?: MouseInteraction;
   private isDragging = false;
   private lastMoveEvent?: BaseEvent;
   private interactionTimer?: number;
@@ -130,9 +131,11 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     switch (type) {
       case 'rotate':
         this.primaryInteraction = this.rotateInteraction;
+        this.lastPrimaryRotateInteraction = this.rotateInteraction;
         break;
       case 'rotate-point':
         this.primaryInteraction = this.rotatePointInteraction;
+        this.lastPrimaryRotateInteraction = this.rotatePointInteraction;
         break;
       case 'zoom':
         this.primaryInteraction = this.zoomInteraction;
@@ -238,11 +241,14 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
       this.currentInteraction = this.rotateInteraction;
     }
 
-    if (event.buttons === 1 || event.buttons === 4) {
+    if (event.buttons === 1) {
       this.draggingInteraction =
         this.currentInteraction || this.primaryInteraction;
     } else if (event.buttons === 2) {
       this.draggingInteraction = this.panInteraction;
+    } else if (event.buttons === 4) {
+      this.draggingInteraction =
+        this.lastPrimaryRotateInteraction ?? this.rotateInteraction;
     }
 
     if (


### PR DESCRIPTION
## Summary

Makes a small change to always instantiate the `TapInteractionHandler`, regardless of the `cameraControls` flag, as this interaction handler only emits events rather than interacting with the camera. This allows for handling of `tap` events when performing a box-query.

Additionally, this PR makes a few small changes as polish for the removal of the box-selection feature flag:
- The rotate camera interaction is now mapped to the Middle or Auxiliary mouse button (`4`), and will use either `rotate-point` or `rotate` depending on the last one used as a primary interaction
- The styling of the box-query outline + fill has been adjusted slightly to show the fill behind the border of the `inclusive` query

## Test Plan

- Verify that `tap` events are emitted when clicking with the `<vertex-viewer-box-query-tool>`
- Verify that pressing the middle/auxiliary mouse button performs a rotate

## Release Notes

N/A

## Possible Regressions

Tap interactions, camera interactions

## Dependencies

N/A
