### PR TITLE
[PLAT-2258] Subscription Retries

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
+++ b/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
@@ -105,21 +105,6 @@ describe(SceneTreeController, () => {
     stream.invokeOnData(resp);
   };
 
-  const waitForConnection = async (
-    stream: ResponseStreamMock<unknown>,
-    controller: SceneTreeController
-  ): Promise<void> => {
-    initiateHandshakeOnStream(stream);
-    await new Promise((resolve) => {
-      controller.onStateChange.on((state: SceneTreeState) => {
-        const connected = state.connection.type === 'connected';
-        if (connected) {
-          resolve(connected);
-        }
-      });
-    });
-  };
-
   describe(SceneTreeController.prototype.connect, () => {
     it('emits connecting and connected state changes', async () => {
       const { controller, client, stream } = createController(10);

--- a/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
+++ b/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
@@ -324,7 +324,7 @@ describe(SceneTreeController, () => {
 
     it('emits subscription failure if no handshake is received within the timeout', async () => {
       const subscriptionHandshakeTimeout = 50;
-      const { controller, client, stream } = createController(
+      const { controller, client } = createController(
         10,
         subscriptionHandshakeTimeout
       );

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -221,7 +221,7 @@ export class SceneTreeController {
       connection.subscriptionStatusState.stream.cancel();
       this.clearHandshakeTimer();
 
-      const stream = await this.subscribe(jwtProvider, sceneViewId);
+      const stream = await this.subscribe();
 
       this.invalidatePage(0);
       this.updateState({
@@ -285,7 +285,7 @@ export class SceneTreeController {
 
       const [, stream] = await Promise.all([
         this.fetchPage(0),
-        this.subscribe(jwtProvider, sceneViewId),
+        this.subscribe(),
       ]);
 
       this.updateState({
@@ -797,10 +797,7 @@ export class SceneTreeController {
    * Performs a network request that will listen to server-side changes of the
    * scene tree's data.
    */
-  private subscribe(
-    jwtProvider: JwtProvider,
-    sceneViewId: string
-  ): Promise<ResponseStream<SubscribeResponse>> {
+  private subscribe(): Promise<ResponseStream<SubscribeResponse>> {
     return this.ifConnectionHasJwt((jwt) => {
       const stream = this.requestServerStream(jwt, (metadata) => {
         const sub = this.client.subscribe(new SubscribeRequest(), metadata);

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -77,11 +77,17 @@ export interface ConnectingState {
   sceneViewId: string;
 }
 
+export interface SubscriptionStatusState {
+  attempt: number;
+  stream: ResponseStream<SubscribeResponse>;
+}
+
 export interface ConnectedState {
   type: 'connected';
   jwtProvider: JwtProvider;
   sceneViewId: string;
   subscription: Disposable;
+  subscriptionStatusState?: SubscriptionStatusState;
 }
 
 export interface ConnectionFailedState {
@@ -133,6 +139,7 @@ type ConnectionState =
 export class SceneTreeController {
   private static IDLE_RECONNECT_IN_SECONDS = 4 * 60;
   private static LOST_CONNECTION_RECONNECT_IN_SECONDS = 2;
+  private static MAX_SUBSCRIPTION_RETRY_COUNT = 2;
 
   private nextPageId = 0;
   private pages = new Map<number, Page>();
@@ -196,6 +203,58 @@ export class SceneTreeController {
     this.debugLogs = debugLogs;
   }
 
+  private async handleSubscriptionHandshakeTimeout(
+    jwtProvider: JwtProvider,
+    sceneViewId: string
+  ): Promise<void> {
+    const connection = this.getState().connection;
+    if (
+      this.isConnectedState(connection) &&
+      connection.subscriptionStatusState?.attempt != null &&
+      connection.subscriptionStatusState.attempt <
+        SceneTreeController.MAX_SUBSCRIPTION_RETRY_COUNT
+    ) {
+      const newAttempt = connection.subscriptionStatusState.attempt + 1;
+      console.warn(
+        `Failed to subscribe within the allotted timeout. Retry attempt={${newAttempt}}`
+      );
+      connection.subscriptionStatusState.stream.cancel();
+      this.clearHandshakeTimer();
+
+      const stream = await this.subscribe(jwtProvider, sceneViewId);
+
+      this.invalidatePage(0);
+      this.updateState({
+        ...this.state,
+        connection: {
+          ...connection,
+          type: 'connected',
+          subscriptionStatusState: {
+            attempt: newAttempt,
+            stream,
+          },
+        },
+      });
+
+      this.subscriptionHandshakeTimer = window.setTimeout(() => {
+        this.handleSubscriptionHandshakeTimeout(jwtProvider, sceneViewId);
+      }, this.connectOptions.subscriptionHandshakeGracePeriodInMs);
+    } else {
+      this.updateState({
+        ...this.state,
+        connection: {
+          type: 'failure',
+          jwtProvider,
+          sceneViewId,
+          details: new SceneTreeErrorDetails(
+            'SUBSCRIPTION_FAILURE',
+            SceneTreeErrorCode.SUBSCRIPTION_FAILURE
+          ),
+        },
+      });
+    }
+  }
+
   public async connect(jwtProvider: JwtProvider): Promise<void> {
     const { connection } = this.state;
     const jwt = jwtProvider();
@@ -224,34 +283,28 @@ export class SceneTreeController {
     try {
       this.log('Scene tree controller connecting.');
 
-      await this.fetchPage(0);
-
-      this.subscriptionHandshakeTimer = window.setTimeout(() => {
-        this.updateState({
-          ...this.state,
-          connection: {
-            type: 'failure',
-            jwtProvider,
-            sceneViewId,
-            details: new SceneTreeErrorDetails(
-              'SUBSCRIPTION_FAILURE',
-              SceneTreeErrorCode.SUBSCRIPTION_FAILURE
-            ),
-          },
-        });
-      }, this.connectOptions.subscriptionHandshakeGracePeriodInMs);
-
-      const stream = await this.subscribe();
-      stream.on('end', () => this.startConnectionLostReconnectTimer());
+      const [, stream] = await Promise.all([
+        this.fetchPage(0),
+        this.subscribe(jwtProvider, sceneViewId),
+      ]);
 
       this.updateState({
         ...this.state,
         connection: {
-          ...connecting,
+          jwtProvider,
+          sceneViewId,
           type: 'connected',
           subscription: { dispose: () => stream.cancel() },
+          subscriptionStatusState: {
+            attempt: 0,
+            stream,
+          },
         },
       });
+
+      this.subscriptionHandshakeTimer = window.setTimeout(() => {
+        this.handleSubscriptionHandshakeTimeout(jwtProvider, sceneViewId);
+      }, this.connectOptions.subscriptionHandshakeGracePeriodInMs);
     } catch (e) {
       this.ifErrorIsFatal(e, () => {
         this.updateState({
@@ -744,7 +797,10 @@ export class SceneTreeController {
    * Performs a network request that will listen to server-side changes of the
    * scene tree's data.
    */
-  private subscribe(): Promise<ResponseStream<SubscribeResponse>> {
+  private subscribe(
+    jwtProvider: JwtProvider,
+    sceneViewId: string
+  ): Promise<ResponseStream<SubscribeResponse>> {
     return this.ifConnectionHasJwt((jwt) => {
       const stream = this.requestServerStream(jwt, (metadata) => {
         const sub = this.client.subscribe(new SubscribeRequest(), metadata);
@@ -837,6 +893,7 @@ export class SceneTreeController {
 
       stream.on('end', () => {
         this.invalidateAfterOffset(0);
+        this.startConnectionLostReconnectTimer();
       });
 
       return stream;
@@ -878,6 +935,7 @@ export class SceneTreeController {
       const res = await page.res;
 
       const currentPage = this.getPage(page.index);
+
       // Only handle the result if the page has not been invalidated.
       if (currentPage?.id === page.id) {
         const cursor = res.getCursor();
@@ -966,7 +1024,9 @@ export class SceneTreeController {
   }
 
   private updateState(newState: SceneTreeState): void {
-    if (this.loadingTimer && !this.isViewLoading(newState.rows)) {
+    const updateLoadingTimer =
+      this.loadingTimer && !this.isViewLoading(newState.rows);
+    if (updateLoadingTimer) {
       clearTimeout(this.loadingTimer);
       this.loadingTimer = undefined;
       this.state = {
@@ -1124,5 +1184,11 @@ export class SceneTreeController {
     if (this.debugLogs) {
       console.debug(message, optionalParams);
     }
+  }
+
+  private isConnectedState(
+    connection: ConnectionState
+  ): connection is ConnectedState {
+    return connection.type === 'connected';
   }
 }


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->

These changes introduce a retry on the subscription call when the handshake timeout fails within the allotted timeout. This is to improve resiliency for first time connections, and attempts so establish a handshake more consistently. 

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
