### PR TITLE
[PLAT-2346] Rename displayListSummary

### DIFF
--- a/packages/viewer/src/lib/mappers/frameStreaming.ts
+++ b/packages/viewer/src/lib/mappers/frameStreaming.ts
@@ -6,7 +6,6 @@ import { Mapper as M } from '@vertexvis/utils';
 import { Token } from '../token';
 import {
   CrossSectioning,
-  DisplayListSummary,
   Frame,
   FrameCamera,
   FrameCameraBase,
@@ -14,6 +13,7 @@ import {
   FrameScene,
   ImageAttributesLike,
   Orientation,
+  SceneViewSummary,
 } from '../types';
 import { fromPbUuid } from './core';
 import {
@@ -140,7 +140,7 @@ export const fromPbCrossSectioning: M.Func<
 
 const fromPbItemSetSummary: M.Func<
   vertexvis.protobuf.stream.IItemSetSummary,
-  DisplayListSummary.ItemSetSummary
+  SceneViewSummary.ItemSetSummary
 > = M.defineMapper(
   M.read(
     M.requiredProp('count'),
@@ -154,14 +154,14 @@ const fromPbItemSetSummary: M.Func<
 
 const fromPbDisplayListSummary: M.Func<
   vertexvis.protobuf.stream.IDisplayListSummary,
-  DisplayListSummary.DisplayListSummary
+  SceneViewSummary.SceneViewSummary
 > = M.defineMapper(
   M.read(
     M.mapProp('visibleSummary', M.ifDefined(fromPbItemSetSummary)),
     M.mapProp('selectedVisibleSummary', M.ifDefined(fromPbItemSetSummary))
   ),
   ([visibleSummary, selectedVisibleSummary]) =>
-    DisplayListSummary.create({
+    SceneViewSummary.create({
       visibleSummary: visibleSummary ?? undefined,
       selectedVisibleSummary: selectedVisibleSummary ?? undefined,
     })
@@ -195,7 +195,7 @@ const fromPbSceneAttributes: M.Func<
     boundingBox: BoundingBox.BoundingBox;
     crossSectioning: CrossSectioning.CrossSectioning;
     hasChanged: boolean;
-    displayListSummary: DisplayListSummary.DisplayListSummary;
+    displayListSummary: SceneViewSummary.SceneViewSummary;
   }
 > = M.defineMapper(
   M.read(
@@ -230,7 +230,7 @@ const fromPbFrameSceneAttributes: M.Func<
     boundingBox: BoundingBox.BoundingBox;
     crossSectioning: CrossSectioning.CrossSectioning;
     hasChanged: boolean;
-    displayListSummary: DisplayListSummary.DisplayListSummary;
+    displayListSummary: SceneViewSummary.SceneViewSummary;
   }
 > = M.defineMapper(
   M.read(

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -15,10 +15,10 @@ import { constrainViewVector } from '../rendering/vectors';
 import * as ClippingPlanes from './clippingPlanes';
 import * as CrossSectioning from './crossSectioning';
 import { DepthBuffer } from './depthBuffer';
-import * as DisplayListSummary from './displayListSummary';
 import { FeatureMap } from './featureMap';
 import * as FrameCamera from './frameCamera';
 import { Orientation } from './orientation';
+import * as SceneViewSummary from './sceneViewSummary';
 
 export class Frame {
   private cachedDepthBuffer?: Promise<DepthBuffer | undefined>;
@@ -123,7 +123,7 @@ export class FrameScene {
     public readonly crossSection: CrossSectioning.CrossSectioning,
     public readonly worldOrientation: Orientation,
     public readonly hasChanged: boolean,
-    public readonly displayListSummary: DisplayListSummary.DisplayListSummary
+    public readonly sceneViewSummary: SceneViewSummary.SceneViewSummary
   ) {}
 }
 

--- a/packages/viewer/src/lib/types/index.ts
+++ b/packages/viewer/src/lib/types/index.ts
@@ -4,7 +4,6 @@
 import * as Animation from './animation';
 import * as ClippingPlanes from './clippingPlanes';
 import * as CrossSectioning from './crossSectioning';
-import * as DisplayListSummary from './displayListSummary';
 import * as Events from './events';
 import * as Flags from './flags';
 import * as FlyTo from './flyToOptions';
@@ -12,6 +11,7 @@ import * as FrameCamera from './frameCamera';
 import * as Interactions from './interactions';
 import * as LoadableResource from './loadableResource';
 import * as SceneViewStateIdentifier from './sceneViewStateIdentifier';
+import * as SceneViewSummary from './sceneViewSummary';
 
 export * from './depthBuffer';
 export * from './entities';
@@ -30,7 +30,6 @@ export {
   Animation,
   ClippingPlanes,
   CrossSectioning,
-  DisplayListSummary,
   Events,
   Flags,
   FlyTo,
@@ -38,4 +37,5 @@ export {
   Interactions,
   LoadableResource,
   SceneViewStateIdentifier,
+  SceneViewSummary,
 };

--- a/packages/viewer/src/lib/types/sceneViewSummary.ts
+++ b/packages/viewer/src/lib/types/sceneViewSummary.ts
@@ -5,14 +5,12 @@ export interface ItemSetSummary {
   boundingBox?: BoundingBox.BoundingBox;
 }
 
-export interface DisplayListSummary {
+export interface SceneViewSummary {
   visibleSummary: ItemSetSummary;
   selectedVisibleSummary: ItemSetSummary;
 }
 
-export function create(
-  data: Partial<DisplayListSummary> = {}
-): DisplayListSummary {
+export function create(data: Partial<SceneViewSummary> = {}): SceneViewSummary {
   return {
     visibleSummary: data.visibleSummary ?? { count: 0 },
     selectedVisibleSummary: data.selectedVisibleSummary ?? { count: 0 },


### PR DESCRIPTION
## Summary

Renaming the summary added with #499 from `displayListSummary` to `sceneViewSummary` to avoid using the term `DisplayList` in the SDK context.

## Test Plan

- Verify that the `displayListSummary` is remapped to a `sceneViewSummary` on the frame

## Release Notes

N/A

## Possible Regressions

Display list summary

## Dependencies

N/A
