### PR TITLE
[PLAT-2825] Update to minor version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "nextVersionBump": "patch",
+  "nextVersionBump": "minor",
   "devDependencies": {
     "eslint": "^8.17.0",
     "http-server": "^14.1.1",


### PR DESCRIPTION
## Summary

After #479 moved some of the types around, the `nextVersionBump` needs to be moved to `minor` to reflect that the typings have moved.

## Test Plan

- Verify the canary release is for the next minor version (0.17.0)

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
