### PR TITLE
[PLAT-3942] Exposing the volume selection model types and emitting the controller when changed

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -1565,6 +1565,10 @@ export interface VertexViewerCustomEvent<T> extends CustomEvent<T> {
   detail: T;
   target: HTMLVertexViewerElement;
 }
+export interface VertexViewerBoxQueryToolCustomEvent<T> extends CustomEvent<T> {
+  detail: T;
+  target: HTMLVertexViewerBoxQueryToolElement;
+}
 export interface VertexViewerDomElementCustomEvent<T> extends CustomEvent<T> {
   detail: T;
   target: HTMLVertexViewerDomElementElement;
@@ -2371,6 +2375,12 @@ declare namespace LocalJSX {
      * The model that contains the points representing the corners of the box displayed on screen, the type of the query to be performed, and methods for setting these values.
      */
     model?: VolumeIntersectionQueryModel;
+    /**
+     * Event emitted when the `VolumeIntersectionQueryController` associated with this tool changes.
+     */
+    onControllerChanged?: (
+      event: VertexViewerBoxQueryToolCustomEvent<VolumeIntersectionQueryController>
+    ) => void;
     /**
      * The default operation to perform when a drag has completed and the intersection query will be run. Defaults to `clearAndSelect`, and can be changed to `select` or `deselect`.
      *

--- a/packages/viewer/src/components/viewer-box-query-tool/readme.md
+++ b/packages/viewer/src/components/viewer-box-query-tool/readme.md
@@ -56,6 +56,13 @@ type of query to be performed on pointer up is populated on the `<vertex-viewer-
 | `viewer`        | --               | The viewer that this component is bound to. This is automatically assigned if added to the light-dom of a parent viewer element.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `HTMLVertexViewerElement \| undefined`           | `undefined`        |
 
 
+## Events
+
+| Event               | Description                                                                                   | Type                                             |
+| ------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `controllerChanged` | Event emitted when the `VolumeIntersectionQueryController` associated with this tool changes. | `CustomEvent<VolumeIntersectionQueryController>` |
+
+
 ## CSS Custom Properties
 
 | Name                                                | Description                                                                                                                                                                                                     |

--- a/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.spec.tsx
+++ b/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.spec.tsx
@@ -76,6 +76,27 @@ describe('vertex-viewer-box-query-tool', () => {
     expect(bounds).toBeNull();
   });
 
+  it('notifies when the controller changes', async () => {
+    const { stream, ws } = makeViewerStream();
+
+    const onControllerChanged = jest.fn();
+    const page = await newSpecPage({
+      components: [Viewer, ViewerBoxQueryTool, ViewerLayer],
+      template: () => (
+        <vertex-viewer stream={stream}>
+          <vertex-viewer-box-query-tool
+            onControllerChanged={onControllerChanged}
+          ></vertex-viewer-box-query-tool>
+        </vertex-viewer>
+      ),
+    });
+
+    const viewer = page.root as HTMLVertexViewerElement;
+    await loadViewerStreamKey(key1, { viewer, stream, ws });
+
+    expect(onControllerChanged).toHaveBeenCalled();
+  });
+
   it('sends a selection query for the frustum using exclusive', async () => {
     const { stream, ws } = makeViewerStream();
 

--- a/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.tsx
+++ b/packages/viewer/src/components/viewer-box-query-tool/viewer-box-query-tool.tsx
@@ -1,4 +1,14 @@
-import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+  State,
+  Watch,
+} from '@stencil/core';
 import { Disposable } from '@vertexvis/utils';
 
 import { VolumeIntersectionQueryController } from '../../lib/volume-intersection/controller';
@@ -79,6 +89,12 @@ export class ViewerBoxQueryTool {
 
   @State()
   private details?: VolumeIntersectionQueryDetails;
+
+  /**
+   * Event emitted when the `VolumeIntersectionQueryController` associated with this tool changes.
+   */
+  @Event()
+  public controllerChanged!: EventEmitter<VolumeIntersectionQueryController>;
 
   @Element()
   private hostEl!: HTMLVertexViewerBoxQueryToolElement;
@@ -177,6 +193,8 @@ export class ViewerBoxQueryTool {
     this.operationStartedDisposable = controller?.onExecuteComplete(
       this.handleExecuteComplete
     );
+
+    this.controllerChanged.emit(this.controller);
   }
 
   /**

--- a/packages/viewer/src/lib/volume-intersection/index.ts
+++ b/packages/viewer/src/lib/volume-intersection/index.ts
@@ -1,1 +1,2 @@
 export * from './controller';
+export * from './model';


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes enable developers to use the volume selection tool to get the controller when the controller is initialized or changes.

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
