### PR TITLE
[PLAT-1372] Support resetting rotation

### DIFF
--- a/packages/geometry/src/matrix4.ts
+++ b/packages/geometry/src/matrix4.ts
@@ -687,6 +687,15 @@ export function position(matrix: Matrix4, other: Matrix4): Matrix4 {
 }
 
 /**
+ * Returns true if the matrix is an identity matrix.
+ */
+export function isIdentity(matrix: Matrix4): boolean {
+  const identity = makeIdentity();
+
+  return matrix.every((v, i) => v === identity[i]);
+}
+
+/**
  * Returns an object representation of a `Matrix4`.
  */
 export function toObject(m: Matrix4): Matrix4AsObject {

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -149,6 +149,7 @@ export class ViewerTransformWidget {
 
   private canvasBounds?: DOMRect;
   private canvasResizeObserver?: ResizeObserver;
+  private hostStyleObserver?: MutationObserver;
   private canvasRef?: HTMLCanvasElement;
 
   private hoveredChangeDisposable?: Disposable;
@@ -157,6 +158,7 @@ export class ViewerTransformWidget {
     window.addEventListener('pointermove', this.handlePointerMove);
 
     this.canvasResizeObserver = new ResizeObserver(this.handleResize);
+    this.hostStyleObserver = new MutationObserver(this.handleStyleChange);
 
     if (this.canvasRef != null) {
       this.canvasResizeObserver.observe(this.canvasRef);
@@ -164,30 +166,20 @@ export class ViewerTransformWidget {
       this.setupTransformWidget(this.canvasRef);
     }
 
-    this.handleViewerChanged(this.viewer, undefined);
-
-    readDOM(() => {
-      const hostStyles = window.getComputedStyle(this.hostEl);
-
-      this.xArrowColor = hostStyles
-        .getPropertyValue('--viewer-transform-widget-x-axis-arrow-color')
-        .trim();
-      this.yArrowColor = hostStyles
-        .getPropertyValue('--viewer-transform-widget-y-axis-arrow-color')
-        .trim();
-      this.zArrowColor = hostStyles
-        .getPropertyValue('--viewer-transform-widget-z-axis-arrow-color')
-        .trim();
-      this.hoveredColor = hostStyles
-        .getPropertyValue('--viewer-transform-widget-hovered-arrow-color')
-        .trim();
+    this.hostStyleObserver.observe(this.hostEl, {
+      attributes: true,
+      attributeFilter: ['style'],
     });
+
+    this.handleViewerChanged(this.viewer, undefined);
+    this.handleStyleChange();
   }
 
   protected disconnectedCallback(): void {
     window.removeEventListener('pointermove', this.handlePointerMove);
 
     this.canvasResizeObserver?.disconnect();
+    this.hostStyleObserver?.disconnect();
 
     this.hoveredChangeDisposable?.dispose();
     this.widget?.dispose();
@@ -244,12 +236,14 @@ export class ViewerTransformWidget {
    */
   @Watch('rotation')
   protected handleRotationChanged(
-    newRotation: Euler.Euler,
+    newRotation?: Euler.Euler,
     oldRotation?: Euler.Euler
   ): void {
-    this.currentTransform = this.getTransformForNewRotation(newRotation);
-    this.startingTransform = this.currentTransform;
-    this.widget?.updateTransform(this.currentTransform);
+    if (newRotation != null) {
+      this.currentTransform = this.getTransformForNewRotation(newRotation);
+      this.startingTransform = this.currentTransform;
+      this.widget?.updateTransform(this.currentTransform);
+    }
     console.debug(
       `Updating widget rotation [previous=${JSON.stringify(
         oldRotation
@@ -325,6 +319,32 @@ export class ViewerTransformWidget {
     if (this.canvasRef != null) {
       this.updateCanvasBounds(this.canvasRef);
     }
+  };
+
+  private handleStyleChange = (): void => {
+    readDOM(() => {
+      const hostStyles = window.getComputedStyle(this.hostEl);
+
+      this.xArrowColor = hostStyles
+        .getPropertyValue('--viewer-transform-widget-x-axis-arrow-color')
+        .trim();
+      this.yArrowColor = hostStyles
+        .getPropertyValue('--viewer-transform-widget-y-axis-arrow-color')
+        .trim();
+      this.zArrowColor = hostStyles
+        .getPropertyValue('--viewer-transform-widget-z-axis-arrow-color')
+        .trim();
+      this.hoveredColor = hostStyles
+        .getPropertyValue('--viewer-transform-widget-hovered-arrow-color')
+        .trim();
+
+      this.getTransformWidget().updateColors({
+        xArrow: this.xArrowColor,
+        yArrow: this.yArrowColor,
+        zArrow: this.zArrowColor,
+        hovered: this.hoveredColor,
+      });
+    });
   };
 
   private handlePointerMove = (event: PointerEvent): void => {

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -239,11 +239,24 @@ export class ViewerTransformWidget {
     newRotation?: Euler.Euler,
     oldRotation?: Euler.Euler
   ): void {
-    if (newRotation != null) {
-      this.currentTransform = this.getTransformForNewRotation(newRotation);
+    const rotationToApply = newRotation ?? Euler.create();
+
+    this.currentTransform = this.getTransformForNewRotation(rotationToApply);
+    this.startingTransform = this.currentTransform;
+
+    // If the removal of the previous rotation above results in an identity matrix,
+    // clear the transformation on the widget to prevent it from appearing at the origin.
+    if (
+      newRotation == null &&
+      this.currentTransform != null &&
+      Matrix4.isIdentity(this.currentTransform)
+    ) {
+      this.currentTransform = undefined;
       this.startingTransform = this.currentTransform;
-      this.widget?.updateTransform(this.currentTransform);
     }
+
+    this.widget?.updateTransform(this.currentTransform);
+
     console.debug(
       `Updating widget rotation [previous=${JSON.stringify(
         oldRotation

--- a/packages/viewer/src/components/viewer-transform-widget/widget.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/widget.ts
@@ -169,12 +169,12 @@ export class TransformWidget extends ReglComponent {
     this.hoveredArrowFillColor = colors.hovered ?? this.hoveredArrowFillColor;
     this.outlineColor = colors.outline ?? this.outlineColor;
 
-    this.xArrow?.updateFillColor(this.getXTranslationColor());
-    this.yArrow?.updateFillColor(this.getYTranslationColor());
-    this.zArrow?.updateFillColor(this.getZTranslationColor());
-    this.xRotation?.updateFillColor(this.getXRotationColor());
-    this.yRotation?.updateFillColor(this.getYRotationColor());
-    this.zRotation?.updateFillColor(this.getZRotationColor());
+    this.xArrow?.updateFillColor(this.getXTranslationColor(), true);
+    this.yArrow?.updateFillColor(this.getYTranslationColor(), true);
+    this.zArrow?.updateFillColor(this.getZTranslationColor(), true);
+    this.xRotation?.updateFillColor(this.getXRotationColor(), true);
+    this.yRotation?.updateFillColor(this.getYRotationColor(), true);
+    this.zRotation?.updateFillColor(this.getZRotationColor(), true);
     this.hoveredElement?.updateFillColor(this.hoveredArrowFillColor);
   }
 

--- a/packages/viewer/src/lib/transforms/drawable.ts
+++ b/packages/viewer/src/lib/transforms/drawable.ts
@@ -50,10 +50,16 @@ export abstract class Drawable<T extends DrawablePoints = DrawablePoints> {
     });
   }
 
-  public updateFillColor(color?: Color.Color | string): void {
+  public updateFillColor(
+    color?: Color.Color | string,
+    isInitialColor = false
+  ): void {
     if (color != null) {
       this.fillColor =
         typeof color === 'string' ? color : Color.toHexString(color);
+      this.initialFillColor = isInitialColor
+        ? this.fillColor
+        : this.initialFillColor;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes an issue where resetting the rotation would result in an identity matrix. 

## Test Plan

- Verify the widget can still be rotated as expected
- Verify the widget can still have its positional information cleared

## Release Notes

N/A

## Possible Regressions

Transform widget

## Dependencies

N/A
