### PR TITLE
[PLAT-3386] Always request images with at least 1x1 dimensions

### DIFF
--- a/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
+++ b/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
@@ -231,6 +231,39 @@ describe(ViewerStream, () => {
       await expect(failure).resolves.toBeDefined();
       startStream.mockRestore();
     });
+
+    it('always requests at least a 1x1 pixel', async () => {
+      const { stream, ws } = makeStreamBase();
+
+      const startSpy = jest
+        .spyOn(stream, 'startStream')
+        .mockResolvedValue(Fixtures.Responses.startStream().response);
+      jest
+        .spyOn(stream, 'syncTime')
+        .mockResolvedValue(Fixtures.Responses.syncTime().response);
+
+      const connecting = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connecting' && s.resource.resource.id === '123'
+      );
+
+      stream.load(urn123, clientId, deviceId, config);
+      await expect(connecting).resolves.toBeDefined();
+
+      await simulateFrame(ws);
+      const connected = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connected'
+      );
+      await expect(connected).resolves.toBeDefined();
+
+      expect(startSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dimensions: expect.objectContaining({
+            width: 1,
+            height: 1,
+          }),
+        })
+      );
+    });
   });
 
   describe('reconnect', () => {
@@ -361,6 +394,46 @@ describe(ViewerStream, () => {
 
       await expect(reconnected).resolves.toBe(false);
     });
+
+    it('always requests at least a 1x1 pixel', async () => {
+      const { stream, ws } = makeStreamBase();
+
+      jest
+        .spyOn(stream, 'startStream')
+        .mockResolvedValue(Fixtures.Responses.startStream().response);
+      jest
+        .spyOn(stream, 'syncTime')
+        .mockResolvedValue(Fixtures.Responses.syncTime().response);
+      const reconnectSpy = jest
+        .spyOn(stream, 'reconnect')
+        .mockResolvedValue(Fixtures.Responses.reconnect().response);
+
+      const closeWs = jest.spyOn(ws, 'close');
+
+      const connected123 = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connected' && s.resource.resource.id === '123'
+      );
+      stream.load(urn123, clientId, deviceId, config);
+      await simulateFrame(ws);
+      await connected123;
+
+      const reconnected123 = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connected' && s.resource.resource.id === '123'
+      );
+      ws.receiveMessage(encode(Fixtures.Requests.gracefulReconnect()));
+
+      expect(closeWs).toHaveBeenCalled();
+      await expect(reconnected123).resolves.toBeDefined();
+
+      expect(reconnectSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dimensions: expect.objectContaining({
+            width: 1,
+            height: 1,
+          }),
+        })
+      );
+    });
   });
 
   describe('refresh token', () => {
@@ -447,12 +520,18 @@ describe(ViewerStream, () => {
   });
 
   function makeStream(): { stream: ViewerStream; ws: WebSocketClientMock } {
+    const { stream, ws } = makeStreamBase();
+    stream.update({ dimensions, streamAttributes, frameBgColor });
+
+    return { stream, ws };
+  }
+
+  function makeStreamBase(): { stream: ViewerStream; ws: WebSocketClientMock } {
     const ws = new WebSocketClientMock();
     const stream = new ViewerStream(ws, {
       tokenRefreshOffsetInSeconds: 0,
       offlineThresholdInSeconds: offlineReconnectThresholdInMs / 1000,
     });
-    stream.update({ dimensions, streamAttributes, frameBgColor });
 
     return { stream, ws };
   }

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -164,7 +164,7 @@ export class ViewerStream extends StreamApi {
     if (fields.dimensions != null && fields.dimensions !== this.dimensions) {
       this.dimensions = fields.dimensions;
       this.ifState('connected', () =>
-        this.updateDimensions({ dimensions: this.dimensions })
+        this.updateDimensions({ dimensions: this.getDimensions() })
       );
     }
 

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -387,7 +387,7 @@ export class ViewerStream extends StreamApi {
     const res = fromPbStartStreamResponseOrThrow(
       await this.startStream({
         streamKey: { value: resource.resource.id },
-        dimensions: this.dimensions,
+        dimensions: this.getDimensions(),
         frameBackgroundColor: toPbColorOrThrow(this.frameBgColor),
         streamAttributes: toPbStreamAttributesOrThrow(this.streamAttributes),
         sceneViewStateId:
@@ -421,7 +421,7 @@ export class ViewerStream extends StreamApi {
     const res = fromPbReconnectResponseOrThrow(
       await this.reconnect({
         streamId: { hex: state.streamId },
-        dimensions: this.dimensions,
+        dimensions: this.getDimensions(),
         frameBackgroundColor: toPbColorOrThrow(this.frameBgColor),
         streamAttributes: toPbStreamAttributesOrThrow(this.streamAttributes),
       })
@@ -579,6 +579,15 @@ export class ViewerStream extends StreamApi {
       this.state = state;
       this.stateChanged.emit(this.state);
     }
+  }
+
+  private getDimensions(): Dimensions.Dimensions {
+    if (Dimensions.area(this.dimensions) === 0) {
+      // Ensure we always request at least a 1-pixel frame, even if the dimensions
+      // haven't been set higher than zero.
+      return Dimensions.create(1, 1);
+    }
+    return this.dimensions;
   }
 
   private ifState<T>(


### PR DESCRIPTION
## Summary

Updates the `ViewerStream` to always request images with at least 1x1 dimensions rather than requesting a zero-area image and displaying an error.

## Test Plan

- Verify that errors are not logged when a frame is requested with zero-area dimensions
  - For starting a stream and reconnecting, adding `display: none` to the viewer when initialized previously logged this error
  - For updating stream dimensions, adding `display: none` to the viewer after it has loaded initially previously logged this

## Release Notes

N/A

## Possible Regressions

Stream dimensions

## Dependencies

N/A
