### PR TITLE
[PLAT-3145] Subscribe before first GetTree

### DIFF
--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -290,10 +290,10 @@ export class SceneTreeController {
     try {
       this.log('Scene tree controller connecting.');
 
-      const [, stream] = await Promise.all([
-        this.fetchPage(0),
-        this.subscribe(),
-      ]);
+      // Ensure we have a subscription prior to attempting to get the first page
+      // to make sure we receive any ListChange that comes through
+      const stream = await this.subscribe();
+      await this.fetchPage(0);
 
       if (this.state.connection.type !== 'cancelled') {
         this.updateState({


### PR DESCRIPTION
## Summary

Updates the initial setup of the scene-tree controller to wait for the `subscribe()` call prior to attempting to fetch the first page. This appears to have been causing an issue where the `ListChange` sent by STS was getting lost (no `listener` available to send the change to) and the initial `GetTree` was receiving an empty list.

## Test Plan

- Verify that the tree does not appear blank on initial load
- Verify that the tree spinner properly resolves on initial load

## Release Notes

N/A

## Possible Regressions

Tree connections

## Dependencies

N/A
