### PR TITLE
[PLAT-2825] Add Aborted status code mapping

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -949,8 +949,6 @@ export class SceneTreeController {
           currentPage.metadataKeys
         );
 
-        console.log(fetchedRows);
-
         const start = this.state.rows.slice(0, offset);
         const end = this.state.rows.slice(
           start.length + fetchedRows.length,

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -949,6 +949,8 @@ export class SceneTreeController {
           currentPage.metadataKeys
         );
 
+        console.log(fetchedRows);
+
         const start = this.state.rows.slice(0, offset);
         const end = this.state.rows.slice(
           start.length + fetchedRows.length,
@@ -1151,6 +1153,8 @@ export class SceneTreeController {
           'UNAUTHORIZED',
           SceneTreeErrorCode.UNAUTHORIZED
         );
+      } else if (e.code === grpc.Code.Aborted) {
+        return new SceneTreeErrorDetails('ABORTED', SceneTreeErrorCode.ABORTED);
       } else {
         return new SceneTreeErrorDetails('UNKNOWN', SceneTreeErrorCode.UNKNOWN);
       }

--- a/packages/viewer/src/components/scene-tree/lib/errors.ts
+++ b/packages/viewer/src/components/scene-tree/lib/errors.ts
@@ -7,6 +7,7 @@ export enum SceneTreeErrorCode {
   DISCONNECTED = 3,
   SUBSCRIPTION_FAILURE = 4,
   UNAUTHORIZED = 5,
+  ABORTED = 6,
 }
 
 export class SceneTreeErrorDetails {
@@ -28,13 +29,15 @@ function getSceneTreeErrorMessage(code: SceneTreeErrorCode): string {
     case SceneTreeErrorCode.SCENE_TREE_DISABLED:
       return 'The tree for this scene is not enabled. Enable the tree for this scene to interact with the tree.';
     case SceneTreeErrorCode.MISSING_VIEWER:
-      return 'Could not find reference to the viewer';
+      return 'Could not find reference to the viewer.';
     case SceneTreeErrorCode.DISCONNECTED:
       return 'Disconnected from server.';
     case SceneTreeErrorCode.SUBSCRIPTION_FAILURE:
-      return 'The tree was not able to receive subscription events';
+      return 'The tree was not able to receive subscription events.';
     case SceneTreeErrorCode.UNAUTHORIZED:
       return 'The tree was unauthorized to connect to the server. The associated Viewer may not be connected.';
+    case SceneTreeErrorCode.ABORTED:
+      return 'Unable to load the tree for this scene.';
   }
 }
 


### PR DESCRIPTION
## Summary

Adds error mapping for the `Aborted` status code to display a separate message from the `Unknown` status code catch all.

## Test Plan

- Verify that attempting to load a tree that has been blocked results in the `Aborted` request messaging

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
