### PR TITLE
[PLAT-2348] Support changing frame background color for an active stream

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.10.4"
+    "@vertexvis/frame-streaming-protos": "^0.10.5"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.10.4",
+    "@vertexvis/frame-streaming-protos": "^0.10.5",
     "@vertexvis/geometry": "0.18.1",
     "@vertexvis/html-templates": "0.18.1",
     "@vertexvis/scene-tree-protos": "^0.1.18",

--- a/packages/viewer/src/components/viewer/utils.ts
+++ b/packages/viewer/src/components/viewer/utils.ts
@@ -12,3 +12,12 @@ export function getElementBackgroundColor(
 export function getElementBoundingClientRect(element: HTMLElement): ClientRect {
   return element.getBoundingClientRect();
 }
+
+export function getElementPropertyValue(
+  element: HTMLElement,
+  property: string
+): string | undefined {
+  const styles = window.getComputedStyle(element);
+  const value = styles.getPropertyValue(property);
+  return value !== '' ? value : undefined;
+}

--- a/packages/viewer/src/components/viewer/viewer.css
+++ b/packages/viewer/src/components/viewer/viewer.css
@@ -27,7 +27,6 @@
   width: 100%;
   height: 100%;
   position: relative;
-  background: #ffffff;
 }
 .enable-pointer-events {
   touch-action: none;
@@ -37,7 +36,6 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: #ffffff;
 }
 
 .error-message {

--- a/packages/viewer/src/components/viewer/viewer.css
+++ b/packages/viewer/src/components/viewer/viewer.css
@@ -27,7 +27,7 @@
   width: 100%;
   height: 100%;
   position: relative;
-  background: var(--image-background, var(--viewer-background, #ffffff));
+  background: #ffffff;
 }
 .enable-pointer-events {
   touch-action: none;
@@ -37,7 +37,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: var(--viewer-background, #ffffff);
+  background: #ffffff;
 }
 
 .error-message {

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -250,6 +250,67 @@ describe('vertex-viewer', () => {
         })
       );
     });
+
+    it('updates the stream with correct stream attributes', async () => {
+      (getElementBackgroundColor as jest.Mock).mockReturnValue(
+        Color.fromHexString('#00ffff')
+      );
+
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      const mutationObserver = (global as any).MutationObserver;
+      let observerFns: VoidFunction[] = [];
+      (global as any).MutationObserver = class {
+        public disconnect = jest.fn();
+        public observe = jest.fn();
+
+        public constructor(fn: VoidFunction) {
+          observerFns = [...observerFns, fn];
+        }
+      };
+      /* eslint-enable @typescript-eslint/no-explicit-any */
+
+      const { stream, ws } = makeViewerStream();
+      const viewer = await newViewerSpec({
+        template: () => (
+          <vertex-viewer
+            clientId={clientId}
+            stream={stream}
+            featureLines={{ width: 1 }}
+            selectionHighlighting={{
+              lineWidth: 2,
+              color: '#fff222',
+              opacity: 0.3,
+            }}
+            featureHighlighting={{ highlightColor: 0xff0000 }}
+            depthBuffers="all"
+            featureMaps="all"
+          />
+        ),
+      });
+
+      const update = jest.spyOn(stream, 'update');
+      await loadViewerStreamKey(key1, { viewer, stream, ws });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).MutationObserver = mutationObserver;
+
+      observerFns.forEach((fn) => fn());
+
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          frameBgColor: expect.objectContaining({ r: 0, g: 255, b: 255 }),
+          streamAttributes: expect.objectContaining({
+            frames: {
+              frameBackgroundColor: expect.objectContaining({
+                r: 0,
+                g: 255,
+                b: 255,
+              }),
+            },
+          }),
+        })
+      );
+    });
   });
 
   describe(Viewer.prototype.unload, () => {

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -7,7 +7,7 @@ import { h } from '@stencil/core';
 import { NewSpecPageOptions, SpecPage } from '@stencil/core/internal';
 import { newSpecPage } from '@stencil/core/testing';
 import { Dimensions } from '@vertexvis/geometry';
-import { Async, Color } from '@vertexvis/utils';
+import { Async } from '@vertexvis/utils';
 
 import { MouseInteractionHandler } from '../../lib/interactions/mouseInteractionHandler';
 import { TapInteractionHandler } from '../../lib/interactions/tapInteractionHandler';
@@ -25,10 +25,7 @@ import {
   makeViewerStream,
   receiveFrame,
 } from '../../testing/viewer';
-import {
-  getElementBackgroundColor,
-  getElementBoundingClientRect,
-} from './utils';
+import { getElementBoundingClientRect, getElementPropertyValue } from './utils';
 import { Viewer } from './viewer';
 
 describe('vertex-viewer', () => {
@@ -206,9 +203,7 @@ describe('vertex-viewer', () => {
     });
 
     it('loads stream with correct stream attributes', async () => {
-      (getElementBackgroundColor as jest.Mock).mockReturnValue(
-        Color.fromHexString('#0000ff')
-      );
+      (getElementPropertyValue as jest.Mock).mockReturnValue('#0000ff');
 
       const { stream, ws } = makeViewerStream();
       const viewer = await newViewerSpec({
@@ -252,9 +247,7 @@ describe('vertex-viewer', () => {
     });
 
     it('updates the stream with correct stream attributes', async () => {
-      (getElementBackgroundColor as jest.Mock).mockReturnValue(
-        Color.fromHexString('#00ffff')
-      );
+      (getElementPropertyValue as jest.Mock).mockReturnValue('#00ffff');
 
       /* eslint-disable @typescript-eslint/no-explicit-any */
       const mutationObserver = (global as any).MutationObserver;

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -57,7 +57,7 @@ import {
   measureCanvasRenderer,
 } from '../../lib/rendering';
 import { Scene } from '../../lib/scenes/scene';
-import { readDOM, writeDOM } from '../../lib/stencil';
+import { writeDOM } from '../../lib/stencil';
 import {
   getStorageEntry,
   StorageKeys,
@@ -82,7 +82,6 @@ import { Frame } from '../../lib/types/frame';
 import { FrameCameraType } from '../../lib/types/frameCamera';
 import {
   DEFAULT_VIEWER_SCENE_WAIT_MS,
-  getElementBackgroundColor,
   getElementBoundingClientRect,
   getElementPropertyValue,
 } from './utils';

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -414,6 +414,7 @@ export class Viewer {
   private canvasRenderer!: CanvasRenderer;
 
   private mutationObserver?: MutationObserver;
+  private styleObserver?: MutationObserver;
   private resizeObserver?: ResizeObserver;
   private isResizing?: boolean;
   private isResizeUpdate?: boolean;
@@ -930,6 +931,12 @@ export class Viewer {
       childList: true,
       subtree: true,
     });
+
+    this.styleObserver = new MutationObserver((_) => this.syncViewerStyles());
+    this.styleObserver.observe(this.hostElement, {
+      attributes: true,
+      attributeFilter: ['style'],
+    });
   }
 
   private injectViewerApi(): void {
@@ -953,6 +960,19 @@ export class Viewer {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (node as any).viewer = this.hostElement;
       });
+  }
+
+  private syncViewerStyles(): void {
+    const backgroundColor = this.getBackgroundColor();
+
+    this.stream?.update({
+      frameBgColor: backgroundColor,
+      streamAttributes: {
+        frames: {
+          frameBackgroundColor: backgroundColor,
+        },
+      },
+    });
   }
 
   private calculateComponentDimensions(): void {

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -1167,48 +1167,17 @@ export class Viewer {
   }
 
   private updateViewerBackground(): void {
-    const imageBackground = getElementPropertyValue(
-      this.hostElement,
-      '--image-background'
-    );
-    const viewerBackground = getElementPropertyValue(
-      this.hostElement,
-      '--viewer-background'
-    );
+    const backgroundColor = this.getBackgroundColor();
 
     writeDOM(() => {
       this.viewerContainerElement?.style.setProperty(
         'background',
-        viewerBackground ?? '#ffffff'
+        backgroundColor != null ? Color.toHexString(backgroundColor) : '#ffffff'
       );
       this.canvasContainerElement?.style.setProperty(
         'background',
-        imageBackground ?? viewerBackground ?? '#ffffff'
+        backgroundColor != null ? Color.toHexString(backgroundColor) : '#ffffff'
       );
-    });
-
-    readDOM(() => {
-      const hostStyles = window.getComputedStyle(this.hostElement);
-      const viewerBackgroundProperty = hostStyles.getPropertyValue(
-        '--viewer-background'
-      );
-      const imageBackgroundProperty =
-        hostStyles.getPropertyValue('--image-background');
-      const viewerBackground =
-        viewerBackgroundProperty !== '' ? viewerBackgroundProperty : undefined;
-      const imageBackground =
-        imageBackgroundProperty !== '' ? imageBackgroundProperty : undefined;
-
-      writeDOM(() => {
-        this.viewerContainerElement?.style.setProperty(
-          'background',
-          viewerBackground ?? '#ffffff'
-        );
-        this.canvasContainerElement?.style.setProperty(
-          'background',
-          imageBackground ?? viewerBackground ?? '#ffffff'
-        );
-      });
     });
   }
 
@@ -1424,7 +1393,7 @@ export class Viewer {
 
       return propertyColor != null
         ? Color.fromCss(propertyColor)
-        : getElementBackgroundColor(this.canvasContainerElement);
+        : Color.create(255, 255, 255);
     }
   }
 

--- a/packages/viewer/src/interfaces.d.ts
+++ b/packages/viewer/src/interfaces.d.ts
@@ -26,6 +26,10 @@ export interface PhantomOptions {
   opacity?: number;
 }
 
+export interface FrameOptions {
+  frameBackgroundColor?: Color3;
+}
+
 export interface HTMLDomRendererPositionableElement {
   position: Vector3.Vector3;
   positionJson: string;
@@ -47,4 +51,5 @@ export interface StreamAttributes {
   featureMaps?: FrameType;
   experimentalRenderingOptions?: string;
   selectionHighlighting?: SelectionHighlightingOptions;
+  frames?: FrameOptions;
 }

--- a/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
+++ b/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
@@ -1,4 +1,5 @@
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
+import { Color } from '@vertexvis/utils';
 
 import { toPbStreamAttributes } from '../streamAttributes';
 
@@ -126,6 +127,25 @@ describe(toPbStreamAttributes, () => {
           highlightColor: { r: 255, g: 0, b: 0 },
           occludedOpacity: { value: 0.5 },
           outline: { lineWidth: 2, lineColor: { r: 0, g: 255, b: 0 } },
+        },
+      });
+    });
+  });
+
+  describe('frame options', () => {
+    it('should support changing the background color', () => {
+      const res = toPbStreamAttributes({
+        frames: {
+          frameBackgroundColor: Color.create(1, 2, 3),
+        },
+      });
+      expect(res).toMatchObject({
+        frames: {
+          frameBackgroundColor: {
+            r: 1,
+            g: 2,
+            b: 3,
+          },
         },
       });
     });

--- a/packages/viewer/src/lib/mappers/streamAttributes.ts
+++ b/packages/viewer/src/lib/mappers/streamAttributes.ts
@@ -5,6 +5,7 @@ import { Mapper as M } from '@vertexvis/utils';
 import {
   FeatureHighlightOptions,
   FeatureLineOptions,
+  FrameOptions,
   FrameType,
   PhantomOptions,
   SelectionHighlightingOptions,
@@ -106,6 +107,14 @@ const toPbExperimentalRenderingOptions: M.Func<string | undefined, string> =
     (attr) => attr
   );
 
+const toPbFrameOptions: M.Func<
+  FrameOptions | undefined,
+  vertexvis.protobuf.stream.IFrameAttributes
+> = M.defineMapper(
+  M.read(M.ifDefined(M.mapProp('frameBackgroundColor', M.ifDefined(toPbRGBi)))),
+  ([frameBackgroundColor]) => ({ frameBackgroundColor })
+);
+
 export const toPbStreamAttributes: M.Func<
   StreamAttributes,
   vertexvis.protobuf.stream.IStreamAttributes
@@ -118,9 +127,10 @@ export const toPbStreamAttributes: M.Func<
     M.mapProp('featureHighlighting', toPbFeatureHighlight),
     M.mapProp('featureMaps', toPbFrameType),
     M.mapProp('experimentalRenderingOptions', toPbExperimentalRenderingOptions),
-    M.mapProp('selectionHighlighting', toPbSelectionHighlighting)
+    M.mapProp('selectionHighlighting', toPbSelectionHighlighting),
+    M.mapProp('frames', toPbFrameOptions)
   ),
-  ([db, pi, ndl, fl, fh, fm, ero, hs]) => {
+  ([db, pi, ndl, fl, fh, fm, ero, hs, fa]) => {
     const value = {
       depthBuffers: db,
       phantomItems: pi,
@@ -130,6 +140,7 @@ export const toPbStreamAttributes: M.Func<
       featureMaps: fm,
       experimentalRenderingOptions: ero,
       selectionHighlighting: hs,
+      frames: fa,
     };
 
     return value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,10 +2153,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.10.4":
-  version "0.10.4"
-  resolved "https://registry.npmjs.org/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.10.4.tgz#e5957305ce49ec02b79b62dad7321998b6be38c7"
-  integrity sha512-GGcA06hcdT9I4UFYqiOW6O2hXXh2tL7qpPHFx5hp5IFmNPgMfBgo/ELnYUnz2gIHQu3xaBGOxLC+4NCyPoIaxg==
+"@vertexvis/frame-streaming-protos@^0.10.5":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.10.5.tgz#dec60544c23ac6ff58da3a009097bae923ebaa02"
+  integrity sha512-00FtYhRDoNxzhNMahRB8pmH/MAp6HLSrGgCYVo0TdE7v9FT1FCQBHzh+1cvMhQ5cxiiADPmfImrmBTsS30fTWw==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary

Adds support for changing the frame background color after a stream has already been established. Prior to this change, it was only possible to change the frame background color when starting a stream or reconnecting to a stream.

As part of this work, the way the `background` property is set on the `<vertex-viewer>` containers has been changed to sync after frames are drawn, rather than having the value immediately reflected. This prevents the state where the background color of the container has changed, but we haven't received the updated image with the matching background color.


https://github.com/Vertexvis/vertex-web-sdk/assets/5252480/f074f55d-10df-4335-84b2-6977b4b495e8


## Test Plan

- Verify that changing the `--viewer-background` and `--image-background` CSS properties updates the background color of the image
- Verify that by default the background color is still `#ffffff`
- Verify that removing the `--viewer-background` and `--image-background` CSS properties (or setting them to invalid values) changes the background color back to `#ffffff`

## Release Notes

N/A

## Possible Regressions

Viewer background colors

## Dependencies

https://github.com/Vertexvis/frame-streaming-service/pull/361
