### PR TITLE
[PLAT-2244] Correct transform widget position initialization

### DIFF
--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
@@ -258,7 +258,7 @@ describe('vertex-viewer-transform-widget', () => {
     expect(onInteractionStarted).toHaveBeenCalled();
   });
 
-  it.only('performs a transform when initialized with a position', async () => {
+  it('performs a transform when initialized with a position', async () => {
     const { stream, ws } = makeViewerStream();
     const position = Vector3.create(1, 1, 1);
     const page = await newSpecPage({

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -110,7 +110,6 @@ export class ViewerTransformWidget {
     }
 
     this.handleViewerChanged(this.viewer, undefined);
-    this.handlePositionChanged(this.position, undefined);
 
     readDOM(() => {
       const hostStyles = window.getComputedStyle(this.hostEl);
@@ -180,8 +179,8 @@ export class ViewerTransformWidget {
 
     console.debug(
       `Updating widget position [previous=${JSON.stringify(
-        newPosition
-      )}, current=${JSON.stringify(oldPosition)}]`
+        oldPosition
+      )}, current=${JSON.stringify(newPosition)}]`
     );
     this.widget?.updateTransform(this.currentTransform);
 
@@ -450,6 +449,7 @@ export class ViewerTransformWidget {
 
     if (this.position != null) {
       this.currentTransform = Matrix4.makeTranslation(this.position);
+      this.startingTransform = this.currentTransform;
       this.widget.updateTransform(this.currentTransform);
     }
     if (this.viewer?.frame != null) {

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -110,6 +110,7 @@ export class ViewerTransformWidget {
     }
 
     this.handleViewerChanged(this.viewer, undefined);
+    this.handlePositionChanged(this.position, undefined);
 
     readDOM(() => {
       const hostStyles = window.getComputedStyle(this.hostEl);


### PR DESCRIPTION
## Summary

Corrects an issue where the `startingTransform` was not set when loading the transform widget with a starting position.

## Test Plan

- Verify the transform widget works as expected when initialized with a position

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
