### PR TITLE
[PLAT-3012] Ignore invalid summaries on incoming frames

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -77,7 +77,7 @@ import {
   StencilBufferManager,
   Viewport,
 } from '../../lib/types';
-import { Frame, FrameScene } from '../../lib/types/frame';
+import { Frame } from '../../lib/types/frame';
 import { FrameCameraType } from '../../lib/types/frameCamera';
 import {
   getElementBackgroundColor,

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -73,10 +73,11 @@ import { ViewerStream } from '../../lib/stream/stream';
 import {
   FrameCamera,
   Orientation,
+  SceneViewSummary,
   StencilBufferManager,
   Viewport,
 } from '../../lib/types';
-import { Frame } from '../../lib/types/frame';
+import { Frame, FrameScene } from '../../lib/types/frame';
 import { FrameCameraType } from '../../lib/types/frameCamera';
 import {
   getElementBackgroundColor,
@@ -1101,7 +1102,10 @@ export class Viewer {
       const canvas = this.canvasElement.getContext('2d');
       if (canvas != null) {
         const previousFrame = this.frame;
-        this.frame = frame;
+        this.frame = SceneViewSummary.copySummaryIfInvalid(
+          frame,
+          previousFrame
+        );
 
         this.updateInteractionApi(previousFrame);
 

--- a/packages/viewer/src/lib/types/__tests__/sceneViewSummary.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/sceneViewSummary.spec.ts
@@ -64,8 +64,5 @@ function copyWithValidSummary(frame: Frame, count: number): Frame {
 }
 
 function copyWithInvalidSummary(frame: Frame): Frame {
-  return copyWithSummary(frame, {
-    selectedVisibleSummary: { count: -1 },
-    visibleSummary: { count: -1 },
-  });
+  return copyWithSummary(frame, {});
 }

--- a/packages/viewer/src/lib/types/__tests__/sceneViewSummary.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/sceneViewSummary.spec.ts
@@ -1,3 +1,5 @@
+import { BoundingBox, Vector3 } from '@vertexvis/geometry';
+
 import { makePerspectiveFrame } from '../../../testing/fixtures';
 import { Frame, SceneViewSummary } from '..';
 
@@ -52,20 +54,18 @@ function copyWithValidSummary(frame: Frame, count: number): Frame {
   return copyWithSummary(frame, {
     selectedVisibleSummary: {
       count,
+      boundingBox: BoundingBox.create(Vector3.create(), Vector3.right()),
     },
     visibleSummary: {
       count,
+      boundingBox: BoundingBox.create(Vector3.create(), Vector3.right()),
     },
   });
 }
 
 function copyWithInvalidSummary(frame: Frame): Frame {
   return copyWithSummary(frame, {
-    selectedVisibleSummary: {
-      count: -1,
-    },
-    visibleSummary: {
-      count: -1,
-    },
+    selectedVisibleSummary: { count: -1 },
+    visibleSummary: { count: -1 },
   });
 }

--- a/packages/viewer/src/lib/types/__tests__/sceneViewSummary.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/sceneViewSummary.spec.ts
@@ -1,0 +1,71 @@
+import { makePerspectiveFrame } from '../../../testing/fixtures';
+import { Frame, SceneViewSummary } from '..';
+
+describe('SceneViewSummary', () => {
+  describe('SceneViewSummary.copySummaryIfInvalid', () => {
+    const baseFrame = makePerspectiveFrame();
+
+    it('copies the summary of the previous frame if the current summary is invalid', () => {
+      const previousValid = copyWithValidSummary(baseFrame, 1);
+      const previousInvalid = copyWithInvalidSummary(baseFrame);
+      const current = copyWithInvalidSummary(baseFrame);
+
+      expect(
+        SceneViewSummary.copySummaryIfInvalid(current, previousValid).scene
+          .sceneViewSummary
+      ).toMatchObject(previousValid.scene.sceneViewSummary);
+      expect(
+        SceneViewSummary.copySummaryIfInvalid(current, previousInvalid).scene
+          .sceneViewSummary
+      ).toMatchObject(current.scene.sceneViewSummary);
+    });
+
+    it('uses the summary of the current frame if it is valid', () => {
+      const previousValid = copyWithValidSummary(baseFrame, 1);
+      const previousInvalid = copyWithInvalidSummary(baseFrame);
+      const current = copyWithValidSummary(baseFrame, 2);
+
+      expect(
+        SceneViewSummary.copySummaryIfInvalid(current, previousValid).scene
+          .sceneViewSummary
+      ).toMatchObject(current.scene.sceneViewSummary);
+      expect(
+        SceneViewSummary.copySummaryIfInvalid(current, previousInvalid).scene
+          .sceneViewSummary
+      ).toMatchObject(current.scene.sceneViewSummary);
+    });
+  });
+});
+
+function copyWithSummary(
+  frame: Frame,
+  summary?: SceneViewSummary.SceneViewSummary
+): Frame {
+  return frame.copy({
+    scene: frame.scene.copy({
+      sceneViewSummary: summary,
+    }),
+  });
+}
+
+function copyWithValidSummary(frame: Frame, count: number): Frame {
+  return copyWithSummary(frame, {
+    selectedVisibleSummary: {
+      count,
+    },
+    visibleSummary: {
+      count,
+    },
+  });
+}
+
+function copyWithInvalidSummary(frame: Frame): Frame {
+  return copyWithSummary(frame, {
+    selectedVisibleSummary: {
+      count: -1,
+    },
+    visibleSummary: {
+      count: -1,
+    },
+  });
+}

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -125,6 +125,31 @@ export class FrameScene {
     public readonly hasChanged: boolean,
     public readonly sceneViewSummary: SceneViewSummary.SceneViewSummary
   ) {}
+
+  public copy({
+    camera,
+    boundingBox,
+    crossSection,
+    worldOrientation,
+    hasChanged,
+    sceneViewSummary,
+  }: Partial<{
+    camera: FrameCameraBase;
+    boundingBox: BoundingBox.BoundingBox;
+    crossSection: CrossSectioning.CrossSectioning;
+    worldOrientation: Orientation;
+    hasChanged: boolean;
+    sceneViewSummary: SceneViewSummary.SceneViewSummary;
+  }>): FrameScene {
+    return new FrameScene(
+      camera ?? this.camera,
+      boundingBox ?? this.boundingBox,
+      crossSection ?? this.crossSection,
+      worldOrientation ?? this.worldOrientation,
+      hasChanged ?? this.hasChanged,
+      sceneViewSummary ?? this.sceneViewSummary
+    );
+  }
 }
 
 interface FrameCameraMatrices {

--- a/packages/viewer/src/lib/types/sceneViewSummary.ts
+++ b/packages/viewer/src/lib/types/sceneViewSummary.ts
@@ -8,14 +8,14 @@ export interface ItemSetSummary {
 }
 
 export interface SceneViewSummary {
-  visibleSummary: ItemSetSummary;
-  selectedVisibleSummary: ItemSetSummary;
+  visibleSummary?: ItemSetSummary;
+  selectedVisibleSummary?: ItemSetSummary;
 }
 
 export function create(data: Partial<SceneViewSummary> = {}): SceneViewSummary {
   return {
-    visibleSummary: data.visibleSummary ?? { count: 0 },
-    selectedVisibleSummary: data.selectedVisibleSummary ?? { count: 0 },
+    visibleSummary: data.visibleSummary,
+    selectedVisibleSummary: data.selectedVisibleSummary,
   };
 }
 
@@ -30,8 +30,5 @@ export function copySummaryIfInvalid(current: Frame, previous?: Frame): Frame {
 }
 
 function isInvalid(summary: SceneViewSummary): boolean {
-  return (
-    summary.visibleSummary?.boundingBox == null ||
-    summary.selectedVisibleSummary?.boundingBox == null
-  );
+  return summary.visibleSummary == null;
 }

--- a/packages/viewer/src/lib/types/sceneViewSummary.ts
+++ b/packages/viewer/src/lib/types/sceneViewSummary.ts
@@ -1,5 +1,7 @@
 import { BoundingBox } from '@vertexvis/geometry';
 
+import { Frame } from './frame';
+
 export interface ItemSetSummary {
   count: number;
   boundingBox?: BoundingBox.BoundingBox;
@@ -15,4 +17,21 @@ export function create(data: Partial<SceneViewSummary> = {}): SceneViewSummary {
     visibleSummary: data.visibleSummary ?? { count: 0 },
     selectedVisibleSummary: data.selectedVisibleSummary ?? { count: 0 },
   };
+}
+
+export function copySummaryIfInvalid(current: Frame, previous?: Frame): Frame {
+  return isInvalid(current.scene.sceneViewSummary)
+    ? current.copy({
+        scene: current.scene.copy({
+          sceneViewSummary: previous?.scene.sceneViewSummary,
+        }),
+      })
+    : current;
+}
+
+function isInvalid(summary: SceneViewSummary): boolean {
+  return (
+    summary.selectedVisibleSummary.count === -1 ||
+    summary.visibleSummary.count === -1
+  );
 }

--- a/packages/viewer/src/lib/types/sceneViewSummary.ts
+++ b/packages/viewer/src/lib/types/sceneViewSummary.ts
@@ -31,7 +31,7 @@ export function copySummaryIfInvalid(current: Frame, previous?: Frame): Frame {
 
 function isInvalid(summary: SceneViewSummary): boolean {
   return (
-    summary.selectedVisibleSummary.count === -1 ||
-    summary.visibleSummary.count === -1
+    summary.visibleSummary?.boundingBox == null ||
+    summary.selectedVisibleSummary?.boundingBox == null
   );
 }


### PR DESCRIPTION
## Summary

Adds support for ignoring "invalid" display list summaries on incoming frames, instead copying the previous frame's summary. This corrects a case on reconnects where the new FrameStream had not received a summary, and would send an empty set of visible/selected items rather than the current counts/bounds.

## Test Plan

- Verify that the `sceneViewSummary` property on the `viewer.frame` maintains its state across reconnects
- Verify that the `sceneViewSummary` property is updated after a reconnect if a selection/visibility change is made

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

https://github.com/Vertexvis/frame-streaming-service/pull/339
