### PR TITLE
[PLAT-3187] Handle view cube interactions with no geometry

### DIFF
--- a/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.spec.tsx
+++ b/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.spec.tsx
@@ -4,7 +4,7 @@ jest.mock('../../lib/rendering/imageLoaders');
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
-import { Vector3 } from '@vertexvis/geometry';
+import { BoundingBox, Vector3 } from '@vertexvis/geometry';
 
 import { loadImageBytes } from '../../lib/rendering/imageLoaders';
 import { FrameCameraBase, Orientation } from '../../lib/types';
@@ -206,6 +206,41 @@ describe('vertex-viewer-view-cube interactions', () => {
       })
     );
     expect(cameraMock.viewAll).toHaveBeenCalled();
+    expect(cameraMock.render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        animation: expect.objectContaining({
+          milliseconds: 500,
+        }),
+      })
+    );
+  });
+
+  it('performs standard view when side clicked with no visible geometry', async () => {
+    (sceneMock.boundingBox as jest.Mock).mockReturnValue(
+      BoundingBox.create(Vector3.origin(), Vector3.origin())
+    );
+
+    const page = await newSpecPage({
+      components: [ViewerViewCube],
+      template: () => <vertex-viewer-view-cube />,
+    });
+
+    page.rootInstance.viewer = viewer;
+
+    const frontEl = page.root?.shadowRoot?.querySelector(
+      '.cube-side-face-front'
+    );
+    frontEl?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+
+    await awaitScene;
+
+    expect(cameraMock.standardView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        position: Vector3.back(),
+        up: Vector3.up(),
+      })
+    );
+    expect(cameraMock.viewAll).not.toHaveBeenCalled();
     expect(cameraMock.render).toHaveBeenCalledWith(
       expect.objectContaining({
         animation: expect.objectContaining({

--- a/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.tsx
+++ b/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.tsx
@@ -160,11 +160,21 @@ export class ViewerViewCube {
             this.worldOrientation.matrix
           );
 
-          scene
-            .camera()
-            .standardView(worldStandardView)
-            .viewAll()
-            .render(animation);
+          // Check to see if any geometry is visible. If not, don't perform viewAll
+          const currentBoundingBox = scene.boundingBox();
+          if (
+            currentBoundingBox?.max != null &&
+            Vector3.isEqual(currentBoundingBox.max, Vector3.origin()) &&
+            Vector3.isEqual(currentBoundingBox.min, Vector3.origin())
+          ) {
+            scene.camera().standardView(worldStandardView).render(animation);
+          } else {
+            scene
+              .camera()
+              .standardView(worldStandardView)
+              .viewAll()
+              .render(animation);
+          }
         }
       };
     }


### PR DESCRIPTION
## Summary
Previously, we always performed a 'view all' when selecting a standard view on the view cube, which caused exceptions when no geometry was visible.  Therefore, this PR adjusts the standard view interactions to only perform a 'view all' when geometry is visible.  If there's no visible geometry, the default camera position for the view will be used instead.

## Test Plan
Verify view cube interactions work as expected, particularly when there's no visible geometry

## Release Notes
None

## Possible Regressions
Interacting with the view cube

## Dependencies
None