### PR TITLE
[PLAT-2346] Wire up display list summary

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.9.0"
+    "@vertexvis/frame-streaming-protos": "^0.10.0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/stream-api/src/testing/fixtures/requests.ts
+++ b/packages/stream-api/src/testing/fixtures/requests.ts
@@ -61,6 +61,14 @@ export function drawFrame(
       crossSectioning: {
         sectionPlanes: [],
       },
+      displayListSummary: {
+        visibleSummary: {
+          count: 100,
+        },
+        selectedVisibleSummary: {
+          count: 0,
+        },
+      },
     },
     imageAttributes: {
       frameDimensions: { width: 200, height: 150 },

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.9.0",
+    "@vertexvis/frame-streaming-protos": "^0.10.0",
     "@vertexvis/geometry": "0.17.2",
     "@vertexvis/html-templates": "0.17.2",
     "@vertexvis/scene-tree-protos": "^0.1.15",

--- a/packages/viewer/src/lib/mappers/frameStreaming.ts
+++ b/packages/viewer/src/lib/mappers/frameStreaming.ts
@@ -138,7 +138,7 @@ export const fromPbCrossSectioning: M.Func<
     })
 );
 
-export const fromPbItemSetSummary: M.Func<
+const fromPbItemSetSummary: M.Func<
   vertexvis.protobuf.stream.IItemSetSummary,
   DisplayListSummary.ItemSetSummary
 > = M.defineMapper(
@@ -152,7 +152,7 @@ export const fromPbItemSetSummary: M.Func<
   })
 );
 
-export const fromPbDisplayListSummary: M.Func<
+const fromPbDisplayListSummary: M.Func<
   vertexvis.protobuf.stream.IDisplayListSummary,
   DisplayListSummary.DisplayListSummary
 > = M.defineMapper(

--- a/packages/viewer/src/lib/types/displayListSummary.ts
+++ b/packages/viewer/src/lib/types/displayListSummary.ts
@@ -1,0 +1,20 @@
+import { BoundingBox } from '@vertexvis/geometry';
+
+export interface ItemSetSummary {
+  count: number;
+  boundingBox?: BoundingBox.BoundingBox;
+}
+
+export interface DisplayListSummary {
+  visibleSummary: ItemSetSummary;
+  selectedVisibleSummary: ItemSetSummary;
+}
+
+export function create(
+  data: Partial<DisplayListSummary> = {}
+): DisplayListSummary {
+  return {
+    visibleSummary: data.visibleSummary ?? { count: 0 },
+    selectedVisibleSummary: data.selectedVisibleSummary ?? { count: 0 },
+  };
+}

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -15,6 +15,7 @@ import { constrainViewVector } from '../rendering/vectors';
 import * as ClippingPlanes from './clippingPlanes';
 import * as CrossSectioning from './crossSectioning';
 import { DepthBuffer } from './depthBuffer';
+import * as DisplayListSummary from './displayListSummary';
 import { FeatureMap } from './featureMap';
 import * as FrameCamera from './frameCamera';
 import { Orientation } from './orientation';
@@ -121,7 +122,8 @@ export class FrameScene {
     public readonly boundingBox: BoundingBox.BoundingBox,
     public readonly crossSection: CrossSectioning.CrossSectioning,
     public readonly worldOrientation: Orientation,
-    public readonly hasChanged: boolean
+    public readonly hasChanged: boolean,
+    public readonly displayListSummary: DisplayListSummary.DisplayListSummary
   ) {}
 }
 

--- a/packages/viewer/src/lib/types/index.ts
+++ b/packages/viewer/src/lib/types/index.ts
@@ -4,6 +4,7 @@
 import * as Animation from './animation';
 import * as ClippingPlanes from './clippingPlanes';
 import * as CrossSectioning from './crossSectioning';
+import * as DisplayListSummary from './displayListSummary';
 import * as Events from './events';
 import * as Flags from './flags';
 import * as FlyTo from './flyToOptions';
@@ -29,6 +30,7 @@ export {
   Animation,
   ClippingPlanes,
   CrossSectioning,
+  DisplayListSummary,
   Events,
   Flags,
   FlyTo,

--- a/packages/viewer/src/testing/fixtures.ts
+++ b/packages/viewer/src/testing/fixtures.ts
@@ -35,6 +35,14 @@ const baseDrawFramePayload: Partial<DrawFramePayload> = {
       sectionPlanes: [{ normal: { x: 0, y: 0, z: 0 }, offset: 0 }],
     },
     hasChanged: false,
+    displayListSummary: {
+      visibleSummary: {
+        count: 100,
+      },
+      selectedVisibleSummary: {
+        count: 0,
+      },
+    },
   },
   imageAttributes: {
     frameDimensions: { width: 100, height: 50 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,10 +2138,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.9.0.tgz#89909f0323b15eb646d7265899975b0edc88872c"
-  integrity sha512-E57lw/4H/jSQiFZAFLciTh9MtzZrUrkjWv7Z6MnNK3+LJ6pED5JHq8sddMpHJ8ypjoTxvidHCESTP9ipBeMabw==
+"@vertexvis/frame-streaming-protos@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.10.0.tgz#de7cb815b8e78e72b1a69f775c97cf2cc6f04f59"
+  integrity sha512-iifLgvHikYFR1Jyi6oMpMw0wv36OWgZ5LsIbtRPiRug9qRXJgEFpTBBQGT9j3X8H1/jd34erDypyNFKrTDYEFA==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary

Wires up the `DisplayListSummary` introduced with version `0.10.0` of the frame-streaming-protos.

## Test Plan

- Verify that frames emitted through the `receiveFrame` or `drawFrame` methods have a `displayListSummary` field on the `scene`

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
