### PR TITLE
[PLAT-3395] Support cancelling scene-tree filters

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -287,6 +287,10 @@ export namespace Components {
   }
   interface VertexSceneTreeSearch {
     /**
+     * Clears the current search term and clears any debounced filters.
+     */
+    clear: () => Promise<void>;
+    /**
      * The scene tree controller
      */
     controller?: SceneTreeController;

--- a/packages/viewer/src/components/scene-tree-search/readme.md
+++ b/packages/viewer/src/components/scene-tree-search/readme.md
@@ -36,6 +36,16 @@ functionality will need to be wired programmatically to
 
 ## Methods
 
+### `clear() => Promise<void>`
+
+Clears the current search term and clears any debounced filters.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `setFocus() => Promise<void>`
 
 Gives focus to the the component's internal text input.

--- a/packages/viewer/src/components/scene-tree-search/scene-tree-search.tsx
+++ b/packages/viewer/src/components/scene-tree-search/scene-tree-search.tsx
@@ -72,6 +72,7 @@ export class SceneTreeSearch {
 
   private inputEl?: HTMLInputElement;
   private onStateChangeDisposable?: Disposable;
+  private searchDisposable?: Disposable;
 
   /**
    * Gives focus to the the component's internal text input.
@@ -106,6 +107,15 @@ export class SceneTreeSearch {
    */
   protected disconnectedCallback(): void {
     this.onStateChangeDisposable?.dispose();
+  }
+
+  /**
+   * Clears the current search term and clears any debounced filters.
+   */
+  @Method()
+  public async clear(): Promise<void> {
+    this.value = '';
+    this.searchDisposable?.dispose();
   }
 
   /**
@@ -183,7 +193,12 @@ export class SceneTreeSearch {
   };
 
   private handleDebounceChanged(): void {
-    this.search = debounceEvent(this.search, this.debounce);
+    const emitter = debounceEvent(this.search, this.debounce);
+
+    // Track this emitter in two separate variables to maintain the `EventEmitter` typing for
+    // `this.search`. This allows for correct generation of `CustomEvent` types.
+    this.search = emitter;
+    this.searchDisposable = emitter;
   }
 
   private setupController(): void {

--- a/packages/viewer/src/components/scene-tree/scene-tree.css
+++ b/packages/viewer/src/components/scene-tree/scene-tree.css
@@ -74,6 +74,9 @@
 
 .error,
 .empty-results {
+  position: absolute;
+  top: 0;
+  left: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -83,6 +86,7 @@
   padding: 1rem;
   box-sizing: border-box;
   justify-content: center;
+  background-color: white;
 }
 
 .error-section {

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -687,13 +687,12 @@ export class SceneTree {
                 <vertex-viewer-spinner class="loading" size="md" />
               </slot>
             )}
+            <slot />
             {this.showEmptyResults && (
               <slot name="empty-results">
                 <div class="empty-results">No Results Found.</div>
               </slot>
             )}
-
-            <slot />
           </div>
         )}
 

--- a/packages/viewer/src/lib/stencil.ts
+++ b/packages/viewer/src/lib/stencil.ts
@@ -1,5 +1,10 @@
 // eslint-disable-next-line no-restricted-imports
 import { EventEmitter, readTask, writeTask } from '@stencil/core';
+import { Disposable } from '@vertexvis/utils';
+
+export interface EventEmitterDisposable<E>
+  extends EventEmitter<E>,
+    Disposable {}
 
 export function readDOM(task: () => void): void {
   readTask(task);
@@ -12,12 +17,17 @@ export function writeDOM(task: () => void): void {
 export function debounceEvent<E>(
   event: EventEmitter<E>,
   wait: number
-): EventEmitter<E> {
+): EventEmitterDisposable<E> {
   let timer: number | undefined = undefined;
   function debounce(value: E): void {
     window.clearTimeout(timer);
     timer = window.setTimeout(() => event.emit(value), wait);
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return { emit: debounce as any };
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    emit: debounce as any,
+    dispose() {
+      window.clearTimeout(timer);
+    },
+  };
 }

--- a/packages/viewer/src/testing/grpc.ts
+++ b/packages/viewer/src/testing/grpc.ts
@@ -1,3 +1,5 @@
+import { UnaryResponse } from '@vertexvis/scene-tree-protos/scenetree/protos/scene_tree_api_pb_service';
+
 export function mockGrpcUnaryResult(
   result: unknown,
   timeout = 10
@@ -7,6 +9,26 @@ export function mockGrpcUnaryResult(
     setTimeout(() => {
       handler(null, result);
     }, timeout);
+  };
+}
+
+export function mockCancellableGrpcUnaryResult(
+  result: unknown,
+  timeout = 10,
+  onCancel?: VoidFunction
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): (...args: any[]) => unknown {
+  return (_, __, handler): UnaryResponse => {
+    const timer = setTimeout(() => {
+      handler(null, result);
+    }, timeout);
+
+    return {
+      cancel: () => {
+        clearTimeout(timer);
+        onCancel?.();
+      },
+    };
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds support for cancelling any in-flight filters of the scene-tree to avoid cases where a longer running filter would reduce the view of the tree after a clear. 
- Adds a disposable event emitter to the `<vertex-scene-tree-search>` element, along with a `clear` method to support cancelling any events that were debounced
- Fixes a small unrelated issue where the `No Results Found.` overlay was actually shifting (causing it to become scrollable) instead of acting as an overlay

## Test Plan

- Verify metadata filtering the scene-tree still works as expected
- Verify that performing a long-running metadata filter and cancelling after a few seconds properly returns to the base scene-tree and remains in that state (previously the tree would become filtered at a later point)

## Release Notes

N/A

## Possible Regressions

Scene tree filtering

## Dependencies

https://github.com/Vertexvis/scene-tree-service/pull/183
