### PR TITLE
[PLAT-3441] Update default scene-tree-search behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "nextVersionBump": "patch",
+  "nextVersionBump": "minor",
   "devDependencies": {
     "eslint": "^8.17.0",
     "http-server": "^14.1.1",

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -296,8 +296,12 @@ export namespace Components {
     controller?: SceneTreeController;
     /**
      * Specifies the delay, in milliseconds, to emit `search` events after user input.
+     *
+     * If this value is specified, searches will automatically occur after a keystroke has occurred and the debounce threshold has elapsed.
+     *
+     * Defaults to `undefined`, and searches only occur on an `Enter` press or a `blur` event.
      */
-    debounce: number;
+    debounce?: number;
     /**
      * If `true`, disables user interaction of the component.
      */
@@ -2007,6 +2011,10 @@ declare namespace LocalJSX {
     controller?: SceneTreeController;
     /**
      * Specifies the delay, in milliseconds, to emit `search` events after user input.
+     *
+     * If this value is specified, searches will automatically occur after a keystroke has occurred and the debounce threshold has elapsed.
+     *
+     * Defaults to `undefined`, and searches only occur on an `Enter` press or a `blur` event.
      */
     debounce?: number;
     /**

--- a/packages/viewer/src/components/scene-tree-search/readme.md
+++ b/packages/viewer/src/components/scene-tree-search/readme.md
@@ -18,13 +18,13 @@ functionality will need to be wired programmatically to
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                     | Type                               | Default     |
-| ------------- | ------------- | ------------------------------------------------------------------------------- | ---------------------------------- | ----------- |
-| `controller`  | --            | The scene tree controller                                                       | `SceneTreeController \| undefined` | `undefined` |
-| `debounce`    | `debounce`    | Specifies the delay, in milliseconds, to emit `search` events after user input. | `number`                           | `350`       |
-| `disabled`    | `disabled`    | If `true`, disables user interaction of the component.                          | `boolean`                          | `false`     |
-| `placeholder` | `placeholder` | Placeholder text if `value` is empty.                                           | `string \| undefined`              | `undefined` |
-| `value`       | `value`       | The current text value of the component. Value is updated on user interaction.  | `string`                           | `''`        |
+| Property      | Attribute     | Description                                                                                                                                                                                                                                                                                                    | Type                               | Default     |
+| ------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- |
+| `controller`  | --            | The scene tree controller                                                                                                                                                                                                                                                                                      | `SceneTreeController \| undefined` | `undefined` |
+| `debounce`    | `debounce`    | Specifies the delay, in milliseconds, to emit `search` events after user input.  If this value is specified, searches will automatically occur after a keystroke has occurred and the debounce threshold has elapsed.  Defaults to `undefined`, and searches only occur on an `Enter` press or a `blur` event. | `number \| undefined`              | `undefined` |
+| `disabled`    | `disabled`    | If `true`, disables user interaction of the component.                                                                                                                                                                                                                                                         | `boolean`                          | `false`     |
+| `placeholder` | `placeholder` | Placeholder text if `value` is empty.                                                                                                                                                                                                                                                                          | `string \| undefined`              | `undefined` |
+| `value`       | `value`       | The current text value of the component. Value is updated on user interaction.                                                                                                                                                                                                                                 | `string`                           | `''`        |
 
 
 ## Events

--- a/packages/viewer/src/components/scene-tree-search/scene-tree-search.spec.tsx
+++ b/packages/viewer/src/components/scene-tree-search/scene-tree-search.spec.tsx
@@ -158,6 +158,112 @@ describe('vertex-scene-tree-search', () => {
     );
   });
 
+  it('does not emit search events without Enter press by default', async () => {
+    const onSearch = jest.fn();
+
+    const page = await newSpecPage({
+      components: [SceneTreeSearch],
+      template: () => <vertex-scene-tree-search onSearch={onSearch} />,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector(
+      '.input'
+    ) as HTMLInputElement;
+    input.value = 'text';
+    input.dispatchEvent(new Event('input'));
+
+    await Async.delay(50);
+    expect(onSearch).not.toHaveBeenCalled();
+
+    await Async.delay(100);
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('emits search events when Enter is pressed', async () => {
+    const onSearch = jest.fn();
+
+    const page = await newSpecPage({
+      components: [SceneTreeSearch],
+      template: () => <vertex-scene-tree-search onSearch={onSearch} />,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector(
+      '.input'
+    ) as HTMLInputElement;
+    input.value = 'text';
+    input.dispatchEvent(new Event('input'));
+
+    await Async.delay(5);
+    expect(onSearch).not.toHaveBeenCalled();
+
+    input.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter' }));
+
+    await Async.delay(1);
+    expect(onSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: 'text',
+      })
+    );
+  });
+
+  it('emits search events when a blur occurs, and content has not been emitted', async () => {
+    const onSearch = jest.fn();
+
+    const page = await newSpecPage({
+      components: [SceneTreeSearch],
+      template: () => <vertex-scene-tree-search onSearch={onSearch} />,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector(
+      '.input'
+    ) as HTMLInputElement;
+    input.value = 'text';
+    input.dispatchEvent(new Event('input'));
+
+    await Async.delay(5);
+    expect(onSearch).not.toHaveBeenCalled();
+
+    input.dispatchEvent(new Event('blur'));
+
+    await Async.delay(1);
+    expect(onSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: 'text',
+      })
+    );
+  });
+
+  it('does not emit search events when a blur occurs, and content has been emitted', async () => {
+    const onSearch = jest.fn();
+
+    const page = await newSpecPage({
+      components: [SceneTreeSearch],
+      template: () => <vertex-scene-tree-search onSearch={onSearch} />,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector(
+      '.input'
+    ) as HTMLInputElement;
+    input.value = 'text';
+    input.dispatchEvent(new Event('input'));
+
+    await Async.delay(5);
+    expect(onSearch).not.toHaveBeenCalled();
+
+    input.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter' }));
+    await Async.delay(1);
+    expect(onSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: 'text',
+      })
+    );
+
+    input.dispatchEvent(new Event('blur'));
+
+    await Async.delay(1);
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
   it('emits search event when cleared', async () => {
     const onSearch = jest.fn();
 


### PR DESCRIPTION
## Summary

Updates the default behavior of the `<vertex-scene-tree-search>` element to require either an `Enter` press or a `blur` event to trigger the search by making the `debounce` field optional. If a `debounce` is specified, the search behavior will be the same as it was prior to this change.

## Test Plan

- Verify default behavior of the search component
  - Should search when `Enter` is pressed
  - Should search when a `blur` event occurs (this also requires the value to have changed)
  - Should always search when the input is cleared (either by button or by deleting all text)
- Verify debounce behavior of the search component continues to work as expected

## Release Notes

N/A

## Possible Regressions

scene-tree-search behavior

## Dependencies

N/A
