### PR TITLE
[PLAT-3145] Add Watch to specific row props

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
@@ -8,6 +8,7 @@ import {
   Method,
   Prop,
   State,
+  Watch,
 } from '@stencil/core';
 import { Point } from '@vertexvis/geometry';
 import {
@@ -270,6 +271,13 @@ export class SceneTreeTableLayout {
     this.resizeObserver?.disconnect();
     this.stateMap.columnWidths = [];
     this.stateMap.columnWidthPercentages = [];
+  }
+
+  @Watch('rows')
+  @Watch('totalRows')
+  @Watch('rowHeight')
+  protected async handleViewportRowsPropsChanged(): Promise<void> {
+    await this.computeAndUpdateViewportRows();
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a `@Watch` for specific `row` properties (`rows`, `totalRows`, and `rowHeight`) that impact the rendering of the viewport start/end indices. This is normally done as a part of `componentWillRender`, but some of the changes to these values appear to not have been triggering a rerender. This was resulting in a potential spinner condition where the viewport indices never correctly got updated, and resulted in the first row not being rendered. This appears to have been specifically an issue with the `viewer-react` components, as I did not see this purely using the SDK elements.

## Test Plan

- Verify that the spinner does not appear in Connect

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
