### PR TITLE
[PLAT-2787] Fix WebGL warnings

### DIFF
--- a/packages/viewer/src/components/viewer-hit-result-indicator/lib/__tests__/indicator.spec.ts
+++ b/packages/viewer/src/components/viewer-hit-result-indicator/lib/__tests__/indicator.spec.ts
@@ -8,10 +8,8 @@ import shapeBuilder from 'regl-shape';
 
 import { axisPositions } from '../../../../lib/transforms/axis-lines';
 import { computeArrowNdcValues } from '../../../../lib/transforms/axis-translation';
-import { DrawablePoints } from '../../../../lib/transforms/drawable';
 import { AxisLine } from '../../../../lib/transforms/line';
 import { Mesh, TriangleMesh } from '../../../../lib/transforms/mesh';
-import { flattenPointArray } from '../../../../lib/transforms/util';
 import {
   Frame,
   FrameCameraBase,
@@ -28,6 +26,7 @@ import {
   makeOrthographicFrame,
   makePerspectiveFrame,
 } from '../../../../testing/fixtures';
+import { createdPaddedFloat64Array } from '../../../../testing/webgl';
 import {
   DEFAULT_PLANE_SIZE_SCALAR,
   DEFAULT_POINT_SIZE_SCALAR,
@@ -137,13 +136,6 @@ function updateFrameCameraPosition(
     makeDepthImagePng(100, 50),
     makeFeatureMapBytes(100, 50, (pt) => Color.create(0, 0, 0))
   );
-}
-
-function createdPaddedFloat64Array(points: DrawablePoints): Float64Array {
-  return new Float64Array([
-    ...flattenPointArray(points.toArray()),
-    ...new Array(4).fill(0),
-  ]);
 }
 
 describe(HitIndicator, () => {

--- a/packages/viewer/src/components/viewer-hit-result-indicator/lib/__tests__/indicator.spec.ts
+++ b/packages/viewer/src/components/viewer-hit-result-indicator/lib/__tests__/indicator.spec.ts
@@ -34,6 +34,7 @@ import {
 } from '../indicator';
 import { computePlaneNdcValues } from '../plane';
 import { computePointNdcValues } from '../point';
+import { DrawablePoints } from '../../../../lib/transforms/drawable';
 
 type MockShapeBuilder = jest.Mock<{ createShape: jest.Mock }>;
 
@@ -138,6 +139,12 @@ function updateFrameCameraPosition(
   );
 }
 
+
+function createdPaddedFloat64Array(points: DrawablePoints): Float64Array {
+  return new Float64Array([...flattenPointArray(points.toArray()), ...new Array(4).fill(0)]);
+}
+
+
 describe(HitIndicator, () => {
   const canvas = document.createElement('canvas');
 
@@ -197,19 +204,19 @@ describe(HitIndicator, () => {
     indicator.updateTransformAndNormal(hithitPositionTransform, hitNormal);
 
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.arrow.points.toArray())),
+      createdPaddedFloat64Array(meshes.arrow.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.axis.points.toArray())),
+      createdPaddedFloat64Array(meshes.axis.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.plane.points.toArray())),
+      createdPaddedFloat64Array(meshes.plane.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.point.points.toArray())),
+      createdPaddedFloat64Array(meshes.point.points),
       expect.anything()
     );
   });
@@ -234,19 +241,19 @@ describe(HitIndicator, () => {
     indicator.updateTransformAndNormal(hithitPositionTransform, hitNormal);
 
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.arrow.points.toArray())),
+      createdPaddedFloat64Array(meshes.arrow.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.axis.points.toArray())),
+      createdPaddedFloat64Array(meshes.axis.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.plane.points.toArray())),
+      createdPaddedFloat64Array(meshes.plane.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.point.points.toArray())),
+      createdPaddedFloat64Array(meshes.point.points),
       expect.anything()
     );
   });

--- a/packages/viewer/src/components/viewer-hit-result-indicator/lib/__tests__/indicator.spec.ts
+++ b/packages/viewer/src/components/viewer-hit-result-indicator/lib/__tests__/indicator.spec.ts
@@ -8,6 +8,7 @@ import shapeBuilder from 'regl-shape';
 
 import { axisPositions } from '../../../../lib/transforms/axis-lines';
 import { computeArrowNdcValues } from '../../../../lib/transforms/axis-translation';
+import { DrawablePoints } from '../../../../lib/transforms/drawable';
 import { AxisLine } from '../../../../lib/transforms/line';
 import { Mesh, TriangleMesh } from '../../../../lib/transforms/mesh';
 import { flattenPointArray } from '../../../../lib/transforms/util';
@@ -34,7 +35,6 @@ import {
 } from '../indicator';
 import { computePlaneNdcValues } from '../plane';
 import { computePointNdcValues } from '../point';
-import { DrawablePoints } from '../../../../lib/transforms/drawable';
 
 type MockShapeBuilder = jest.Mock<{ createShape: jest.Mock }>;
 
@@ -139,11 +139,12 @@ function updateFrameCameraPosition(
   );
 }
 
-
 function createdPaddedFloat64Array(points: DrawablePoints): Float64Array {
-  return new Float64Array([...flattenPointArray(points.toArray()), ...new Array(4).fill(0)]);
+  return new Float64Array([
+    ...flattenPointArray(points.toArray()),
+    ...new Array(4).fill(0),
+  ]);
 }
-
 
 describe(HitIndicator, () => {
   const canvas = document.createElement('canvas');

--- a/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
@@ -36,6 +36,7 @@ import {
   makePerspectiveFrame,
 } from '../../../testing/fixtures';
 import { TransformWidget } from '../widget';
+import { DrawablePoints } from '../../../lib/transforms/drawable';
 
 type MockShapeBuilder = jest.Mock<{ createShape: jest.Mock }>;
 
@@ -143,6 +144,10 @@ function updateFrameCameraPosition(
   );
 }
 
+function createdPaddedFloat64Array(points: DrawablePoints): Float64Array {
+  return new Float64Array([...flattenPointArray(points.toArray()), ...new Array(4).fill(0)]);
+}
+
 describe(TransformWidget, () => {
   const canvas = document.createElement('canvas');
 
@@ -177,27 +182,27 @@ describe(TransformWidget, () => {
     widget.updateTransform(positionTransform);
 
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.xArrow.points.toArray())),
+      createdPaddedFloat64Array(meshes.xArrow.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.yArrow.points.toArray())),
+      createdPaddedFloat64Array(meshes.yArrow.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.zArrow.points.toArray())),
+      createdPaddedFloat64Array(meshes.zArrow.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.xAxis.points.toArray())),
+      createdPaddedFloat64Array(meshes.xAxis.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.yAxis.points.toArray())),
+      createdPaddedFloat64Array(meshes.yAxis.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.zAxis.points.toArray())),
+      createdPaddedFloat64Array(meshes.zAxis.points),
       expect.anything()
     );
   });
@@ -218,27 +223,27 @@ describe(TransformWidget, () => {
     widget.updateTransform(positionTransform);
 
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.xArrow.points.toArray())),
+      createdPaddedFloat64Array(meshes.xArrow.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.yArrow.points.toArray())),
+      createdPaddedFloat64Array(meshes.yArrow.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.zArrow.points.toArray())),
+      createdPaddedFloat64Array(meshes.zArrow.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.xAxis.points.toArray())),
+      createdPaddedFloat64Array(meshes.xAxis.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.yAxis.points.toArray())),
+      createdPaddedFloat64Array(meshes.yAxis.points),
       expect.anything()
     );
     expect(mockShapeBuilder().createShape).toHaveBeenCalledWith(
-      new Float64Array(flattenPointArray(meshes.zAxis.points.toArray())),
+      createdPaddedFloat64Array(meshes.zAxis.points),
       expect.anything()
     );
   });

--- a/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
@@ -15,6 +15,7 @@ import {
   yAxisArrowPositions,
   zAxisArrowPositions,
 } from '../../../lib/transforms/axis-translation';
+import { DrawablePoints } from '../../../lib/transforms/drawable';
 import { testDrawable } from '../../../lib/transforms/hits';
 import { AxisLine } from '../../../lib/transforms/line';
 import { TriangleMesh } from '../../../lib/transforms/mesh';
@@ -36,7 +37,6 @@ import {
   makePerspectiveFrame,
 } from '../../../testing/fixtures';
 import { TransformWidget } from '../widget';
-import { DrawablePoints } from '../../../lib/transforms/drawable';
 
 type MockShapeBuilder = jest.Mock<{ createShape: jest.Mock }>;
 
@@ -145,7 +145,10 @@ function updateFrameCameraPosition(
 }
 
 function createdPaddedFloat64Array(points: DrawablePoints): Float64Array {
-  return new Float64Array([...flattenPointArray(points.toArray()), ...new Array(4).fill(0)]);
+  return new Float64Array([
+    ...flattenPointArray(points.toArray()),
+    ...new Array(4).fill(0),
+  ]);
 }
 
 describe(TransformWidget, () => {

--- a/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
@@ -15,11 +15,9 @@ import {
   yAxisArrowPositions,
   zAxisArrowPositions,
 } from '../../../lib/transforms/axis-translation';
-import { DrawablePoints } from '../../../lib/transforms/drawable';
 import { testDrawable } from '../../../lib/transforms/hits';
 import { AxisLine } from '../../../lib/transforms/line';
 import { TriangleMesh } from '../../../lib/transforms/mesh';
-import { flattenPointArray } from '../../../lib/transforms/util';
 import {
   Frame,
   FrameCameraBase,
@@ -36,6 +34,7 @@ import {
   makeOrthographicFrame,
   makePerspectiveFrame,
 } from '../../../testing/fixtures';
+import { createdPaddedFloat64Array } from '../../../testing/webgl';
 import { TransformWidget } from '../widget';
 
 type MockShapeBuilder = jest.Mock<{ createShape: jest.Mock }>;
@@ -142,13 +141,6 @@ function updateFrameCameraPosition(
     makeDepthImagePng(100, 50),
     makeFeatureMapBytes(100, 50, (pt) => Color.create(0, 0, 0))
   );
-}
-
-function createdPaddedFloat64Array(points: DrawablePoints): Float64Array {
-  return new Float64Array([
-    ...flattenPointArray(points.toArray()),
-    ...new Array(4).fill(0),
-  ]);
 }
 
 describe(TransformWidget, () => {

--- a/packages/viewer/src/lib/transforms/drawable.ts
+++ b/packages/viewer/src/lib/transforms/drawable.ts
@@ -32,7 +32,7 @@ export abstract class Drawable<T extends DrawablePoints = DrawablePoints> {
   ) {
     const pointsAsArray = points.toArray();
 
-    this.pointsArray = new Float64Array(pointsAsArray.length * 2);
+    this.pointsArray = new Float64Array(pointsAsArray.length * 2 + 4);
     flattenPointArray(pointsAsArray).forEach(
       (v, i) => (this.pointsArray[i] = v)
     );

--- a/packages/viewer/src/testing/webgl.ts
+++ b/packages/viewer/src/testing/webgl.ts
@@ -1,0 +1,11 @@
+import { DrawablePoints } from '../lib/transforms/drawable';
+import { flattenPointArray } from '../lib/transforms/util';
+
+export function createdPaddedFloat64Array(
+  points: DrawablePoints
+): Float64Array {
+  return new Float64Array([
+    ...flattenPointArray(points.toArray()),
+    ...new Array(4).fill(0),
+  ]);
+}


### PR DESCRIPTION
## Summary

Fixes an issue with our components that leverage WebGL where the buffers created were not large enough for draw calls. Looking at the internals of the `regl-shape` library, this appears to be related to the typed arrays there being created using the length of the provided `pointsArray`, and there is a specific callout in the README around ensuring the `count` provided is less than half the length of the provided `pointsArray` (which we used exactly half). The specific value of `4` appears to relate to the fill colors, as providing a value of `2` results in a loss of fill colors in certain scenarios, where a value of `3` results in the same warning (in addition to other issues related to the odd-length array).

Specific warning:
```
 GL_INVALID_OPERATION: Vertex buffer is not big enough for the draw call
```

## Test Plan

- Render the transform widget and verify that these errors no longer appear
- Render hit result indicators and verify that these errors no longer appear
- Verify the fill colors for both of the above elements continue to work as expected

## Release Notes

N/A

## Possible Regressions

Transform widget and hit result indicators

## Dependencies

N/A
