### PR TITLE
[PLAT-3234] Apply phantom state of SceneViewState

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.10.6"
+    "@vertexvis/frame-streaming-protos": "^0.10.7"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.10.5"
+    "@vertexvis/frame-streaming-protos": "^0.10.6"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.10.5",
+    "@vertexvis/frame-streaming-protos": "^0.10.6",
     "@vertexvis/geometry": "0.19.0",
     "@vertexvis/html-templates": "0.19.0",
     "@vertexvis/scene-tree-protos": "^0.1.18",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.10.6",
+    "@vertexvis/frame-streaming-protos": "^0.10.7",
     "@vertexvis/geometry": "0.19.0",
     "@vertexvis/html-templates": "0.19.0",
     "@vertexvis/scene-tree-protos": "^0.1.18",

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -40,6 +40,7 @@ describe(toPbSceneViewStateFeatures, () => {
         'visibility',
         'transforms',
         'cross_section',
+        'phantom',
       ])
     ).toMatchObject([
       vertexvis.protobuf.stream.SceneViewStateFeature
@@ -54,6 +55,8 @@ describe(toPbSceneViewStateFeatures, () => {
         .SCENE_VIEW_STATE_FEATURE_TRANSFORM,
       vertexvis.protobuf.stream.SceneViewStateFeature
         .SCENE_VIEW_STATE_FEATURE_CROSS_SECTION,
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_PHANTOM,
     ]);
   });
 

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -320,6 +320,9 @@ export function toPbSceneViewStateFeatures(
       case 'cross_section':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_CROSS_SECTION;
+     case 'phantom':
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_PHANTOM;
       default:
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_INVALID;

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -320,7 +320,7 @@ export function toPbSceneViewStateFeatures(
       case 'cross_section':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_CROSS_SECTION;
-     case 'phantom':
+      case 'phantom':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_PHANTOM;
       default:

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -232,7 +232,8 @@ export type SceneViewStateFeature =
   | 'material_overrides'
   | 'selection'
   | 'transforms'
-  | 'visibility';
+  | 'visibility'
+  | 'phantom';
 
 /**
  * A class that represents the `Scene` that has been loaded into the viewer. On

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,10 +2153,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.10.5":
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.10.5.tgz#dec60544c23ac6ff58da3a009097bae923ebaa02"
-  integrity sha512-00FtYhRDoNxzhNMahRB8pmH/MAp6HLSrGgCYVo0TdE7v9FT1FCQBHzh+1cvMhQ5cxiiADPmfImrmBTsS30fTWw==
+"@vertexvis/frame-streaming-protos@^0.10.7":
+  version "0.10.7"
+  resolved "https://registry.npmjs.org/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.10.7.tgz#a5c7bfbbb11cd2af574ebeb88341ac05037d5aef"
+  integrity sha512-k1hDianBV+zEsU2gozU5VbGsxwhzQeGpC/zPLxEl5bNOGBG6TsfW8t6YTo5a6JYeB1G19E/xzvzlVOKMYx4h2A==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary
We want to add phantom state as a feature of a SceneViewState that can be applied to the current scene individually, instead of applying the full SceneViewState.

## Test Plan
Verify that a user can apply just the phantom state of a SceneViewState

## Release Notes
None

## Possible Regressions
Viewing snapshots

## Dependencies
None