### PR TITLE
[PLAT-3557] Add support for animation when loading SceneViewStates

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.11.1"
+    "@vertexvis/frame-streaming-protos": "^0.11.2"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.11.1",
+    "@vertexvis/frame-streaming-protos": "^0.11.2",
     "@vertexvis/geometry": "0.19.2",
     "@vertexvis/html-templates": "0.19.2",
     "@vertexvis/scene-tree-protos": "^0.1.18",

--- a/packages/viewer/src/lib/scenes/__tests__/sceneViewStateLoader.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/sceneViewStateLoader.spec.ts
@@ -1,0 +1,414 @@
+jest.mock('@vertexvis/stream-api');
+
+import { vertexvis } from '@vertexvis/frame-streaming-protos';
+import { StreamApi } from '@vertexvis/stream-api';
+
+import { random } from '../../../testing';
+import { fromPbFrameOrThrow } from '../../mappers';
+import { Orientation } from '../../types';
+import { SceneViewStateLoader } from '../sceneViewStateLoader';
+
+describe('SceneViewStateLoader', () => {
+  const sceneId = random.guid();
+  const sceneViewId = random.guid();
+  const streamApi = new StreamApi();
+  const loader = new SceneViewStateLoader(
+    streamApi,
+    fromPbFrameOrThrow(Orientation.DEFAULT),
+    sceneId,
+    sceneViewId
+  );
+
+  describe('applySceneViewState', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
+
+    it('applies a scene view state by ID', async () => {
+      const sceneViewStateId = random.guid();
+
+      await loader.applySceneViewState(sceneViewStateId);
+
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+        }),
+        true
+      );
+      expect(streamApi.flyTo).not.toHaveBeenCalled();
+    });
+
+    it('applies a scene view state by ID in an identifier', async () => {
+      const sceneViewStateId = random.guid();
+
+      await loader.applySceneViewState({ id: sceneViewStateId });
+
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+        }),
+        true
+      );
+      expect(streamApi.flyTo).not.toHaveBeenCalled();
+    });
+
+    it('applies a scene view state by supplied ID in an identifier', async () => {
+      const sceneViewStateSuppliedId = random.string();
+
+      await loader.applySceneViewState({
+        suppliedId: sceneViewStateSuppliedId,
+      });
+
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateSuppliedId: {
+            value: sceneViewStateSuppliedId,
+          },
+        }),
+        true
+      );
+      expect(streamApi.flyTo).not.toHaveBeenCalled();
+    });
+
+    it('animates to a scene view state by ID and waits for the animation by default', async () => {
+      const animationId = random.guid();
+      const sceneViewStateId = random.guid();
+
+      const flyToSpy = jest.spyOn(streamApi, 'flyTo');
+      const eventSpy = jest.spyOn(streamApi, 'onEvent');
+
+      flyToSpy.mockResolvedValueOnce({
+        flyTo: {
+          animationId: {
+            hex: animationId,
+          },
+        },
+      });
+
+      eventSpy.mockImplementationOnce((fn) => {
+        fn({
+          event: {
+            animationCompleted: {
+              animationId: {
+                hex: animationId,
+              },
+            },
+          },
+          sentAtTime: {
+            seconds: 1000,
+          },
+        });
+
+        return {
+          dispose: jest.fn(),
+        };
+      });
+
+      await loader.applySceneViewState(sceneViewStateId, {
+        animation: {
+          milliseconds: 1000,
+        },
+      });
+
+      expect(streamApi.flyTo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateIdentifier: {
+            sceneViewStateId: {
+              hex: sceneViewStateId,
+            },
+          },
+        }),
+        true
+      );
+      expect(streamApi.onEvent).toHaveBeenCalled();
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+        }),
+        true
+      );
+    });
+
+    it('animates to a scene view state by ID and skips waiting for the animation', async () => {
+      const animationId = random.guid();
+      const sceneViewStateId = random.guid();
+
+      const flyToSpy = jest.spyOn(streamApi, 'flyTo');
+
+      flyToSpy.mockResolvedValueOnce({
+        flyTo: {
+          animationId: {
+            hex: animationId,
+          },
+        },
+      });
+
+      await loader.applySceneViewState(sceneViewStateId, {
+        animation: {
+          milliseconds: 1000,
+        },
+        waitForAnimation: false,
+      });
+
+      expect(streamApi.flyTo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateIdentifier: {
+            sceneViewStateId: {
+              hex: sceneViewStateId,
+            },
+          },
+        }),
+        true
+      );
+      expect(streamApi.onEvent).not.toHaveBeenCalled();
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+        }),
+        true
+      );
+    });
+  });
+
+  describe('applyPartialSceneViewState', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
+
+    it('applies a partial scene view state by ID', async () => {
+      const sceneViewStateId = random.guid();
+
+      await loader.applyPartialSceneViewState(sceneViewStateId, ['selection']);
+
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+          sceneViewStateFeatureSubset: [
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_SELECTION,
+          ],
+        }),
+        true
+      );
+      expect(streamApi.flyTo).not.toHaveBeenCalled();
+    });
+
+    it('applies a partial scene view state by ID in an identifier', async () => {
+      const sceneViewStateId = random.guid();
+
+      await loader.applyPartialSceneViewState({ id: sceneViewStateId }, [
+        'selection',
+      ]);
+
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+          sceneViewStateFeatureSubset: [
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_SELECTION,
+          ],
+        }),
+        true
+      );
+      expect(streamApi.flyTo).not.toHaveBeenCalled();
+    });
+
+    it('applies a partial scene view state by supplied ID in an identifier', async () => {
+      const sceneViewStateSuppliedId = random.string();
+
+      await loader.applyPartialSceneViewState(
+        {
+          suppliedId: sceneViewStateSuppliedId,
+        },
+        ['selection']
+      );
+
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateSuppliedId: {
+            value: sceneViewStateSuppliedId,
+          },
+          sceneViewStateFeatureSubset: [
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_SELECTION,
+          ],
+        }),
+        true
+      );
+      expect(streamApi.flyTo).not.toHaveBeenCalled();
+    });
+
+    it('does not animate to a partial scene view state by ID without camera in the feature list', async () => {
+      const animationId = random.guid();
+      const sceneViewStateId = random.guid();
+
+      const flyToSpy = jest.spyOn(streamApi, 'flyTo');
+
+      flyToSpy.mockResolvedValueOnce({
+        flyTo: {
+          animationId: {
+            hex: animationId,
+          },
+        },
+      });
+
+      await loader.applyPartialSceneViewState(sceneViewStateId, ['selection'], {
+        animation: {
+          milliseconds: 1000,
+        },
+      });
+
+      expect(streamApi.flyTo).not.toHaveBeenCalled();
+      expect(streamApi.onEvent).not.toHaveBeenCalled();
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+          sceneViewStateFeatureSubset: [
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_SELECTION,
+          ],
+        }),
+        true
+      );
+    });
+
+    it('animates to a partial scene view state by ID and waits for the animation by default', async () => {
+      const animationId = random.guid();
+      const sceneViewStateId = random.guid();
+
+      const flyToSpy = jest.spyOn(streamApi, 'flyTo');
+      const eventSpy = jest.spyOn(streamApi, 'onEvent');
+
+      flyToSpy.mockResolvedValueOnce({
+        flyTo: {
+          animationId: {
+            hex: animationId,
+          },
+        },
+      });
+
+      eventSpy.mockImplementationOnce((fn) => {
+        fn({
+          event: {
+            animationCompleted: {
+              animationId: {
+                hex: animationId,
+              },
+            },
+          },
+          sentAtTime: {
+            seconds: 1000,
+          },
+        });
+
+        return {
+          dispose: jest.fn(),
+        };
+      });
+
+      await loader.applyPartialSceneViewState(
+        sceneViewStateId,
+        ['selection', 'camera'],
+        {
+          animation: {
+            milliseconds: 1000,
+          },
+        }
+      );
+
+      expect(streamApi.flyTo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateIdentifier: {
+            sceneViewStateId: {
+              hex: sceneViewStateId,
+            },
+          },
+        }),
+        true
+      );
+      expect(streamApi.onEvent).toHaveBeenCalled();
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+          sceneViewStateFeatureSubset: [
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_SELECTION,
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_CAMERA,
+          ],
+        }),
+        true
+      );
+    });
+
+    it('animates to a partial scene view state by ID and skips waiting for the animation', async () => {
+      const animationId = random.guid();
+      const sceneViewStateId = random.guid();
+
+      const flyToSpy = jest.spyOn(streamApi, 'flyTo');
+
+      flyToSpy.mockResolvedValueOnce({
+        flyTo: {
+          animationId: {
+            hex: animationId,
+          },
+        },
+      });
+
+      await loader.applyPartialSceneViewState(
+        sceneViewStateId,
+        ['selection', 'camera'],
+        {
+          animation: {
+            milliseconds: 1000,
+          },
+          waitForAnimation: false,
+        }
+      );
+
+      expect(streamApi.flyTo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateIdentifier: {
+            sceneViewStateId: {
+              hex: sceneViewStateId,
+            },
+          },
+        }),
+        true
+      );
+      expect(streamApi.onEvent).not.toHaveBeenCalled();
+      expect(streamApi.loadSceneViewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneViewStateId: {
+            hex: sceneViewStateId,
+          },
+          sceneViewStateFeatureSubset: [
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_SELECTION,
+            vertexvis.protobuf.stream.SceneViewStateFeature
+              .SCENE_VIEW_STATE_FEATURE_CAMERA,
+          ],
+        }),
+        true
+      );
+    });
+  });
+});

--- a/packages/viewer/src/lib/scenes/sceneViewStateLoader.ts
+++ b/packages/viewer/src/lib/scenes/sceneViewStateLoader.ts
@@ -1,0 +1,113 @@
+import { vertexvis } from '@vertexvis/frame-streaming-protos';
+import { StreamApi, toProtoDuration } from '@vertexvis/stream-api';
+import { UUID } from '@vertexvis/utils';
+
+import { FrameDecoder } from '../mappers';
+import { DEFAULT_TIMEOUT_IN_MS } from '../stream/dispatcher';
+import { SceneViewStateIdentifier } from '../types';
+import { ApplySceneViewStateOptions, SceneViewStateFeature } from '.';
+import { CameraRenderResult } from './cameraRenderResult';
+import {
+  buildSceneViewStateIdentifier,
+  toPbSceneViewStateFeatures,
+} from './mapper';
+
+export class SceneViewStateLoader {
+  public constructor(
+    private stream: StreamApi,
+    private decodeFrame: FrameDecoder,
+    public readonly sceneId: UUID.UUID,
+    public readonly sceneViewId: UUID.UUID
+  ) {}
+
+  public async applySceneViewState(
+    sceneViewStateId:
+      | UUID.UUID
+      | SceneViewStateIdentifier.SceneViewStateIdentifier,
+    opts: ApplySceneViewStateOptions = {}
+  ): Promise<vertexvis.protobuf.stream.ILoadSceneViewStateResult | undefined> {
+    const pbIdField = buildSceneViewStateIdentifier(sceneViewStateId);
+
+    await this.animateToSceneViewState(pbIdField, opts);
+
+    return await this.stream.loadSceneViewState(
+      {
+        ...pbIdField,
+        frameCorrelationId: opts.suppliedCorrelationId
+          ? { value: opts.suppliedCorrelationId }
+          : undefined,
+      },
+      true
+    );
+  }
+
+  public async applyPartialSceneViewState(
+    sceneViewStateId:
+      | UUID.UUID
+      | SceneViewStateIdentifier.SceneViewStateIdentifier,
+    featuresToApply: SceneViewStateFeature[],
+    opts: ApplySceneViewStateOptions = {}
+  ): Promise<vertexvis.protobuf.stream.ILoadSceneViewStateResult | undefined> {
+    const pbIdField = buildSceneViewStateIdentifier(sceneViewStateId);
+    const pbFeatures = toPbSceneViewStateFeatures(featuresToApply);
+
+    if (featuresToApply.includes('camera')) {
+      await this.animateToSceneViewState(pbIdField, opts);
+    }
+
+    return await this.stream.loadSceneViewState(
+      {
+        ...pbIdField,
+        frameCorrelationId: opts.suppliedCorrelationId
+          ? { value: opts.suppliedCorrelationId }
+          : undefined,
+        sceneViewStateFeatureSubset: pbFeatures,
+      },
+      true
+    );
+  }
+
+  private async animateToSceneViewState(
+    identifier:
+      | Pick<
+          vertexvis.protobuf.stream.ILoadSceneViewStatePayload,
+          'sceneViewStateId'
+        >
+      | Pick<
+          vertexvis.protobuf.stream.ILoadSceneViewStatePayload,
+          'sceneViewStateSuppliedId'
+        >,
+    opts: ApplySceneViewStateOptions
+  ): Promise<void> {
+    if (opts.animation != null) {
+      const corrId = UUID.create();
+
+      const flyToResult = await this.stream.flyTo(
+        {
+          sceneViewStateIdentifier: identifier,
+          animation: {
+            duration: toProtoDuration(opts.animation.milliseconds),
+          },
+          frameCorrelationId: {
+            value: corrId,
+          },
+        },
+        true
+      );
+
+      if (opts.waitForAnimation == null || opts.waitForAnimation) {
+        const renderResult = new CameraRenderResult(
+          this.stream,
+          this.decodeFrame,
+          {
+            animationId: flyToResult.flyTo?.animationId?.hex ?? undefined,
+            correlationId: corrId,
+          },
+          opts.animation.milliseconds + DEFAULT_TIMEOUT_IN_MS
+        );
+
+        await renderResult.onAnimationCompleted.once();
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,11 +2216,6 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.11.1.tgz#ecd37e4b1188774d82cf234831bc6a18b8bab898"
-  integrity sha512-DYbh/nTpfpk+SOAxnFcAyh1WlGEQHrIP8jQnDQMDVL7y/DdidORqCnMEhbvutSLFPYXOPgvihvMMt0jVI3tnvg==
-
 "@vertexvis/frame-streaming-protos@^0.11.2":
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.11.2.tgz#f7cf414ed0fcec3812a96f2a0ecb298315be0ba6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,6 +2221,11 @@
   resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.11.1.tgz#ecd37e4b1188774d82cf234831bc6a18b8bab898"
   integrity sha512-DYbh/nTpfpk+SOAxnFcAyh1WlGEQHrIP8jQnDQMDVL7y/DdidORqCnMEhbvutSLFPYXOPgvihvMMt0jVI3tnvg==
 
+"@vertexvis/frame-streaming-protos@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.11.2.tgz#f7cf414ed0fcec3812a96f2a0ecb298315be0ba6"
+  integrity sha512-oJiYwZ1H2qZWm4DutS0TJynray7aDZL49pxgQa6/1HMbU0z7zyeoKG+c070gmnSWFW5uv79Z12RJqUQKg6y6Cg==
+
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@vertexvis/jest-config-vertexvis/-/jest-config-vertexvis-0.5.4.tgz#b6f720700133347c6a3fe3bcf743e61fba5c3e3b"


### PR DESCRIPTION
## Summary

Adds support for similar animation configuration as the `scene.camera().render()` method to the `scene.applySceneViewState()` and `scene.applyPartialSceneViewState()` methods. If this animation duration is configured, these methods will now perform a `flyTo` (and wait for the animation to complete) using the provided ID prior to applying the SceneViewState. The wait for the animation to complete is also configurable using the `waitForAnimation` flag, and if no animation duration is provided, it will maintain the same behavior as today. Additionally, the `scene.applyPartialSceneViewState()` method will only respect the provided animation if the `'camera'` feature is provided in the list of items to apply.

## Test Plan

- Verify that the `scene.applySceneViewState()` without an animation configuration continues to work as expected
- Verify that the `scene.applyPartialSceneViewState()` without an animation configuration continues to work as expected
- Verify that providing an animation configuration to `scene.applySceneViewState()` works as expected
  - By default, should wait for the animation before applying other features
  - Providing `waitForAnimation: false`, the other features should apply during the animation
- Verify that providing an animation configuration to `scene.applyPartialSceneViewState()` works as expected
  - By default, should wait for the animation before applying other features
  - Providing `waitForAnimation: false`, the other features should apply during the animation
  - Not providing the `'camera'` feature should not change the camera

## Release Notes

N/A

## Possible Regressions

Loading of SceneViewStates

## Dependencies

https://github.com/Vertexvis/frame-streaming-service/pull/367
