### PR TITLE
[PLAT-3931] Verifying the dom element & dom group have a transform applied prior to acting on it

### DIFF
--- a/packages/viewer/src/components/viewer-dom-element/utils.ts
+++ b/packages/viewer/src/components/viewer-dom-element/utils.ts
@@ -2,6 +2,8 @@ export function isVertexViewerDomElement(
   el: unknown
 ): el is HTMLVertexViewerDomElementElement {
   return (
-    el instanceof HTMLElement && el.nodeName === 'VERTEX-VIEWER-DOM-ELEMENT'
+    el instanceof HTMLElement &&
+    el.nodeName === 'VERTEX-VIEWER-DOM-ELEMENT' &&
+    (el as HTMLVertexViewerDomElementElement).matrix != null
   );
 }

--- a/packages/viewer/src/components/viewer-dom-group/utils.ts
+++ b/packages/viewer/src/components/viewer-dom-group/utils.ts
@@ -2,7 +2,8 @@ export function isVertexViewerDomGroup(
   el: unknown
 ): el is HTMLVertexViewerDomGroupElement {
   return (
-    (el instanceof HTMLElement && el.nodeName === 'VERTEX-VIEWER-DOM-GROUP') ||
-    (el instanceof HTMLElement && el.dataset.isDomGroupElement != null)
+    ((el instanceof HTMLElement && el.nodeName === 'VERTEX-VIEWER-DOM-GROUP') ||
+      (el instanceof HTMLElement && el.dataset.isDomGroupElement != null)) &&
+    (el as HTMLVertexViewerDomGroupElement).matrix != null
   );
 }


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
Prior to this check, we were not verifying that the matrix was set on the dom element. This check will verify that the matrix is also defined. The dom group was defined, but there was no matrix on it. This change prevents reading the matrix if the matrix is not present on the group or element.

Exception:

```
bundle.esm.js:675 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
    at Object.multiply$2 [as multiply] (bundle.esm.js:675:17)
    at getElementDepths (renderer2d.tsx:63:35)
    at update2d (renderer2d.tsx:28:20)
    at ViewerDomRenderer.updateElements (viewer-dom-renderer.tsx:158:9)
    at ViewerDomRenderer.componentWillRender (viewer-dom-renderer.tsx:123:10)
    at safeCall (index.js:1577:36)
    at index.js:1353:39
    at then (index.js:1586:61)
    at dispatchHooks (index.js:1353:19)
    at Array.dispatch (index.js:1324:28)
```
<img width="612" alt="image" src="https://github.com/Vertexvis/vertex-web-sdk/assets/49169871/89e1d4e7-b8e3-47bf-bb1e-8c3186b36ee1">




## Test Plan
<!-- How to test changes. -->
- This was reproducible on the first pin placed in the viewer. 
- Verify the exception is now gone after this change when placing a pin. 


## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
