### PR TITLE
[PLAT-2763] Only dispose scene-tree subscription once

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
+++ b/packages/viewer/src/components/scene-tree/lib/__tests__/controller.spec.ts
@@ -463,7 +463,7 @@ describe(SceneTreeController, () => {
       expect(pages).toEqual([]);
     });
 
-    it('cancels subscription when disconnected', async () => {
+    it('does not cancel subscription when disconnected', async () => {
       const { controller, stream, client } = createController(10);
       (client.getTree as jest.Mock).mockImplementation(
         mockGrpcUnaryResult(createGetTreeResponse(10, 100))
@@ -475,7 +475,7 @@ describe(SceneTreeController, () => {
       initiateHandshakeOnStream(stream);
 
       controller.disconnect();
-      expect(cancel).toHaveBeenCalled();
+      expect(cancel).not.toHaveBeenCalled();
     });
 
     it('resubscribes on server termination', async () => {

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -412,10 +412,6 @@ export class SceneTreeController {
     }
 
     const { connection } = this.state;
-    if (connection.type === 'connected') {
-      connection.subscription.dispose();
-    }
-
     this.updateState({
       connection: {
         type: 'disconnected',


### PR DESCRIPTION
## Summary
We were calling _dispose_ on the scene tree connection twice, which was throwing errors in scene-tree.  Therefore, this PR removes the duplicate call.

## Test Plan
Verify that the scene tree works as expected. Particularly, verify that scene view states can be applied to an instance of the scene tree.

## Release Notes
None

## Possible Regressions
Scene-tree connection

## Dependencies
None