### PR TITLE
[PLAT-2474] Prevent highlighting text in label

### DIFF
--- a/packages/viewer/src/components/viewer-pin-label/readme.md
+++ b/packages/viewer/src/components/viewer-pin-label/readme.md
@@ -49,7 +49,7 @@ Type: `Promise<void>`
 | `--viewer-annotations-pin-label-focused-border-color` | A CSS color that specifies the color of the label's border when focused.              |
 | `--viewer-annotations-pin-label-max-height`           | A CSS length that specifies the maximum height of the label. Defaults to `50rem`.     |
 | `--viewer-annotations-pin-label-max-width`            | A CSS length that specifies the maximum width of the label. Defaults to `25rem`.      |
-| `--viewer-annotations-pin-label-min-width`            | A CSS length that specifies the minimum width of the label. Defaults to `1rem`.       |
+| `--viewer-annotations-pin-label-min-width`            | A CSS length that specifies the minimum width of the label. Defaults to `2rem`.       |
 | `--viewer-annotations-pin-label-padding-x`            | A var that specifies the horizontal padding of the label                              |
 | `--viewer-annotations-pin-label-padding-y`            | A var that specifies the vertical padding of the label                                |
 

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.css
@@ -55,7 +55,7 @@
 
   /**
    * @prop --viewer-annotations-pin-label-min-width: A CSS length that
-   * specifies the minimum width of the label. Defaults to `1rem`.
+   * specifies the minimum width of the label. Defaults to `2rem`.
    */
   --viewer-annotations-pin-label-min-width: 2rem;
 

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.spec.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.spec.tsx
@@ -307,7 +307,7 @@ describe('vertex-viewer-pin-label', () => {
       'min(var(--viewer-annotations-pin-label-max-width), calc(100px - 90px))'
     );
     expect(label.style.minWidth).toBe(
-      'min(16px, min(var(--viewer-annotations-pin-label-max-width), calc(100px - 90px)))'
+      'min(8px, min(var(--viewer-annotations-pin-label-max-width), calc(100px - 90px)))'
     );
   });
 

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -247,7 +247,7 @@ export class VertexPinLabel {
 
   private computeMinWidth(): string {
     if (this.contentElBounds != null) {
-      const expected = `${this.contentElBounds.width + 16}px`;
+      const expected = `${this.contentElBounds.width + 8}px`;
 
       return `min(${expected}, ${this.computeMaxWidth()})`;
     } else {
@@ -350,6 +350,9 @@ export class VertexPinLabel {
       this.relativePointerDownPosition &&
       this.pinPointerDownPosition != null
     ) {
+      // Prevent selection of any text while interacting with the label
+      event.preventDefault();
+
       const point = getMouseClientPosition(event, this.elementBounds);
       const relative = translatePointToRelative(point, this.elementBounds);
 

--- a/packages/viewer/src/lib/pins/interactions.ts
+++ b/packages/viewer/src/lib/pins/interactions.ts
@@ -155,13 +155,13 @@ export class PinsInteractionHandler implements InteractionHandler {
       this.controller.getToolMode() === 'edit' &&
       isDroppableSurface
     ) {
-      this.addCursor(this.getCusorType());
+      this.addCursor(this.getCursorType());
     } else {
       this.clearCursor();
     }
   };
 
-  private getCusorType(): Cursor {
+  private getCursorType(): Cursor {
     switch (this.controller.getToolType()) {
       case 'pin-icon':
         return pinCursor;


### PR DESCRIPTION
## Summary
When moving a text markup label around the screen, the text in other labels was being highlighted.  Further, it was requested that we reduced the extra space on the right side of the label.

## Test Plan
Verify that moving a text markup label no longer highlights the text in other labels

## Release Notes
None

## Possible Regressions
Text markup

## Dependencies
None