### PR TITLE
[PLAT-2222] Add warning when no keys are present, default to name - same as search

### DIFF
--- a/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.spec.tsx
@@ -63,6 +63,7 @@ import { decodeSceneTreeJwt } from './lib/jwt';
 import {
   deselectItem,
   hideItem,
+  selectFilterResults,
   selectItem,
   selectRangeInSceneTree,
   showItem,
@@ -550,6 +551,52 @@ describe('<vertex-scene-tree>', () => {
       const { tree } = await newConnectedSceneTreeSpec({ controller, token });
       const row = await tree.getRowAtClientY(30);
       expect(row?.node.name).toBe(res.toObject().itemsList[1].name);
+    });
+  });
+
+  describe(SceneTree.prototype.selectFilteredItems, () => {
+    it('defaults to the name for selection if no metadatakeys are defined', async () => {
+      const client = mockSceneTreeClient();
+      const controller = new SceneTreeController(client, 100);
+      mockGetTree({ client });
+      (getSceneTreeContainsElement as jest.Mock).mockReturnValue(true);
+
+      (selectFilterResults as jest.Mock).mockClear();
+
+      const { tree } = await newConnectedSceneTreeSpec({ controller, token });
+      await tree.selectFilteredItems('query');
+      expect(selectFilterResults).toHaveBeenCalledWith(
+        expect.anything(),
+        'query',
+        ['VERTEX_SCENE_ITEM_NAME'],
+        expect.anything(),
+        {
+          append: false,
+        }
+      );
+    });
+
+    it('uses the metadata search keys provided', async () => {
+      const client = mockSceneTreeClient();
+      const controller = new SceneTreeController(client, 100);
+      mockGetTree({ client });
+      (getSceneTreeContainsElement as jest.Mock).mockReturnValue(true);
+
+      const expectedKeys = ['key1', 'key2'];
+      (selectFilterResults as jest.Mock).mockClear();
+
+      const { tree } = await newConnectedSceneTreeSpec({ controller, token });
+      tree.metadataSearchKeys = expectedKeys;
+      await tree.selectFilteredItems('query');
+      expect(selectFilterResults).toHaveBeenCalledWith(
+        expect.anything(),
+        'query',
+        expectedKeys,
+        expect.anything(),
+        {
+          append: false,
+        }
+      );
     });
   });
 

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -577,7 +577,7 @@ export class SceneTree {
 
       if (definedMetadataKeys.length === 0) {
         console.warn(
-          "No metadata keys were found to perform the search. Defaulting to ['VERTEX_SCENE_ITEM_NAME']"
+          "No metadata keys were found to perform the selection. Defaulting to ['VERTEX_SCENE_ITEM_NAME']"
         );
       }
 

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -570,10 +570,21 @@ export class SceneTree {
     options?: SceneTreeOperationOptions
   ): Promise<void> {
     if (this.viewer != null) {
-      const columnsToSearch =
+      const definedMetadataKeys =
         this.metadataSearchKeys.length > 0
           ? this.metadataSearchKeys
           : this.metadataKeys;
+
+      if (definedMetadataKeys.length === 0) {
+        console.warn(
+          "No metadata keys were found to perform the search. Defaulting to ['VERTEX_SCENE_ITEM_NAME']"
+        );
+      }
+
+      const columnsToSearch =
+        definedMetadataKeys.length > 0
+          ? definedMetadataKeys
+          : ['VERTEX_SCENE_ITEM_NAME'];
 
       await selectFilterResults(
         this.viewer,


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
When no developer provided metadata keys are present, we log out a warning, and default the value to the name (Consistent with the search experience)

## Test Plan
<!-- How to test changes. -->

Initiate a viewer without metadata keys, apply a search filter, and try to do a selectFilteredItems. Previously this would fail, but with the [recent changes in metadata service](https://github.com/Vertexvis/metadata-service/pull/115), as well as this warning, the experience should be obvious.

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
https://github.com/Vertexvis/metadata-service/pull/115
