### PR TITLE
[PLAT-3729] Prevent viewer selection

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.css
+++ b/packages/viewer/src/components/viewer/viewer.css
@@ -18,6 +18,9 @@
   height: 300px;
   min-width: 1px;
   min-height: 1px;
+
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .canvas-container {

--- a/packages/viewer/src/lib/interactions/__tests__/touchInteractionHandler.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/touchInteractionHandler.spec.ts
@@ -90,6 +90,16 @@ describe(TouchInteractionHandler, () => {
     expect(api.rotateCamera).toHaveBeenCalledTimes(1);
   });
 
+  it('prevents default behavior for touch events', () => {
+    div.dispatchEvent(touchStart1);
+    window.dispatchEvent(touchMoveWithOneFingerTouch);
+    window.dispatchEvent(touchEnd1);
+
+    expect(touchStart1.defaultPrevented).toBe(true);
+    expect(touchMoveWithOneFingerTouch.defaultPrevented).toBe(true);
+    expect(touchEnd1.defaultPrevented).toBe(true);
+  });
+
   describe(TouchInteractionHandler.prototype.dispose, () => {
     it('should not handle events if disposed', () => {
       handler.dispose();

--- a/packages/viewer/src/lib/interactions/touchInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/touchInteractionHandler.ts
@@ -26,6 +26,8 @@ export class TouchInteractionHandler extends MultiTouchInteractionHandler {
 
   private handleTouchStart(event: TouchEvent): void {
     if (event.touches.length >= 1) {
+      event.preventDefault();
+
       const touch1 = event.touches[0];
       const touch2 = event.touches[1];
 
@@ -43,6 +45,8 @@ export class TouchInteractionHandler extends MultiTouchInteractionHandler {
   }
 
   private handleTouchMove(event: TouchEvent): void {
+    event.preventDefault();
+
     if (event.touches.length === 1) {
       this.handleOnePointTouchMove(event.touches[0]);
     } else if (event.touches.length === 2) {
@@ -60,6 +64,8 @@ export class TouchInteractionHandler extends MultiTouchInteractionHandler {
   }
 
   private handleTouchEnd(event: TouchEvent): void {
+    event.preventDefault();
+
     this.interactionApi?.endInteraction();
 
     this.isInteracting = false;


### PR DESCRIPTION
## Summary

Adds an `event.preventDefault()` for touch events (similar to what we do for pointer events) and also adds a `user-select: none` to the viewer prevent accidental selection when rotating the model or interacting with the context menu.

## Test Plan

- Verify that the viewer does not become selected when interacting on mobile
- Verify that default touch behavior (on iOS this magnifies what's under the tap point on long press) no longer occurs

## Release Notes

N/A

## Possible Regressions

Selection in viewer children (tested with markup and that allows selection similar to the behavior today)

## Dependencies

N/A
