### PR TITLE
[PLAT-3952] Clear material overrides

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.13.0"
+    "@vertexvis/frame-streaming-protos": "^0.13.1"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.13.0",
+    "@vertexvis/frame-streaming-protos": "^0.13.1",
     "@vertexvis/geometry": "0.20.0",
     "@vertexvis/html-templates": "0.20.0",
     "@vertexvis/scene-tree-protos": "^0.1.18",

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -24,6 +24,7 @@ describe(buildSceneOperation, () => {
           { type: 'view-representation', id: 'entire-part' },
           { type: 'view-representation', id: repId },
           { type: 'clear-representation' },
+          { type: 'clear-override' },
         ],
         { dimensions: Dimensions.create(100, 100) }
       )
@@ -49,6 +50,7 @@ describe(buildSceneOperation, () => {
         },
         { viewRepresentation: { id: { hex: repId } } },
         { clearRepresentation: {} },
+        { clearMaterial: {} },
       ],
     });
   });

--- a/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
@@ -292,33 +292,35 @@ describe(Scene, () => {
             operationTypes: [
               {
                 changeMaterial: {
-                  material: {
-                    d: 255,
-                    ka: {
-                      a: 0,
-                      b: 0,
-                      g: 0,
-                      r: 0,
+                  materialOverride: {
+                    colorMaterial: {
+                      d: 255,
+                      ka: {
+                        a: 0,
+                        b: 0,
+                        g: 0,
+                        r: 0,
+                      },
+                      kd: {
+                        a: 255,
+                        b: 34,
+                        g: 17,
+                        r: 255,
+                      },
+                      ke: {
+                        a: 0,
+                        b: 0,
+                        g: 0,
+                        r: 0,
+                      },
+                      ks: {
+                        a: 0,
+                        b: 0,
+                        g: 0,
+                        r: 0,
+                      },
+                      ns: ColorMaterial.defaultColor.glossiness,
                     },
-                    kd: {
-                      a: 255,
-                      b: 34,
-                      g: 17,
-                      r: 255,
-                    },
-                    ke: {
-                      a: 0,
-                      b: 0,
-                      g: 0,
-                      r: 0,
-                    },
-                    ks: {
-                      a: 0,
-                      b: 0,
-                      g: 0,
-                      r: 0,
-                    },
-                    ns: ColorMaterial.defaultColor.glossiness,
                   },
                 },
               },

--- a/packages/viewer/src/lib/scenes/colorMaterial.ts
+++ b/packages/viewer/src/lib/scenes/colorMaterial.ts
@@ -43,7 +43,7 @@ export const defaultColor: ColorMaterial = {
 };
 
 /**
- * This helper creats an rgb value color
+ * This helper creates an rgb value color
  * @param hex
  * @param opacity
  */

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -229,13 +229,15 @@ function buildOperationTypes(
       case 'change-material':
         return {
           changeMaterial: {
-            material: {
-              d: op.material.opacity,
-              ns: op.material.glossiness,
-              ka: op.material.ambient,
-              kd: op.material.diffuse,
-              ks: op.material.specular,
-              ke: op.material.emissive,
+            materialOverride: {
+              colorMaterial: {
+                d: op.material.opacity,
+                ns: op.material.glossiness,
+                ka: op.material.ambient,
+                kd: op.material.diffuse,
+                ks: op.material.specular,
+                ke: op.material.emissive,
+              },
             },
           },
         };

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -240,7 +240,7 @@ function buildOperationTypes(
           },
         };
       case 'clear-override':
-        return { changeMaterial: {} };
+        return { clearMaterial: {} };
       case 'change-transform':
         return { changeTransform: { transform: { ...op.transform } } };
       case 'clear-transform':

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,10 +2216,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.0.tgz#b49c08855467edb429dcf7d9c6904b7c6215486d"
-  integrity sha512-8aIRjGNFZ/UHY1sS85MsISC0sIJgI6hQtgQKpKNQXHK2HIJ5Cwe3ZNT0Khk5pmcpLpGExczyvern5kTWaLMW7Q==
+"@vertexvis/frame-streaming-protos@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.1.tgz#b3ec132cd98009a49645093387932648702a8255"
+  integrity sha512-GFnzOuDDMKua5J7ws+JB8QNqPSiCHmp3UA241phFltL1Lcvl/8Dkq1tS78ks/8J3BJNVEJRdV8Da9ywQk/27XA==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary
This PR updates the behavior when clearing a material override such that the part reverts to its default material instead of inheriting any material overrides applied to an ancestor of the item.
 
## Test Plan
Verify material overrides work as expected. Specifically, verify the following use case:
1. Apply a material override to a parent item.
2. Clear the material override for one of the children.
3. Verify that the child now appears with its default material and the appearance of the remainder of the parts is unchanged.

## Release Notes
Ability to set an override default material for a scene item

## Possible Regressions
Material overrides

## Dependencies
None