### PR TITLE
[PLAT-2576] Correct skipping of correlation IDs on skipped frames

### DIFF
--- a/packages/viewer/src/lib/rendering/__tests__/canvas.spec.ts
+++ b/packages/viewer/src/lib/rendering/__tests__/canvas.spec.ts
@@ -98,18 +98,6 @@ const drawFrame8: DrawFrame = {
   beforeDraw: jest.fn(),
 };
 
-const drawFrame9: DrawFrame = {
-  canvas,
-  canvasDimensions: Dimensions.create(100, 50),
-  frame: Fixtures.makePerspectiveFrame({
-    ...Fixtures.drawFramePayloadPerspective,
-    sequenceNumber: 3,
-    frameCorrelationIds: ['corr-id-3'],
-  }),
-  viewport: new Viewport(100, 50),
-  beforeDraw: jest.fn(),
-};
-
 describe(createCanvasRenderer, () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -219,14 +207,10 @@ describe(createCanvasRenderer, () => {
     const secondDraw = renderer(drawFrame8);
     const firstResult = await firstDraw;
     const secondResult = await secondDraw;
-    const thirdResult = await renderer(drawFrame9);
 
     expect(firstResult).toBeUndefined();
     expect(secondResult?.correlationIds).toMatchObject(
-      expect.arrayContaining(['corr-id-2'])
-    );
-    expect(thirdResult?.correlationIds).toMatchObject(
-      expect.arrayContaining(['corr-id-3', 'corr-id-1'])
+      expect.arrayContaining(['corr-id-2', 'corr-id-1'])
     );
   });
 

--- a/packages/viewer/src/lib/rendering/canvas.ts
+++ b/packages/viewer/src/lib/rendering/canvas.ts
@@ -112,27 +112,25 @@ export function measureCanvasRenderer(
 }
 
 export function createCanvasRenderer(): CanvasRenderer {
-  let skippedCorrelationIds: string[] = [];
+  let accumulatedCorrelationIds: string[] = [];
 
-  async function trackCorrelationIds(
-    data: DrawFrame,
+  async function addCorrelationIds(
     frame: Frame | undefined
   ): Promise<Frame | undefined> {
-    if (frame == null) {
-      skippedCorrelationIds = [
-        ...skippedCorrelationIds,
-        ...data.frame.correlationIds,
-      ];
-
-      return frame;
-    } else {
-      const frameWithCorrelationIds = frame.appendCorrelationIds(
-        skippedCorrelationIds
-      );
-      skippedCorrelationIds = [];
+    if (frame != null) {
+      const frameWithCorrelationIds = frame.copy({
+        correlationIds: [
+          ...frame.correlationIds,
+          ...accumulatedCorrelationIds.filter(
+            (id) => !frame.correlationIds.includes(id)
+          ),
+        ],
+      });
+      accumulatedCorrelationIds = [];
 
       return frameWithCorrelationIds;
     }
+    return frame;
   }
 
   function loadFrame(): (data: DrawFrame) => Promise<HtmlImage | undefined> {
@@ -178,15 +176,15 @@ export function createCanvasRenderer(): CanvasRenderer {
   return async (data) => {
     const predicatePassing = data.predicate?.() ?? true;
 
+    accumulatedCorrelationIds = [
+      ...accumulatedCorrelationIds,
+      ...data.frame.correlationIds,
+    ];
+
     if (predicatePassing) {
       return load(data).then((image) =>
-        draw(data, image).then((frame) => trackCorrelationIds(data, frame))
+        draw(data, image).then(addCorrelationIds)
       );
-    } else {
-      skippedCorrelationIds = [
-        ...skippedCorrelationIds,
-        ...data.frame.correlationIds,
-      ];
     }
   };
 }

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -61,6 +61,18 @@ export class Frame {
     const png = await decodePng(bytes);
     return FeatureMap.fromPng(png, this.image.imageAttr);
   }
+
+  public appendCorrelationIds(ids: string[]): Frame {
+    return new Frame(
+      [...this.correlationIds, ...ids],
+      this.sequenceNumber,
+      this.dimensions,
+      this.image,
+      this.scene,
+      this.depthBufferBytes,
+      this.featureMapBytes
+    );
+  }
 }
 
 export interface FrameImageLike {

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -62,15 +62,31 @@ export class Frame {
     return FeatureMap.fromPng(png, this.image.imageAttr);
   }
 
-  public appendCorrelationIds(ids: string[]): Frame {
+  public copy({
+    correlationIds,
+    sequenceNumber,
+    dimensions,
+    image,
+    scene,
+    depthBufferBytes,
+    featureMapBytes,
+  }: {
+    correlationIds?: string[];
+    sequenceNumber?: number;
+    dimensions?: Dimensions.Dimensions;
+    image?: FrameImage;
+    scene?: FrameScene;
+    depthBufferBytes?: Uint8Array;
+    featureMapBytes?: Uint8Array;
+  }): Frame {
     return new Frame(
-      [...this.correlationIds, ...ids],
-      this.sequenceNumber,
-      this.dimensions,
-      this.image,
-      this.scene,
-      this.depthBufferBytes,
-      this.featureMapBytes
+      correlationIds ?? this.correlationIds,
+      sequenceNumber ?? this.sequenceNumber,
+      dimensions ?? this.dimensions,
+      image ?? this.image,
+      scene ?? this.scene,
+      depthBufferBytes ?? this.depthBufferBytes,
+      featureMapBytes ?? this.featureMapBytes
     );
   }
 }


### PR DESCRIPTION
## Summary

Corrects a case where skipping the loading/drawing of a frame due to either passed predicate being false (specifically used for resizing behavior), or due to an attempt to draw a frame out of sequence. This approach will track the correlation IDs of frames coming through, and append any skipped values to the next successfully drawn frame.

## Test Plan

- Verify that correlation IDs sent come through on the `frameDrawn` event
  - My approach for reproducing this bug has been to add an alteration on `sceneReady` with a custom ID, then log out correlation IDs as I receive `frameDrawn` events, then resizing the browser while refreshing

## Release Notes

N/A

## Possible Regressions

Correlation IDs on the `frame` attribute + events

## Dependencies

N/A
