### PR TITLE
[PLAT-2556] Support generation of source maps for viewer

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -79,7 +79,6 @@
     "@types/jest": "^27.5.1",
     "@types/jsonwebtoken": "^8.5.8",
     "@vertexvis/eslint-config-vertexvis-typescript": "^0.5.0",
-    "@vertexvis/rollup-plugin-vertexvis-copyright": "^0.4.1",
     "@vertexvis/rollup-plugin-web-workers": "^0.1.0",
     "@vertexvis/typescript-config-vertexvis": "1.1.0",
     "@vertexwebsdk/build": "0.17.0",

--- a/packages/viewer/stencil.config.ts
+++ b/packages/viewer/stencil.config.ts
@@ -1,6 +1,5 @@
 import { Config } from '@stencil/core';
 import { reactOutputTarget } from '@stencil/react-output-target';
-import { copyright } from '@vertexvis/rollup-plugin-vertexvis-copyright';
 import workers from '@vertexvis/rollup-plugin-web-workers';
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
@@ -11,11 +10,10 @@ import jestConfig from './jest-shared.config';
 
 export const config: Config = {
   namespace: 'viewer',
-  nodeResolve: {
-    browser: true,
-  },
+  sourceMap: true,
+  nodeResolve: { browser: true },
+  preamble: copyright(),
   plugins: [
-    copyright(),
     workers({
       plugins: [
         commonjs(),
@@ -54,3 +52,8 @@ export const config: Config = {
     shadowDomShim: true,
   },
 };
+
+function copyright(): string {
+  const year = new Date(Date.now()).getFullYear();
+  return `Copyright (c) ${year} Vertex Software LLC. All rights reserved.`;
+}

--- a/packages/viewer/tsconfig.json
+++ b/packages/viewer/tsconfig.json
@@ -3,13 +3,16 @@
   "extends": "@vertexwebsdk/build/tsconfig-web",
   "compilerOptions": {
     "inlineSources": false,
-    "sourceMap": false,
-    "inlineSourceMap": true,
     "experimentalDecorators": true,
     "jsx": "react",
     "jsxFactory": "h",
     "target": "es2017"
   },
-  "include": ["src", "types/*.d.ts", "src/components.d.ts", "src/regl-shape.d.ts"],
+  "include": [
+    "src",
+    "types/*.d.ts",
+    "src/components.d.ts",
+    "src/regl-shape.d.ts"
+  ],
   "exclude": ["dist", "node_modules"]
 }

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -20,6 +20,8 @@ install_mo() {
     chmod +x mo
     mv mo ./.lib/mo
   fi
+
+  cat ./.lib/mo
 }
 
 install_mo

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,7 +2150,7 @@
   dependencies:
     "@vertexvis/typescript-config-vertexvis" "1.1.0"
 
-"@vertexvis/rollup-plugin-vertexvis-copyright@0.4.1", "@vertexvis/rollup-plugin-vertexvis-copyright@^0.4.1":
+"@vertexvis/rollup-plugin-vertexvis-copyright@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@vertexvis/rollup-plugin-vertexvis-copyright/-/rollup-plugin-vertexvis-copyright-0.4.1.tgz#31805332f33f90a9c2e63241ed2d1829bb333628"
   integrity sha512-/I+8bhex494KJqS/aD+fqltBwlDzHay0Y85E9Onn5mrs/4utiTfHaHxy3ybpEFvG5dCIWWOcjWL8OdEW/BBrLQ==


### PR DESCRIPTION
## Summary

Adds support for generation of source maps for the @vertexvis/viewer package. This allows consumers to generate their bundles with source maps.

https://vertexvis.atlassian.net/browse/PLAT-2556