### PR TITLE
[PLAT-2801] Wait for connected state when retrieving a Scene

### DIFF
--- a/packages/viewer/src/components/viewer/utils.ts
+++ b/packages/viewer/src/components/viewer/utils.ts
@@ -1,5 +1,7 @@
 import { Color } from '@vertexvis/utils';
 
+export const DEFAULT_VIEWER_SCENE_WAIT_MS = 15000;
+
 export function getElementBackgroundColor(
   element: HTMLElement
 ): Color.Color | undefined {

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -18,6 +18,7 @@ import { random } from '../../testing';
 import { makeImagePng } from '../../testing/fixtures';
 import { triggerResizeObserver } from '../../testing/resizeObserver';
 import {
+  gracefulReconnect,
   key1,
   key2,
   loadViewerStreamKey,
@@ -743,6 +744,34 @@ describe('vertex-viewer', () => {
           }),
         })
       );
+    });
+  });
+
+  describe('scene', () => {
+    it('handles reconnect behavior', async () => {
+      const { stream, ws } = makeViewerStream();
+      const viewer = await newViewerSpec({
+        template: () => (
+          <vertex-viewer
+            clientId={clientId}
+            stream={stream}
+            resizeDebounce={1000}
+          />
+        ),
+      });
+
+      await loadViewerStreamKey(key1, { viewer, stream, ws }, { token });
+
+      await Async.delay(1);
+
+      const result = await gracefulReconnect(
+        { viewer, stream, ws },
+        {
+          beforeReconnect: async () => await viewer.scene(),
+        }
+      );
+
+      expect(result).toBeDefined();
     });
   });
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -77,7 +77,7 @@ import {
   StencilBufferManager,
   Viewport,
 } from '../../lib/types';
-import { Frame } from '../../lib/types/frame';
+import { Frame, FrameScene } from '../../lib/types/frame';
 import { FrameCameraType } from '../../lib/types/frameCamera';
 import {
   getElementBackgroundColor,

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -79,6 +79,7 @@ import {
 import { Frame } from '../../lib/types/frame';
 import { FrameCameraType } from '../../lib/types/frameCamera';
 import {
+  DEFAULT_VIEWER_SCENE_WAIT_MS,
   getElementBackgroundColor,
   getElementBoundingClientRect,
 } from './utils';
@@ -1507,7 +1508,7 @@ export class Viewer {
         setTimeout(() => {
           disposable.dispose();
           reject(new Error('Timed out waiting for connected state.'));
-        }, 15000);
+        }, DEFAULT_VIEWER_SCENE_WAIT_MS);
       });
     }
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -77,7 +77,7 @@ import {
   StencilBufferManager,
   Viewport,
 } from '../../lib/types';
-import { Frame, FrameScene } from '../../lib/types/frame';
+import { Frame } from '../../lib/types/frame';
 import { FrameCameraType } from '../../lib/types/frameCamera';
 import {
   getElementBackgroundColor,

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -29,7 +29,6 @@ import { cssCursor } from '../../lib/dom';
 import { Environment } from '../../lib/environment';
 import {
   ComponentInitializationError,
-  IllegalStateError,
   InteractionHandlerError,
   ViewerInitializationError,
 } from '../../lib/errors';

--- a/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
+++ b/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
@@ -7,7 +7,7 @@ import { FrameCamera } from '../types';
 import { KeyInteraction } from './keyInteraction';
 import { TapEventDetails } from './tapEventDetails';
 
-type SceneProvider = () => Scene;
+type SceneProvider = () => Promise<Scene>;
 
 export class FlyToPositionKeyInteraction
   implements KeyInteraction<TapEventDetails>
@@ -37,7 +37,7 @@ export class FlyToPositionKeyInteraction
       hitResult.hitItems.hits.length > 0 &&
       hitResult.hitItems.hits[0].hitPoint != null
     ) {
-      const camera = this.sceneProvider().camera();
+      const camera = (await this.sceneProvider()).camera();
       const hit = hitResult.hitItems.hits[0];
 
       if (

--- a/packages/viewer/src/lib/interactions/interactionApi.ts
+++ b/packages/viewer/src/lib/interactions/interactionApi.ts
@@ -23,7 +23,7 @@ import {
 } from '../types';
 import { TapEventDetails, TapEventKeys } from './tapEventDetails';
 
-export type SceneProvider = () => Scene;
+export type SceneProvider = () => Promise<Scene>;
 
 export type InteractionConfigProvider = () => Interactions.InteractionConfig;
 
@@ -204,7 +204,7 @@ export abstract class InteractionApi {
   public async beginInteraction(): Promise<void> {
     if (!this.isInteracting()) {
       this.interactionStartedEmitter.emit();
-      this.currentCamera = this.getScene().camera();
+      this.currentCamera = (await this.getScene()).camera();
       await this.stream.beginInteraction();
     }
   }
@@ -218,7 +218,7 @@ export abstract class InteractionApi {
    */
   public async transformCamera(t: CameraTransform): Promise<void> {
     if (this.isInteracting()) {
-      const scene = this.getScene();
+      const scene = await this.getScene();
       const viewport = this.getViewport();
       const frame = this.getFrame();
       const depthBuffer = await frame?.depthBuffer();
@@ -346,7 +346,7 @@ export abstract class InteractionApi {
    * new image for the updated scene.
    */
   public async viewAll(): Promise<void> {
-    await this.getScene().camera().viewAll().render();
+    await (await this.getScene()).camera().viewAll().render();
   }
 
   /**
@@ -600,7 +600,7 @@ export abstract class InteractionApi {
   public async hitItems(
     pt: Point.Point
   ): Promise<vertexvis.protobuf.stream.IHit[]> {
-    const res = await this.getScene().raycaster().hitItems(pt);
+    const res = await (await this.getScene()).raycaster().hitItems(pt);
     return res?.hits ?? [];
   }
 

--- a/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
+++ b/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
@@ -238,7 +238,7 @@ export class InteractionApiOrthographic extends InteractionApi {
     t: CameraTransform<OrthographicCamera>
   ): Promise<void> {
     if (this.isInteracting()) {
-      const scene = this.getScene();
+      const scene = await this.getScene();
       const viewport = this.getViewport();
       const frame = this.getFrame();
       const depthBuffer = await frame?.depthBuffer();

--- a/packages/viewer/src/lib/interactions/interactionApiPerspective.ts
+++ b/packages/viewer/src/lib/interactions/interactionApiPerspective.ts
@@ -77,7 +77,7 @@ export class InteractionApiPerspective extends InteractionApi {
     t: CameraTransform<PerspectiveCamera>
   ): Promise<void> {
     if (this.isInteracting()) {
-      const scene = this.getScene();
+      const scene = await this.getScene();
       const viewport = this.getViewport();
       const frame = this.getFrame();
       const depthBuffer = await frame?.depthBuffer();


### PR DESCRIPTION
## Summary

Updates the `scene()` method of the `<vertex-viewer>` to support requesting a scene when the stream is not in a `connected` state. With this change, calling the `scene()` method will wait up to 15 seconds before rejecting to allow for the call to succeed in the case that the method is called while in a `reconnecting` state.

## Test Plan

- Verify that interacting with the scene during a reconnect succeeds
  - An easy test case here is performing a `tap`, then using the `scene()` method to perform a ray-pick + select
- Verify that beginning and ending camera interactions continue to work as expected (updated to handle the async retrieval of the scene)

## Release Notes

N/A

## Possible Regressions

Camera interactions

## Dependencies

N/A
