### PR TITLE
[PLAT-2919] Update hit indicator default colors and transform widget disabled state initialization

### DIFF
--- a/packages/viewer/src/components/viewer-hit-result-indicator/lib/__tests__/dom.spec.ts
+++ b/packages/viewer/src/components/viewer-hit-result-indicator/lib/__tests__/dom.spec.ts
@@ -1,0 +1,31 @@
+import { parseCssColorValue } from '../dom';
+
+function createMockStyles(): CSSStyleDeclaration {
+  return {
+    getPropertyValue: jest.fn(() => ''),
+  } as unknown as CSSStyleDeclaration;
+}
+
+describe('DOM utils', () => {
+  describe(parseCssColorValue, () => {
+    it('parses values with double quotes', async () => {
+      const styles = createMockStyles();
+
+      (styles.getPropertyValue as jest.Mock).mockImplementation(
+        () => '"#ff0000"'
+      );
+
+      expect(parseCssColorValue(styles, '--property')).toBe('#ff0000');
+    });
+
+    it('parses values with single quotes', async () => {
+      const styles = createMockStyles();
+
+      (styles.getPropertyValue as jest.Mock).mockImplementation(
+        () => "'#ff0000'"
+      );
+
+      expect(parseCssColorValue(styles, '--property')).toBe('#ff0000');
+    });
+  });
+});

--- a/packages/viewer/src/components/viewer-hit-result-indicator/lib/dom.ts
+++ b/packages/viewer/src/components/viewer-hit-result-indicator/lib/dom.ts
@@ -2,5 +2,5 @@ export function parseCssColorValue(
   styles: CSSStyleDeclaration,
   property: string
 ): string {
-  return styles.getPropertyValue(property).trim().replace(/["]*/g, '');
+  return styles.getPropertyValue(property).trim().replace(/["']*/g, '');
 }

--- a/packages/viewer/src/components/viewer-hit-result-indicator/viewer-hit-result-indicator.css
+++ b/packages/viewer/src/components/viewer-hit-result-indicator/viewer-hit-result-indicator.css
@@ -9,19 +9,19 @@
   * @prop --viewer-hit-result-indicator-arrow-color: A CSS color for the arrow
   * representing the normal for this hit indicator. Defaults to `#0099cc`.
   */
-  --viewer-hit-result-indicator-arrow-color: '#0099cc';
+  --viewer-hit-result-indicator-arrow-color: #0099cc;
 
   /**
   * @prop --viewer-hit-result-indicator-plane-color: A CSS color for the plane
   * for this hit indicator. Defaults to `#0099cc`.
   */
-  --viewer-hit-result-indicator-plane-color: '#0099cc';
+  --viewer-hit-result-indicator-plane-color: #0099cc;
 
   /**
   * @prop --viewer-hit-result-indicator-outline-color: A CSS color for the outline
   * of the plane and arrow. Defaults to `#000000`.
   */
-  --viewer-hit-result-indicator-outline-color: '#000000';
+  --viewer-hit-result-indicator-outline-color: #000000;
 
   /**
   * @prop --viewer-hit-result-indicator-plane-opacity: A CSS number for the opacity

--- a/packages/viewer/src/components/viewer-hit-result-indicator/viewer-hit-result-indicator.tsx
+++ b/packages/viewer/src/components/viewer-hit-result-indicator/viewer-hit-result-indicator.tsx
@@ -79,8 +79,6 @@ export class ViewerHitResultIndicator {
         .getPropertyValue('--viewer-hit-result-indicator-plane-opacity')
         .trim();
 
-      console.log(this.arrowColor);
-
       this.indicator?.updateColors({
         arrow: this.arrowColor,
         plane: this.planeColor,

--- a/packages/viewer/src/components/viewer-hit-result-indicator/viewer-hit-result-indicator.tsx
+++ b/packages/viewer/src/components/viewer-hit-result-indicator/viewer-hit-result-indicator.tsx
@@ -79,6 +79,8 @@ export class ViewerHitResultIndicator {
         .getPropertyValue('--viewer-hit-result-indicator-plane-opacity')
         .trim();
 
+      console.log(this.arrowColor);
+
       this.indicator?.updateColors({
         arrow: this.arrowColor,
         plane: this.planeColor,

--- a/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
@@ -493,4 +493,35 @@ describe(TransformWidget, () => {
         ).length
     ).toBe(1);
   });
+
+  it('supports initializing with disabled values', async () => {
+    const widget = new TransformWidget(
+      canvas,
+      {
+        xArrow: '#777777',
+        yArrow: '#888888',
+        zArrow: '#999999',
+        disabledColor: '#333333',
+      },
+      {
+        xRotation: true,
+      }
+    );
+
+    const frame = makePerspectiveFrame();
+    const positionTransform = Matrix4.makeTranslation(Vector3.create(1, 1, 1));
+
+    widget.updateFrame(
+      updateFrameCameraPosition(frame, Vector3.create(100, 100, 100))
+    );
+    widget.updateTransform(positionTransform);
+
+    expect(
+      widget
+        .getDrawableElements()
+        .find(
+          (e) => e.fillColor === '#333333' && e.identifier.includes('x-rotate')
+        )
+    ).toBeDefined();
+  });
 });

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -232,7 +232,7 @@ export class ViewerTransformWidget {
   @Watch('yRotationDisabled')
   @Watch('zRotationDisabled')
   protected handleDisabledPropertyChanged(): void {
-    this.getTransformWidget().updateDisabledAxis({
+    this.widget?.updateDisabledAxis({
       xRotation: this.xRotationDisabled,
       yRotation: this.yRotationDisabled,
       zRotation: this.zRotationDisabled,

--- a/packages/viewer/src/components/viewer-transform-widget/widget.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/widget.ts
@@ -97,7 +97,8 @@ export class TransformWidget extends ReglComponent {
 
   public constructor(
     canvasElement: HTMLCanvasElement,
-    colors: DrawableElementColors = {}
+    colors: DrawableElementColors = {},
+    initialDisabledAxes: Partial<DisabledAxis> = {}
   ) {
     super(canvasElement);
 
@@ -107,6 +108,13 @@ export class TransformWidget extends ReglComponent {
     this.hoveredArrowFillColor = colors.hovered;
     this.outlineColor = colors.outline;
     this.disabledColor = colors.disabledColor ?? '#cccccc';
+
+    this.disabledAxis.xTranslation = initialDisabledAxes.xTranslation ?? false;
+    this.disabledAxis.yTranslation = initialDisabledAxes.yTranslation ?? false;
+    this.disabledAxis.zTranslation = initialDisabledAxes.zTranslation ?? false;
+    this.disabledAxis.xRotation = initialDisabledAxes.xRotation ?? false;
+    this.disabledAxis.yRotation = initialDisabledAxes.yRotation ?? false;
+    this.disabledAxis.zRotation = initialDisabledAxes.zRotation ?? false;
   }
 
   public dispose(): void {


### PR DESCRIPTION
## Summary

Updates the `<vertex-viewer-transform-widget>` element to support having its disabled state updated prior to initialization of the widget by providing it when the widget is initialized. Additionally, this PR updates the CSS definitions for the `<vertex-viewer-hit-result-indicator>` element to not include single quotes, and updates the `parseCssColorValue` method to remove single quotes when retrieving a property value.

## Test Plan

- Verify that the transform widget does not log errors when the disabled states change prior to initialization
- Verify that the transform widget still properly updates disabled states after initialization
- Verify that the hit result indicator has a default color of `#0099cc`

## Release Notes

N/A

## Possible Regressions

Transform widget disabled states

## Dependencies

N/A
