### PR TITLE
[PLAT-2862] Using a unique ID for comparing frames, since the copy may contain additional correlation IDs

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1015,8 +1015,6 @@ export class Viewer {
       this.handleConnectionFailed(previous, state);
     } else if (state.type === 'disconnected') {
       this.handleDisconnected(previous, state);
-    } else if (state.type === 'reconnecting') {
-      this.frame = undefined;
     }
   }
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1047,7 +1047,7 @@ export class Viewer {
       this.deviceIdChange.emit(state.deviceId);
     }
 
-    if (this.frame?.sequenceNumber !== state.frame.sequenceNumber) {
+    if (this.frame?.getId() !== state.frame.getId()) {
       this.updateFrame(state.frame);
     }
 
@@ -1086,7 +1086,7 @@ export class Viewer {
     if (
       this.canvasElement != null &&
       canvasDimensions != null &&
-      this.frame?.sequenceNumber !== frame.sequenceNumber
+      this.frame?.getId() !== frame.getId()
     ) {
       const canvas = this.canvasElement.getContext('2d');
       if (canvas != null) {

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1015,6 +1015,8 @@ export class Viewer {
       this.handleConnectionFailed(previous, state);
     } else if (state.type === 'disconnected') {
       this.handleDisconnected(previous, state);
+    } else if (state.type === 'reconnecting') {
+      this.frame = undefined;
     }
   }
 
@@ -1047,7 +1049,7 @@ export class Viewer {
       this.deviceIdChange.emit(state.deviceId);
     }
 
-    if (this.frame !== state.frame) {
+    if (this.frame?.sequenceNumber !== state.frame.sequenceNumber) {
       this.updateFrame(state.frame);
     }
 
@@ -1086,7 +1088,7 @@ export class Viewer {
     if (
       this.canvasElement != null &&
       canvasDimensions != null &&
-      this.frame !== frame
+      this.frame?.sequenceNumber !== frame.sequenceNumber
     ) {
       const canvas = this.canvasElement.getContext('2d');
       if (canvas != null) {

--- a/packages/viewer/src/lib/types/__tests__/frame.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/frame.spec.ts
@@ -1,7 +1,15 @@
 import { BoundingBox, Line3, Matrix4, Vector3 } from '@vertexvis/geometry';
+import { Dimensions } from '@vertexvis/geometry';
 
+import { makeImageAttributes } from '../../../testing/fixtures';
 import { FrameCamera } from '..';
-import { FrameOrthographicCamera, FramePerspectiveCamera } from '../frame';
+import {
+  Frame,
+  FrameImage,
+  FrameOrthographicCamera,
+  FramePerspectiveCamera,
+  FrameScene,
+} from '../frame';
 
 describe(FramePerspectiveCamera, () => {
   const camera = new FramePerspectiveCamera(
@@ -136,5 +144,21 @@ describe(FrameOrthographicCamera, () => {
         )
       );
     });
+  });
+});
+
+describe(Frame, () => {
+  it('should include the ID on a copy', () => {
+    const frame = new Frame(
+      [],
+      2,
+      {} as Dimensions,
+      new FrameImage(makeImageAttributes(1, 2), new Uint8Array()),
+      {} as FrameScene,
+      undefined,
+      undefined
+    );
+
+    expect(frame.getId()).toEqual(frame.copy({}).getId());
   });
 });

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -32,9 +32,7 @@ export class Frame {
     private readonly depthBufferBytes: Uint8Array | undefined,
     private readonly featureMapBytes: Uint8Array | undefined,
     private readonly id = UUID.create()
-  ) {
-    this.id = UUID.create();
-  }
+  ) {}
 
   public getId(): UUID.UUID {
     return this.id;

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -8,6 +8,7 @@ import {
   Rectangle,
   Vector3,
 } from '@vertexvis/geometry';
+import { UUID } from '@vertexvis/utils';
 
 import { decodePng } from '../../workers/png-decoder-pool';
 import { constrainViewVector } from '../rendering/vectors';
@@ -29,8 +30,15 @@ export class Frame {
     public readonly image: FrameImage,
     public readonly scene: FrameScene,
     private readonly depthBufferBytes: Uint8Array | undefined,
-    private readonly featureMapBytes: Uint8Array | undefined
-  ) {}
+    private readonly featureMapBytes: Uint8Array | undefined,
+    private readonly id = UUID.create()
+  ) {
+    this.id = UUID.create();
+  }
+
+  public getId(): UUID.UUID {
+    return this.id;
+  }
 
   public async depthBuffer(): Promise<DepthBuffer | undefined> {
     if (this.cachedDepthBuffer == null) {
@@ -86,7 +94,8 @@ export class Frame {
       image ?? this.image,
       scene ?? this.scene,
       depthBufferBytes ?? this.depthBufferBytes,
-      featureMapBytes ?? this.featureMapBytes
+      featureMapBytes ?? this.featureMapBytes,
+      this.id
     );
   }
 }


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes add a unique identifier on a frame. We then check the ID of the frame instead of doing an object compare on these frames. This solves the problem of not updating the frame on a reconnect when the frames are in fact equal, but have mismatching correlation IDs which resulted in unnecessarily discarding of frames. 

## Test Plan
<!-- How to test changes. -->
- Open a scene in the viewer
- Interact with it for a while to increase the sequence count on a frame (Rotate for 10-15 seconds)
- Let the viewer sit for a minute or so until you identify that a websocket reconnection has occurred (This can be observed in the network tab when you see a new connection to the web socket)
- Verify the scene you have open is immediately able to be interacted with, and is not stale.


## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
