### PR TITLE
[PLAT-3131] Fix transform widget disconnect + more scene-tree spinners

### DIFF
--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.spec.tsx
@@ -203,13 +203,18 @@ describe('vertex-viewer-transform-widget', () => {
       '#000000',
       '#000000'
     );
-    const beginSpy = jest.spyOn(stream, 'beginInteraction');
+    const beginSpy = jest
+      .spyOn(stream, 'beginInteraction')
+      .mockReturnValue(Promise.resolve({}));
     const updateSpy = jest.spyOn(stream, 'updateInteraction');
     const endSpy = jest
       .spyOn(stream, 'endInteraction')
       .mockReturnValue(Promise.resolve({}));
 
     (convertCanvasPointToWorld as jest.Mock).mockImplementation(() =>
+      Vector3.create(1, 1, 1)
+    );
+    (convertPointToCanvas as jest.Mock).mockImplementation(() =>
       Vector3.create(1, 1, 1)
     );
     (computeUpdatedTransform as jest.Mock).mockImplementation(() =>
@@ -221,6 +226,8 @@ describe('vertex-viewer-transform-widget', () => {
       ?.dispatchEvent(new MouseEvent('pointerdown'));
 
     window.dispatchEvent(new MouseEvent('pointermove'));
+
+    await page.waitForChanges();
 
     expect(beginSpy).toHaveBeenCalled();
     expect(updateSpy).toHaveBeenCalledWith(
@@ -311,7 +318,9 @@ describe('vertex-viewer-transform-widget', () => {
       '#000000',
       '#000000'
     );
-    const beginSpy = jest.spyOn(stream, 'beginInteraction');
+    const beginSpy = jest
+      .spyOn(stream, 'beginInteraction')
+      .mockReturnValue(Promise.resolve({}));
     const updateSpy = jest.spyOn(stream, 'updateInteraction');
     const endSpy = jest
       .spyOn(stream, 'endInteraction')
@@ -332,6 +341,8 @@ describe('vertex-viewer-transform-widget', () => {
       ?.dispatchEvent(new MouseEvent('pointerdown'));
 
     window.dispatchEvent(new MouseEvent('pointermove'));
+
+    await page.waitForChanges();
 
     expect(beginSpy).toHaveBeenCalled();
     expect(updateSpy).toHaveBeenCalledWith(
@@ -538,9 +549,13 @@ describe('vertex-viewer-transform-widget', () => {
       '#000000'
     );
 
+    jest.spyOn(stream, 'beginInteraction').mockReturnValue(Promise.resolve({}));
     const endSpy = jest.spyOn(stream, 'endInteraction');
 
     (convertCanvasPointToWorld as jest.Mock).mockImplementation(() =>
+      Vector3.create(1, 1, 1)
+    );
+    (convertPointToCanvas as jest.Mock).mockImplementation(() =>
       Vector3.create(1, 1, 1)
     );
     (computeUpdatedTransform as jest.Mock).mockImplementation(() =>
@@ -550,6 +565,10 @@ describe('vertex-viewer-transform-widget', () => {
     widget.shadowRoot
       ?.querySelector('canvas')
       ?.dispatchEvent(new MouseEvent('pointerdown'));
+
+    window.dispatchEvent(new MouseEvent('pointermove'));
+
+    await page.waitForChanges();
 
     (mockTransformWidget.updateTransform as jest.Mock).mockClear();
     widget.position = undefined;

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -377,7 +377,6 @@ export class ViewerTransformWidget {
         this.currentTransform
       );
 
-      this.controller?.beginTransform();
       this.interactionStarted.emit();
 
       window.removeEventListener('pointermove', this.handlePointerMove);
@@ -400,6 +399,10 @@ export class ViewerTransformWidget {
       this.viewer.frame != null &&
       this.position != null
     ) {
+      // Begin the transform on the first `pointermove` event as opposed to the
+      // `pointerdown` to prevent accidental no-op transforms (identity matrix).
+      await this.controller?.beginTransform();
+
       const currentCanvas = convertPointToCanvas(
         Point.create(event.clientX, event.clientY),
         canvasBounds

--- a/packages/viewer/src/testing/grpc.ts
+++ b/packages/viewer/src/testing/grpc.ts
@@ -1,21 +1,23 @@
 export function mockGrpcUnaryResult(
-  result: unknown
+  result: unknown,
+  timeout = 10
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): (...args: any[]) => unknown {
   return (_, __, handler) => {
     setTimeout(() => {
       handler(null, result);
-    }, 10);
+    }, timeout);
   };
 }
 
 export function mockGrpcUnaryError(
-  error: unknown
+  error: unknown,
+  timeout = 10
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): (...args: any[]) => unknown {
   return (_, __, handler) => {
     setTimeout(() => {
       handler(error);
-    }, 10);
+    }, timeout);
   };
 }


### PR DESCRIPTION
## Summary

- Fixes an issue with the transform widget where it could become "disconnected" from a part if the handles were double-clicked
- Fixes an issue with the scene-tree where the response to a `ListChange` would not always attempt to fetch the first page of the tree
- Fixes an issue where a second subscription would be set up (in response to a handshake timeout) if the handshake was received on a subscription prior to the `GetTree` response

Transform widget behavior before:


https://github.com/Vertexvis/vertex-web-sdk/assets/5252480/3d847cdb-f3cd-4301-8729-46de9025235f



Transform widget behavior after:

https://github.com/Vertexvis/vertex-web-sdk/assets/5252480/93f63385-4cb4-444b-ae13-b991253e0407


## Test Plan

- Verify that double-clicking the handle on a transform widget then performing a transform works as expected
- Verify that the spinner doesn't appear (or resolves) when loading the scene-tree for the first time in a SceneView
- Verify that only one subscription is set up when initializing the tree and no `Failed to subscribe within the allotted timeout.` is logged

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
