### PR TITLE
[PLAT-2437] Add executeAborted event for box-query tool

### DIFF
--- a/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.spec.tsx
+++ b/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.spec.tsx
@@ -260,7 +260,9 @@ describe('vertex-viewer-box-query-tool', () => {
           expect.objectContaining({
             queryExpression: {
               operand: {
-                root: {},
+                override: {
+                  selection: {},
+                },
               },
             },
             operationTypes: expect.arrayContaining([

--- a/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.tsx
+++ b/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.tsx
@@ -252,7 +252,7 @@ export class ViewerBoxQueryTool {
   private setDefaultClearAndSelectOperation(): void {
     this.controller?.setOperationTransform((builder) => builder.select());
     this.controller?.setAdditionalTransforms([
-      (op) => op.where((q) => q.all()).deselect(),
+      (op) => op.where((q) => q.withSelected()).deselect(),
     ]);
   }
 

--- a/packages/viewer/src/lib/volume-intersection/__tests__/controller.spec.ts
+++ b/packages/viewer/src/lib/volume-intersection/__tests__/controller.spec.ts
@@ -124,10 +124,17 @@ describe('volume intersection controller', () => {
     );
 
     const handleExecuteAborted = jest.fn();
+    const handleExecuteComplete = jest.fn();
     controller.onExecuteAborted(handleExecuteAborted);
+    controller.onExecuteComplete(handleExecuteComplete);
 
     await drag(controller);
 
     expect(handleExecuteAborted).toHaveBeenCalledWith(requestError);
+    expect(handleExecuteComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aborted: true,
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds an `executeAborted` event dispatcher to the volume intersection controller in the case that we receive too many items that match the query. This can then be handled on the consumer-side rather than logging an error for the expected behavior.

## Test Plan

- Verify that there is no console.error log for queries that are aborted
- Verify the listener registered using the `onExecuteAborted` method is called with the error

## Release Notes

N/A

## Possible Regressions

Volume intersection query error handling

## Dependencies

N/A
