### PR TITLE
[PLAT-1181] Handle long press in the scene tree

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.tsx
@@ -2,6 +2,7 @@
 import { h } from '@stencil/core';
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
+import { Async } from '@vertexvis/utils';
 import Chance from 'chance';
 
 import { SceneTreeCellHoverController } from '../scene-tree-table-layout/lib/hover-controller';
@@ -10,6 +11,10 @@ import { SceneTreeTableCell } from './scene-tree-table-cell';
 const random = new Chance();
 
 describe('<vertex-scene-tree-table-cell>', () => {
+  const pointerDownEvent = new MouseEvent('pointerdown', {
+    button: 0,
+  });
+
   it('renders empty element if node is undefined', async () => {
     const { cell } = await newComponentSpec({
       html: `<vertex-scene-tree-table-cell></vertex-scene-tree-table-cell>`,
@@ -206,9 +211,31 @@ describe('<vertex-scene-tree-table-cell>', () => {
     (cell as any).tree = tree;
 
     const originalEvent = new MouseEvent('pointerup', { button: 0 });
+    cell.dispatchEvent(pointerDownEvent);
     cell.dispatchEvent(originalEvent);
 
     expect(tree.selectItem).toHaveBeenCalled();
+  });
+
+  it('does not select cell on long press', async () => {
+    const node = createNode({ selected: false });
+    const { cell } = await newComponentSpec({
+      html: `
+        <vertex-scene-tree-table-cell></vertex-scene-tree-table-cell>
+      `,
+      node,
+    });
+
+    const tree = { selectItem: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (cell as any).tree = tree;
+
+    const originalEvent = new MouseEvent('pointerup', { button: 0 });
+    cell.dispatchEvent(pointerDownEvent);
+    await Async.delay(550); // mock a long press on mobile
+    cell.dispatchEvent(originalEvent);
+
+    expect(tree.selectItem).not.toHaveBeenCalled();
   });
 
   it('supports custom selection handling', async () => {
@@ -232,6 +259,7 @@ describe('<vertex-scene-tree-table-cell>', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (cell as any).tree = tree;
 
+    cell.dispatchEvent(pointerDownEvent);
     const originalEvent = new MouseEvent('pointerup', {
       button: 0,
       altKey: true,
@@ -254,6 +282,7 @@ describe('<vertex-scene-tree-table-cell>', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (cell as any).tree = tree;
 
+    cell.dispatchEvent(pointerDownEvent);
     const originalEvent = new MouseEvent('pointerup', {
       button: 0,
       metaKey: true,
@@ -280,6 +309,7 @@ describe('<vertex-scene-tree-table-cell>', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (cell as any).tree = tree;
 
+    cell.dispatchEvent(pointerDownEvent);
     cell.dispatchEvent(
       new MouseEvent('pointerup', { button: 0, ctrlKey: true })
     );
@@ -303,6 +333,7 @@ describe('<vertex-scene-tree-table-cell>', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (cell as any).tree = tree;
 
+    cell.dispatchEvent(pointerDownEvent);
     cell.dispatchEvent(new MouseEvent('pointerup', { button: 0 }));
 
     expect(tree.selectItem).toHaveBeenCalledWith(
@@ -323,6 +354,8 @@ describe('<vertex-scene-tree-table-cell>', () => {
     const tree = { deselectItem: jest.fn() };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (cell as any).tree = tree;
+
+    cell.dispatchEvent(pointerDownEvent);
 
     cell.dispatchEvent(
       new MouseEvent('pointerup', { button: 0, metaKey: true })
@@ -348,6 +381,7 @@ describe('<vertex-scene-tree-table-cell>', () => {
       button: 0,
       ctrlKey: true,
     });
+    cell.dispatchEvent(pointerDownEvent);
     cell.dispatchEvent(originalEvent);
 
     expect(tree.deselectItem).toHaveBeenCalled();

--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
@@ -159,6 +159,7 @@ export class SceneTreeTableCell {
 
   public disconnectedCallback(): void {
     this.hoverListener?.dispose();
+    this.clearLongPressTimer();
   }
 
   public componentWillRender(): void {

--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
@@ -11,6 +11,7 @@ import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
 import { Disposable } from '@vertexvis/utils';
 import classNames from 'classnames';
 
+import { Events } from '../../lib/types';
 import { SceneTreeOperationHandler } from '../scene-tree/lib/handlers';
 import { SceneTreeCellHoverController } from '../scene-tree-table-layout/lib/hover-controller';
 
@@ -145,12 +146,15 @@ export class SceneTreeTableCell {
 
   private hoverListener?: Disposable;
 
+  private longPressTimer?: number;
+
   public componentDidLoad(): void {
     this.hoverListener = this.hoverController?.stateChanged((id?: string) => {
       this.hovered = id === this.node?.id?.hex;
     });
 
     this.cellLoaded.emit();
+    this.clearLongPressTimer();
   }
 
   public disconnectedCallback(): void {
@@ -172,6 +176,7 @@ export class SceneTreeTableCell {
         onPointerEnter={this.handleCellPointerEnter}
         onPointerLeave={this.handleCellPointerLeave}
         onPointerUp={this.handleCellPointerUp}
+        onPointerDown={this.handleCellPointerDown}
       >
         <div class="wrapper">
           <div class="no-shrink">
@@ -254,7 +259,12 @@ export class SceneTreeTableCell {
   };
 
   private handleCellPointerUp = (event: PointerEvent): void => {
-    if (!this.isScrolling && this.node != null && this.tree != null) {
+    if (
+      !this.isScrolling &&
+      this.node != null &&
+      this.tree != null &&
+      this.longPressTimer != null
+    ) {
       if (this.selectionHandler != null) {
         this.selectionHandler(event, this.node, this.tree);
       } else {
@@ -262,6 +272,11 @@ export class SceneTreeTableCell {
       }
       this.selectionToggled.emit({ node: this.node, originalEvent: event });
     }
+    this.clearLongPressTimer();
+  };
+
+  private handleCellPointerDown = (event: PointerEvent): void => {
+    this.restartLongPressTimer();
   };
 
   private toggleExpansion = (event: PointerEvent): void => {
@@ -324,4 +339,18 @@ export class SceneTreeTableCell {
   ): void => {
     tree.toggleExpandItem(node);
   };
+
+  private clearLongPressTimer(): void {
+    if (this.longPressTimer != null) {
+      window.clearTimeout(this.longPressTimer);
+    }
+    this.longPressTimer = undefined;
+  }
+
+  private restartLongPressTimer(): void {
+    this.clearLongPressTimer();
+    this.longPressTimer = window.setTimeout(() => {
+      this.clearLongPressTimer();
+    }, Events.defaultEventConfig.longPressThreshold);
+  }
 }


### PR DESCRIPTION
## Summary
We want to handle long presses in the scene tree on mobile separately from single tap events. As a result, long pressing on a node in the scene tree will no longer select the item.

## Test Plan
Verify that long pressing on a node in the scene tree does not select the item.

## Release Notes
None

## Possible Regressions
Long presses in the scene tree

## Dependencies
None