### PR TITLE
[PLAT-2334] FovY Support for Perspective Cameras

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.8.6"
+    "@vertexvis/frame-streaming-protos": "^0.8.7"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.8.6",
+    "@vertexvis/frame-streaming-protos": "^0.8.7",
     "@vertexvis/geometry": "0.15.1",
     "@vertexvis/html-templates": "0.15.1",
     "@vertexvis/scene-tree-protos": "^0.1.15",

--- a/packages/viewer/src/lib/mappers/frameStreaming.ts
+++ b/packages/viewer/src/lib/mappers/frameStreaming.ts
@@ -31,15 +31,17 @@ export const fromPbPerspectiveCamera: M.Func<
   M.read(
     M.mapProp('position', M.compose(M.required('position'), fromPbVector3f)),
     M.mapProp('lookAt', M.compose(M.required('lookAt'), fromPbVector3f)),
-    M.mapProp('up', M.compose(M.required('up'), fromPbVector3f))
+    M.mapProp('up', M.compose(M.required('up'), fromPbVector3f)),
+    M.getProp('fovY')
   ),
-  ([position, lookAt, up]) => ({
-    position,
-    lookAt,
-    up,
-    // TODO: map fovY property when available
-    fovY: 45,
-  })
+  ([position, lookAt, up, fovY]) => {
+    return {
+      position,
+      lookAt,
+      up,
+      fovY: fovY?.value != null ? fovY.value : 45,
+    };
+  }
 );
 
 export const fromPbOrthographicCamera: M.Func<
@@ -74,15 +76,17 @@ export const fromPbCamera: M.Func<
     M.mapProp('perspective', M.ifDefined(fromPbPerspectiveCamera)),
     M.mapProp('orthographic', M.ifDefined(fromPbOrthographicCamera))
   ),
-  ([position, lookAt, up, perspective, orthographic]) =>
-    perspective ??
-    orthographic ?? {
-      position: position ?? Vector3.back(),
-      lookAt: lookAt ?? Vector3.origin(),
-      up: up ?? Vector3.up(),
-      // TODO: map fovY property when available
-      fovY: 45,
-    }
+  ([position, lookAt, up, perspective, orthographic]) => {
+    return (
+      perspective ??
+      orthographic ?? {
+        position: position ?? Vector3.back(),
+        lookAt: lookAt ?? Vector3.origin(),
+        up: up ?? Vector3.up(),
+        fovY: 45,
+      }
+    );
+  }
 );
 
 export const fromPbSectionPlane: M.Func<

--- a/packages/viewer/src/lib/scenes/__tests__/camera.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/camera.spec.ts
@@ -89,6 +89,32 @@ describe(PerspectiveCamera, () => {
     }
   );
 
+  describe(PerspectiveCamera.prototype.update, () => {
+    const forward = FrameCamera.createPerspective({
+      position: { x: 0, y: 0, z: 5 },
+    });
+    const camera = new PerspectiveCamera(
+      stream,
+      0.5,
+      forward,
+      boundingBox,
+      jest.fn()
+    );
+
+    it('supports setting the fovY', () => {
+      const distance = camera.signedDistanceToBoundingBoxCenter(boundingBox);
+
+      expect(distance).toBeCloseTo(5);
+
+      const updated = camera.update({
+        ...camera,
+        fovY: 90.2,
+      }) as PerspectiveCamera;
+
+      expect(updated.fovY).toEqual(90.2);
+    });
+  });
+
   describe(PerspectiveCamera.prototype.rotateAroundAxis, () => {
     const camera = new PerspectiveCamera(
       stream,

--- a/packages/viewer/src/lib/scenes/camera.ts
+++ b/packages/viewer/src/lib/scenes/camera.ts
@@ -456,11 +456,12 @@ export class PerspectiveCamera
     return super.fitCameraToBoundingBox(boundingBox, distance, this.viewVector);
   }
 
-  public update(camera: Partial<FrameCamera.FrameCamera>): Camera {
+  public update(camera: Partial<FrameCamera.PerspectiveFrameCamera>): Camera {
+    const fovY = camera.fovY ?? this.fovY;
     return new PerspectiveCamera(
       this.stream,
       this.aspect,
-      { ...this.perspectiveData, ...camera },
+      { ...this.perspectiveData, ...camera, fovY },
       this.boundingBox,
       this.decodeFrame,
       this.flyToOptions

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -194,7 +194,7 @@ export class FrameCameraBase implements FrameCameraLike {
         near,
         far,
         aspectRatio,
-        45
+        camera.fovY ?? 45
       );
     }
   }
@@ -290,7 +290,7 @@ export class FramePerspectiveCamera
     public readonly near: number,
     public readonly far: number,
     public readonly aspectRatio: number,
-    public readonly fovY = 45
+    public readonly fovY: number
   ) {
     super(position, lookAt, up, near, far, aspectRatio);
   }

--- a/packages/viewer/src/lib/types/frameCamera.ts
+++ b/packages/viewer/src/lib/types/frameCamera.ts
@@ -136,6 +136,11 @@ export function toProtobuf(
         position: { ...camera.position },
         lookAt: { ...camera.lookAt },
         up: { ...camera.up },
+        fovY: camera.fovY
+          ? {
+              value: camera.fovY,
+            }
+          : null,
       },
       position: { ...camera.position },
       lookAt: { ...camera.lookAt },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,10 +2138,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.8.6":
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.8.6.tgz#b43f7e0c89f90c3bf8c222df20c2ea45d21d9106"
-  integrity sha512-15Tq5PLpN9pcJWCees26m/63RtLbXz9h0Wh0fBYO3BSmnbM3sscjim+EsO4hC87h/vw8RAHSnMZbqEiEp1MOFw==
+"@vertexvis/frame-streaming-protos@^0.8.7":
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.8.7.tgz#31b99ab821722d86359eba23c7ac1220ed00663d"
+  integrity sha512-u5ONSNbZ2UA2w9JJGSfbbtw6BcqBXC+l+Xo4K95BuRdeKfFWmPzJLex+j+pJfvKKr4PTp1ysREwgy5ZfAW4fqA==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
Introduces support for fovY on a perspective camera. The main plumbing was here for this, was just not mapped via protos. 

## Test Plan
<!-- How to test changes. -->

Verify that the fovY can be passed into perspective cameras. Valid ranges are float values between 1 & 179, which are enforced server-side

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
https://github.com/Vertexvis/frame-streaming-service/pull/308
