### PR TITLE
[PLAT-2949] Opacity on Disabled Transform State

### DIFF
--- a/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/__tests__/widget.spec.ts
@@ -401,12 +401,11 @@ describe(TransformWidget, () => {
     ).toBe(true);
   });
 
-  it('uses the disabled color if the specific axis are disabled', async () => {
+  it('uses an opacity if the specific axis are disabled', async () => {
     const widget = new TransformWidget(canvas, {
       xArrow: '#777777',
       yArrow: '#888888',
       zArrow: '#999999',
-      disabledColor: '#333333',
     });
 
     widget.updateDisabledAxis({
@@ -426,9 +425,7 @@ describe(TransformWidget, () => {
     expect(
       widget
         .getDrawableElements()
-        .filter(
-          (e) => e.fillColor === '#333333' && e.identifier.includes('rotate')
-        ).length
+        .filter((e) => e.disabled && e.identifier.includes('rotate')).length
     ).toBe(3);
 
     // The disabled rotation meshes should have no impact on the translation meshes
@@ -465,9 +462,7 @@ describe(TransformWidget, () => {
     expect(
       widget
         .getDrawableElements()
-        .filter(
-          (e) => e.fillColor === '#333333' && e.identifier.includes('rotate')
-        ).length
+        .filter((e) => e.disabled && e.identifier.includes('rotate')).length
     ).toBe(0);
 
     // the colors should now be present
@@ -501,7 +496,6 @@ describe(TransformWidget, () => {
         xArrow: '#777777',
         yArrow: '#888888',
         zArrow: '#999999',
-        disabledColor: '#333333',
       },
       {
         xRotation: true,
@@ -519,9 +513,7 @@ describe(TransformWidget, () => {
     expect(
       widget
         .getDrawableElements()
-        .find(
-          (e) => e.fillColor === '#333333' && e.identifier.includes('x-rotate')
-        )
+        .find((e) => e.disabled && e.identifier.includes('x-rotate'))
     ).toBeDefined();
   });
 });

--- a/packages/viewer/src/components/viewer-transform-widget/readme.md
+++ b/packages/viewer/src/components/viewer-transform-widget/readme.md
@@ -98,13 +98,12 @@ The widget expects a part selected, which also occurs on a valid hit result.
 
 ## CSS Custom Properties
 
-| Name                                             | Description                                                                               |
-| ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `--viewer-transform-widget-disabled-arrow-color` | A CSS color for the arrow when it is disabled. Defaults to `#cccccc`.                     |
-| `--viewer-transform-widget-hovered-arrow-color`  | A CSS color for the arrow when it is hovered. Defaults to `#ffff00`.                      |
-| `--viewer-transform-widget-x-axis-arrow-color`   | A CSS color for the arrow at the end of the X axis on this widget. Defaults to `#ea3324`. |
-| `--viewer-transform-widget-y-axis-arrow-color`   | A CSS color for the arrow at the end of the Y axis on this widget. Defaults to `#4faf32`. |
-| `--viewer-transform-widget-z-axis-arrow-color`   | A CSS color for the arrow at the end of the Z axis on this widget. Defaults to `#0000ff`. |
+| Name                                            | Description                                                                               |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `--viewer-transform-widget-hovered-arrow-color` | A CSS color for the arrow when it is hovered. Defaults to `#ffff00`.                      |
+| `--viewer-transform-widget-x-axis-arrow-color`  | A CSS color for the arrow at the end of the X axis on this widget. Defaults to `#ea3324`. |
+| `--viewer-transform-widget-y-axis-arrow-color`  | A CSS color for the arrow at the end of the Y axis on this widget. Defaults to `#4faf32`. |
+| `--viewer-transform-widget-z-axis-arrow-color`  | A CSS color for the arrow at the end of the Z axis on this widget. Defaults to `#0000ff`. |
 
 
 ----------------------------------------------

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.css
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.css
@@ -29,12 +29,6 @@
   * when it is hovered. Defaults to `#ffff00`.
   */
   --viewer-transform-widget-hovered-arrow-color: #ffff00;
-
-  /**
-  * @prop --viewer-transform-widget-disabled-arrow-color: A CSS color for the arrow
-  * when it is disabled. Defaults to `#cccccc`.
-  */
-  --viewer-transform-widget-disabled-arrow-color: #cccccc;
 }
 
 .widget {

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -141,7 +141,6 @@ export class ViewerTransformWidget {
   private yArrowColor: Color.Color | string = '#4faf32';
   private zArrowColor: Color.Color | string = '#0000ff';
   private hoveredColor: Color.Color | string = '#ffff00';
-  private disabledColor: Color.Color | string = '#cccccc';
 
   private widget?: TransformWidget;
   private dragging?: Drawable;
@@ -181,9 +180,6 @@ export class ViewerTransformWidget {
         .trim();
       this.hoveredColor = hostStyles
         .getPropertyValue('--viewer-transform-widget-hovered-arrow-color')
-        .trim();
-      this.disabledColor = hostStyles
-        .getPropertyValue('--viewer-transform-widget-disabled-arrow-color')
         .trim();
     });
   }
@@ -563,7 +559,6 @@ export class ViewerTransformWidget {
       yArrow: this.yArrowColor,
       zArrow: this.zArrowColor,
       hovered: this.hoveredColor,
-      disabledColor: this.disabledColor,
     });
 
     if (this.rotation != null) {

--- a/packages/viewer/src/components/viewer-transform-widget/widget.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/widget.ts
@@ -35,7 +35,6 @@ export interface DrawableElementColors {
   zArrow?: Color.Color | string;
   hovered?: Color.Color | string;
   outline?: Color.Color | string;
-  disabledColor?: Color.Color | string;
 }
 
 export interface DisabledAxis {
@@ -93,8 +92,6 @@ export class TransformWidget extends ReglComponent {
   private hoveredArrowFillColor?: Color.Color | string;
   private outlineColor?: Color.Color | string;
 
-  private disabledColor: Color.Color | string;
-
   public constructor(
     canvasElement: HTMLCanvasElement,
     colors: DrawableElementColors = {},
@@ -107,7 +104,6 @@ export class TransformWidget extends ReglComponent {
     this.zArrowFillColor = colors.zArrow;
     this.hoveredArrowFillColor = colors.hovered;
     this.outlineColor = colors.outline;
-    this.disabledColor = colors.disabledColor ?? '#cccccc';
 
     this.disabledAxis.xTranslation = initialDisabledAxes.xTranslation ?? false;
     this.disabledAxis.yTranslation = initialDisabledAxes.yTranslation ?? false;
@@ -141,7 +137,7 @@ export class TransformWidget extends ReglComponent {
       ...this.disabledAxis,
       ...axis,
     };
-    this.updateDisabledOnTriangles();
+    this.updateDisabledOnDrawables();
   }
 
   public updateCursor(cursor?: Point.Point): void {
@@ -173,10 +169,6 @@ export class TransformWidget extends ReglComponent {
     this.hoveredArrowFillColor = colors.hovered ?? this.hoveredArrowFillColor;
     this.outlineColor = colors.outline ?? this.outlineColor;
 
-    this.xAxis?.updateFillColor(this.disabledColor);
-    this.yAxis?.updateFillColor(this.disabledColor);
-    this.zAxis?.updateFillColor(this.disabledColor);
-
     this.xArrow?.updateFillColor(this.getXTranslationColor());
     this.yArrow?.updateFillColor(this.getYTranslationColor());
     this.zArrow?.updateFillColor(this.getZTranslationColor());
@@ -192,10 +184,19 @@ export class TransformWidget extends ReglComponent {
     return this.hoveredChanged.on(listener);
   }
 
-  private updateDisabledOnTriangles(): void {
+  private updateDisabledOnDrawables(): void {
     this.xRotation?.setDisabled(this.disabledAxis.xRotation);
+    this.xyRotationLine?.setDisabled(this.disabledAxis.xRotation);
+    this.xzRotationLine?.setDisabled(this.disabledAxis.xRotation);
+
     this.yRotation?.setDisabled(this.disabledAxis.yRotation);
+    this.yzRotationLine?.setDisabled(this.disabledAxis.yRotation);
+    this.yxRotationLine?.setDisabled(this.disabledAxis.yRotation);
+
     this.zRotation?.setDisabled(this.disabledAxis.zRotation);
+    this.zxRotationLine?.setDisabled(this.disabledAxis.zRotation);
+    this.zyRotationLine?.setDisabled(this.disabledAxis.zRotation);
+
     this.xArrow?.setDisabled(this.disabledAxis.xTranslation);
     this.yArrow?.setDisabled(this.disabledAxis.yTranslation);
     this.zArrow?.setDisabled(this.disabledAxis.zTranslation);
@@ -337,7 +338,7 @@ export class TransformWidget extends ReglComponent {
     this.axisLines = [this.xAxis, this.yAxis, this.zAxis];
     this.translationMeshes = [this.xArrow, this.yArrow, this.zArrow];
     this.rotationMeshes = [this.xRotation, this.yRotation, this.zRotation];
-    this.updateDisabledOnTriangles();
+    this.updateDisabledOnDrawables();
 
     this.availableElements = [
       ...this.axisLines,
@@ -348,39 +349,27 @@ export class TransformWidget extends ReglComponent {
   }
 
   private getXRotationColor(): Color.Color | string | undefined {
-    return this.xRotation?.isDisabled()
-      ? this.disabledColor
-      : this.xArrowFillColor;
+    return this.xArrowFillColor;
   }
 
   private getYRotationColor(): Color.Color | string | undefined {
-    return this.yRotation?.isDisabled()
-      ? this.disabledColor
-      : this.yArrowFillColor;
+    return this.yArrowFillColor;
   }
 
   private getZRotationColor(): Color.Color | string | undefined {
-    return this.zRotation?.isDisabled()
-      ? this.disabledColor
-      : this.zArrowFillColor;
+    return this.zArrowFillColor;
   }
 
   private getXTranslationColor(): Color.Color | string | undefined {
-    return this.xArrow?.isDisabled()
-      ? this.disabledColor
-      : this.xArrowFillColor;
+    return this.xArrowFillColor;
   }
 
   private getYTranslationColor(): Color.Color | string | undefined {
-    return this.yArrow?.isDisabled()
-      ? this.disabledColor
-      : this.yArrowFillColor;
+    return this.yArrowFillColor;
   }
 
   private getZTranslationColor(): Color.Color | string | undefined {
-    return this.zArrow?.isDisabled()
-      ? this.disabledColor
-      : this.zArrowFillColor;
+    return this.zArrowFillColor;
   }
 
   private createRotationLines(

--- a/packages/viewer/src/lib/transforms/drawable.ts
+++ b/packages/viewer/src/lib/transforms/drawable.ts
@@ -28,7 +28,8 @@ export abstract class Drawable<T extends DrawablePoints = DrawablePoints> {
     public points: T,
     public outlineColor: string,
     public fillColor?: string,
-    public shapeProps: Partial<ShapeProps> = {}
+    public shapeProps: Partial<ShapeProps> = {},
+    public disabled: boolean = false
   ) {
     const pointsAsArray = points.toArray();
 

--- a/packages/viewer/src/lib/transforms/line.ts
+++ b/packages/viewer/src/lib/transforms/line.ts
@@ -81,7 +81,8 @@ export class RotationLine extends Drawable<RotationLinePoints> {
     outlineColor: Color.Color | string = '#000000',
     shapeProps: Partial<ShapeProps> = {
       join: 'round' as JoinStyle,
-    }
+    },
+    public disabled: boolean = false
   ) {
     super(
       createShape,
@@ -93,5 +94,9 @@ export class RotationLine extends Drawable<RotationLinePoints> {
       undefined,
       shapeProps
     );
+  }
+
+  public setDisabled(disabled: boolean): void {
+    this.disabled = disabled;
   }
 }

--- a/packages/viewer/src/lib/transforms/mesh.ts
+++ b/packages/viewer/src/lib/transforms/mesh.ts
@@ -88,7 +88,7 @@ export class TriangleMesh extends Drawable<TriangleMeshPoints> {
     outlineColor: Color.Color | string = '#000000',
     fillColor: Color.Color | string = '#000000',
     shapeProps: Partial<ShapeProps> = {},
-    private disabled: boolean = false
+    public disabled: boolean = false
   ) {
     super(
       createShape,

--- a/packages/viewer/src/lib/webgl/regl-component.ts
+++ b/packages/viewer/src/lib/webgl/regl-component.ts
@@ -67,7 +67,12 @@ export abstract class ReglComponent implements Disposable {
   protected draw(): void {
     if (this.reglFrameDisposable == null) {
       this.reglFrameDisposable = this.reglCommand?.frame(() => {
-        this.drawableElements.forEach((el) => el?.draw({ fill: el.fillColor }));
+        this.drawableElements.forEach((el) =>
+          el?.draw({
+            fill: el.fillColor,
+            opacity: !!el.disabled ? 0.2 : 1,
+          })
+        );
       });
     }
   }


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes are to update the disabled state of the transform widget. Instead of specifying a color, the disabled widget shows an opacity to maintain the color to denote which axis are disabled. These changes are being made to make the disabled state a better experience for users who have reported that the disabled state is not obvious. 

![image](https://github.com/Vertexvis/vertex-web-sdk/assets/49169871/2192934c-fcbc-44db-92e9-2a7bbd42a08f)


## Test Plan
<!-- How to test changes. -->
Verify the opacity is shown on a disabled axis by making the opacity lighter for the transform widget.

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
