### PR TITLE
[PLAT-3145] Fix unintentional idle reconnect reduction

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -139,7 +139,7 @@ type ConnectionState =
  * notifying the view about state changes.
  */
 export class SceneTreeController {
-  private static IDLE_RECONNECT_IN_SECONDS = 4 * 1;
+  private static IDLE_RECONNECT_IN_SECONDS = 4 * 60;
   private static LOST_CONNECTION_RECONNECT_IN_SECONDS = 2;
   private static MAX_SUBSCRIPTION_RETRY_COUNT = 2;
 


### PR DESCRIPTION
## Summary

Fixes an accidental leftover testing change with #516.

## Test Plan

- Verify the scene-tree reconnects every 4 minutes

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
