### PR TITLE
[PLAT-2131] Text pins improvements

### DIFF
--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
@@ -82,6 +82,10 @@ export class ViewerPinGroup {
     if (this.pinController == null) {
       this.pinController = new PinController(this.pinModel);
     }
+
+    if (this.selected) {
+      this.labelEl?.setFocus();
+    }
   }
 
   protected disconnectedCallback(): void {

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.spec.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.spec.tsx
@@ -232,7 +232,6 @@ describe('vertex-viewer-pin-label', () => {
     input.dispatchEvent(
       new KeyboardEvent('keydown', {
         key: 'Enter',
-        metaKey: true,
       })
     );
 

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -317,7 +317,10 @@ export class VertexPinLabel {
 
   private handleInputKeyDown = (event: KeyboardEvent): void => {
     event.stopPropagation();
-    if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+    if (
+      event.key === 'Enter' &&
+      (event.ctrlKey || event.metaKey || event.shiftKey)
+    ) {
       this.textareaRows += 1;
       this.value += '\n';
     } else if (event.key === 'Enter') {

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -115,11 +115,9 @@ export class VertexPinLabel {
   public async setFocus(): Promise<void> {
     // HTMLInputElement.focus() doesn't exist in tests.
     if (typeof this.inputEl?.focus === 'function') {
-      if (this.focused) {
-        this.inputEl?.focus();
-      } else {
-        this.inputEl?.blur();
-      }
+      this.focused = true;
+      this.labelFocused.emit(this.pin?.id);
+      this.inputEl?.focus();
     }
   }
 
@@ -318,11 +316,13 @@ export class VertexPinLabel {
   };
 
   private handleInputKeyDown = (event: KeyboardEvent): void => {
+    event.stopPropagation();
     if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+      this.textareaRows += 1;
+      this.value += '\n';
+    } else if (event.key === 'Enter') {
       event.preventDefault();
       this.submit();
-    } else if (event.key === 'Enter') {
-      this.textareaRows += 1;
     }
   };
 

--- a/packages/viewer/src/components/viewer-pin-tool/readme.md
+++ b/packages/viewer/src/components/viewer-pin-tool/readme.md
@@ -190,6 +190,14 @@ storage mechanism, then rehydrate them.
 | `viewer`        | --              | The viewer that this component is bound to. This is automatically assigned if added to the light-dom of a parent viewer element.                                                                                            | `HTMLVertexViewerElement \| undefined` | `undefined`      |
 
 
+## CSS Custom Properties
+
+| Name                                       | Description                                                                  |
+| ------------------------------------------ | ---------------------------------------------------------------------------- |
+| `--viewer-pin-tool-initial-label-offset-x` | The number of pixels to offset the label in the x direction. Defaults to 20. |
+| `--viewer-pin-tool-initial-label-offset-y` | The number of pixels to offset the label in the y direction. Defaults to 20. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/viewer/src/components/viewer-pin-tool/utils.ts
+++ b/packages/viewer/src/components/viewer-pin-tool/utils.ts
@@ -30,7 +30,9 @@ export function translatePointToScreen(
 export function translatePointToRelative(
   pt: Point.Point,
   canvasDimensions: Dimensions.Dimensions,
-  includeOffset?: boolean
+  includeOffset?: boolean,
+  xOffset?: number,
+  yOffset?: number
 ): Point.Point {
   const verticalScaleFactor = 1 / canvasDimensions.height;
   const horizontalScaleFactor = 1 / canvasDimensions.width;
@@ -44,7 +46,7 @@ export function translatePointToRelative(
 
   if (includeOffset) {
     const offset = Point.scale(
-      Point.create(20, 20),
+      Point.create(xOffset, yOffset),
       horizontalScaleFactor,
       verticalScaleFactor
     );
@@ -53,12 +55,19 @@ export function translatePointToRelative(
     // The given point corresponds to the upper left corner of the label, so increase the offset
     // when placing it to the left or above to ensure that part of the label line is visible
     const centerIsToTheRightInXDirection = canvasCenterPoint.x > pt.x;
-    const xOffset = centerIsToTheRightInXDirection ? offset.x : -3 * offset.x;
+    const xOffsetCalculated = centerIsToTheRightInXDirection
+      ? offset.x
+      : -3 * offset.x;
 
     const centerIsBelowInYDirection = canvasCenterPoint.y > pt.y;
-    const yOffset = centerIsBelowInYDirection ? offset.y : -3 * offset.y;
+    const yOffsetCalculated = centerIsBelowInYDirection
+      ? offset.y
+      : -3 * offset.y;
 
-    const offsetPoint = Point.add(point, Point.create(xOffset, yOffset));
+    const offsetPoint = Point.add(
+      point,
+      Point.create(xOffsetCalculated, yOffsetCalculated)
+    );
 
     return constrainRelativePoint(offsetPoint, Range.create(-0.5, 0.5));
   } else {

--- a/packages/viewer/src/components/viewer-pin-tool/utils.ts
+++ b/packages/viewer/src/components/viewer-pin-tool/utils.ts
@@ -29,13 +29,39 @@ export function translatePointToScreen(
  */
 export function translatePointToRelative(
   pt: Point.Point,
-  canvasDimensions: Dimensions.Dimensions
+  canvasDimensions: Dimensions.Dimensions,
+  includeOffset?: boolean
 ): Point.Point {
+  const verticalScaleFactor = 1 / canvasDimensions.height;
+  const horizontalScaleFactor = 1 / canvasDimensions.width;
+  const canvasCenterPoint = Dimensions.center(canvasDimensions);
+
   const point = Point.scale(
-    Point.subtract(pt, Dimensions.center(canvasDimensions)),
-    1 / canvasDimensions.width,
-    1 / canvasDimensions.height
+    Point.subtract(pt, canvasCenterPoint),
+    horizontalScaleFactor,
+    verticalScaleFactor
   );
 
-  return constrainRelativePoint(point, Range.create(-0.5, 0.5));
+  if (includeOffset) {
+    const offset = Point.scale(
+      Point.create(20, 20),
+      horizontalScaleFactor,
+      verticalScaleFactor
+    );
+
+    // We want to place the label towards the center of the screen.
+    // The given point corresponds to the upper left corner of the label, so increase the offset
+    // when placing it to the left or above to ensure that part of the label line is visible
+    const centerIsToTheRightInXDirection = canvasCenterPoint.x > pt.x;
+    const xOffset = centerIsToTheRightInXDirection ? offset.x : -3 * offset.x;
+
+    const centerIsBelowInYDirection = canvasCenterPoint.y > pt.y;
+    const yOffset = centerIsBelowInYDirection ? offset.y : -3 * offset.y;
+
+    const offsetPoint = Point.add(point, Point.create(xOffset, yOffset));
+
+    return constrainRelativePoint(offsetPoint, Range.create(-0.5, 0.5));
+  } else {
+    return constrainRelativePoint(point, Range.create(-0.5, 0.5));
+  }
 }

--- a/packages/viewer/src/components/viewer-pin-tool/viewer-pin-tool.css
+++ b/packages/viewer/src/components/viewer-pin-tool/viewer-pin-tool.css
@@ -6,4 +6,16 @@
   right: 0;
   overflow: hidden;
   pointer-events: none;
+
+  /**
+  * @prop --viewer-pin-tool-initial-label-offset-x: The number of pixels to offset
+  the label in the x direction. Defaults to 20.
+  */
+  --viewer-pin-tool-initial-label-offset-x: 20;
+
+  /**
+  * @prop --viewer-pin-tool-initial-label-offset-y: The number of pixels to offset
+  the label in the y direction. Defaults to 20.
+  */
+  --viewer-pin-tool-initial-label-offset-y: 20;
 }

--- a/packages/viewer/src/components/viewer-pin-tool/viewer-pin-tool.tsx
+++ b/packages/viewer/src/components/viewer-pin-tool/viewer-pin-tool.tsx
@@ -243,12 +243,24 @@ export class ViewerPinTool {
   }
 
   private setupInteractionHandler(): void {
+    const hostStyles = window.getComputedStyle(this.hostEl);
+    const xOffset = hostStyles
+      .getPropertyValue('--viewer-pin-tool-initial-label-offset-x')
+      .trim();
+    const yOffset = hostStyles
+      .getPropertyValue('--viewer-pin-tool-initial-label-offset-y')
+      .trim();
+
     this.clearInteractionHandler();
 
     if (this.pinController != null) {
       this.registeredInteractionHandler =
         this.viewer?.registerInteractionHandler(
-          new PinsInteractionHandler(this.pinController)
+          new PinsInteractionHandler(
+            this.pinController,
+            parseInt(xOffset),
+            parseInt(yOffset)
+          )
         );
     }
   }

--- a/packages/viewer/src/lib/pins/interactions.ts
+++ b/packages/viewer/src/lib/pins/interactions.ts
@@ -17,6 +17,9 @@ export class PinsInteractionHandler implements InteractionHandler {
 
   private cursor?: Disposable;
 
+  private xOffset?: number;
+  private yOffset?: number;
+
   private rectObserver = new ElementRectObserver();
 
   private droppableSurfaces: EntityType[] = [
@@ -29,8 +32,14 @@ export class PinsInteractionHandler implements InteractionHandler {
     return this.rectObserver.rect;
   }
 
-  public constructor(controller: PinController) {
+  public constructor(
+    controller: PinController,
+    xOffset: number,
+    yOffset: number
+  ) {
     this.controller = controller;
+    this.xOffset = xOffset;
+    this.yOffset = yOffset;
   }
 
   public initialize(element: HTMLElement, api: InteractionApi): void {
@@ -106,7 +115,9 @@ export class PinsInteractionHandler implements InteractionHandler {
               const relativePoint = translatePointToRelative(
                 pt,
                 this.elementRect,
-                isNewPin
+                isNewPin,
+                this.xOffset,
+                this.yOffset
               );
               this.controller.setPin({
                 type: 'text',

--- a/packages/viewer/src/lib/pins/interactions.ts
+++ b/packages/viewer/src/lib/pins/interactions.ts
@@ -72,7 +72,6 @@ export class PinsInteractionHandler implements InteractionHandler {
       const [hit] = await api.hitItems(pt);
 
       if (hit?.hitPoint != null && this.elementRect != null) {
-        const relativePoint = translatePointToRelative(pt, this.elementRect);
         if (
           hit?.hitPoint != null &&
           hit?.hitPoint.x != null &&
@@ -103,6 +102,12 @@ export class PinsInteractionHandler implements InteractionHandler {
               });
               break;
             case 'pin-text':
+              const isNewPin = existingPin == null;
+              const relativePoint = translatePointToRelative(
+                pt,
+                this.elementRect,
+                isNewPin
+              );
               this.controller.setPin({
                 type: 'text',
                 id: pinId,
@@ -117,6 +122,7 @@ export class PinsInteractionHandler implements InteractionHandler {
                 },
                 attributes,
               });
+              this.controller.setSelectedPinId(pinId);
               break;
           }
         }

--- a/packages/viewer/src/lib/pins/model.ts
+++ b/packages/viewer/src/lib/pins/model.ts
@@ -90,14 +90,14 @@ export class PinModel {
    * @param pin A pin entity to draw.
    * @returns `true` if the entity has been added.
    */
-  public addPin(pin: Pin, surpressEvent = false): boolean {
+  public addPin(pin: Pin, suppressEvent = false): boolean {
     if (this.entities[pin.id] == null) {
       this.entities = {
         ...this.entities,
         [pin.id]: pin,
       };
 
-      if (!surpressEvent) {
+      if (!suppressEvent) {
         this.entitiesChanged.emit(this.getPins());
       }
       return true;


### PR DESCRIPTION
## Summary
Improvements to text markup, specifically:
- Auto-focuses on new pins when the pin is created such that the user can start typing right away
- Includes a visible label line when the pin is created instead of the label touching the anchor. The label is always positioned towards the center of the screen relative to the anchor point and should be present on the screen.
- Prevents typing 'f' in the pin label from triggering a fit all
- Pressing "Enter" now submits the label text 
- Pressing either "Shift+Enter" or "Control/Command+Enter" now adds a new text line in the existing label

## Test Plan
Verify the items listed above

## Release Notes
None

## Possible Regressions
Text markup

## Dependencies
None