### PR TITLE
[PLAT-3624] Add column resize event for scene tree table

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2118,6 +2118,12 @@ declare namespace LocalJSX {
     layoutHeight?: number;
     layoutOffset?: number;
     layoutWidth?: number;
+    /**
+     * An event that is emitted when the columns of this `<vertex-scene-tree-table-layout>` are resized with an array containing the widths of the columns in pixels.
+     */
+    onColumnsResized?: (
+      event: VertexSceneTreeTableLayoutCustomEvent<number[]>
+    ) => void;
     onLayoutRendered?: (
       event: VertexSceneTreeTableLayoutCustomEvent<void>
     ) => void;

--- a/packages/viewer/src/components/scene-tree-table-layout/readme.md
+++ b/packages/viewer/src/components/scene-tree-table-layout/readme.md
@@ -14,6 +14,13 @@
 | `tree`          | --                | A reference to the scene tree to perform operations for interactions. Such as expansion, visibility and selection.                                                                                                                                                                                        | `HTMLVertexSceneTreeElement \| undefined`              | `undefined` |
 
 
+## Events
+
+| Event            | Description                                                                                                                                                    | Type                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `columnsResized` | An event that is emitted when the columns of this `<vertex-scene-tree-table-layout>` are resized with an array containing the widths of the columns in pixels. | `CustomEvent<number[]>` |
+
+
 ## Methods
 
 ### `scrollToPosition(top: number, options: Pick<DomScrollToOptions, 'behavior'>) => Promise<void>`


### PR DESCRIPTION
## Summary

Adds an event when the `<vertex-scene-tree-table-layout>`'s columns are resized.

This PR also fixes a couple issues around initialization of the layout with column widths don't match the full width of the layout. This fix will cause widths larger than the full width to be scaled down, and widths smaller than the full width to be scaled up.

## Test Plan

- Verify a `columnsResized` event is emitted when the dividers are used to resize the columns

## Release Notes

N/A

## Possible Regressions

Column initial widths

## Dependencies

N/A
