### PR TITLE
[PLAT-1372] Add Vector3 Euler between method

### DIFF
--- a/packages/geometry/src/__tests__/quaternion.test.ts
+++ b/packages/geometry/src/__tests__/quaternion.test.ts
@@ -16,6 +16,40 @@ describe(Quaternion.fromJson, () => {
   });
 });
 
+describe(Quaternion.normalize, () => {
+  it('normalizes the provided quaternion', () => {
+    const q = Quaternion.create({ w: 1, x: 2, y: 3, z: 4 });
+    const normalized = Quaternion.normalize(q);
+    expect(normalized.w).toBeCloseTo(0.1825);
+    expect(normalized.x).toBeCloseTo(0.365);
+    expect(normalized.y).toBeCloseTo(0.5475);
+    expect(normalized.z).toBeCloseTo(0.73);
+  });
+});
+
+describe(Quaternion.magnitude, () => {
+  it('returns the magnitude of the provided quaternion', () => {
+    const magnitude = Quaternion.magnitude(
+      Quaternion.create({ w: 1, x: 2, y: 3, z: 4 })
+    );
+    expect(magnitude).toBeCloseTo(5.48);
+  });
+});
+
+describe(Quaternion.scale, () => {
+  it('scales the provided quaternion', () => {
+    const q = Quaternion.create({ w: 1, x: 2, y: 3, z: 4 });
+    expect(Quaternion.scale(100, q)).toMatchObject(
+      Quaternion.create({
+        w: 100,
+        x: 200,
+        y: 300,
+        z: 400,
+      })
+    );
+  });
+});
+
 describe(Quaternion.fromAxisAngle, () => {
   it('rotates quaternion around axis', () => {
     const q = Quaternion.fromAxisAngle(Vector3.up(), Angle.toRadians(90));

--- a/packages/geometry/src/__tests__/vector3.test.ts
+++ b/packages/geometry/src/__tests__/vector3.test.ts
@@ -1,3 +1,4 @@
+import { Euler } from '..';
 import * as Angle from '../angle';
 import * as Matrix4 from '../matrix4';
 import * as Vector3 from '../vector3';
@@ -94,6 +95,39 @@ describe(Vector3.angleTo, () => {
       Vector3.create(1, 2, 3)
     );
     expect(angle).toEqual(0.3875966866551805);
+  });
+});
+
+describe(Vector3.eulerTo, () => {
+  it('calculates the euler angle between two vectors', () => {
+    const angle1 = Vector3.eulerTo(Vector3.create(1, 1, 0), Vector3.up());
+    const angle2 = Vector3.eulerTo(
+      Vector3.create(1, 2, 3),
+      Vector3.create(3, 2, 1)
+    );
+    const angle3 = Vector3.eulerTo(Vector3.create(0, 1, 1), Vector3.up());
+
+    expect(angle1.x).toBeCloseTo(0);
+    expect(angle1.y).toBeCloseTo(0);
+    expect(angle1.z).toBeCloseTo(Math.PI / 4);
+    expect(angle2.x).toBeCloseTo(Angle.toRadians(-14));
+    expect(angle2.y).toBeCloseTo(Angle.toRadians(38));
+    expect(angle2.z).toBeCloseTo(Angle.toRadians(-14));
+    expect(angle3.x).toBeCloseTo(-Math.PI / 4);
+    expect(angle3.y).toBeCloseTo(0);
+    expect(angle3.z).toBeCloseTo(0);
+  });
+
+  it('returns an euler angle with no rotation if the vectors if the angle between them is 0 degrees', () => {
+    expect(
+      Vector3.eulerTo(Vector3.create(0, 15, 0), Vector3.up())
+    ).toMatchObject(Euler.create());
+  });
+
+  it('returns an euler angle with no rotation if the vectors if the angle between them is 180 degrees', () => {
+    expect(
+      Vector3.eulerTo(Vector3.create(15, 0, 0), Vector3.left())
+    ).toMatchObject(Euler.create());
   });
 });
 

--- a/packages/geometry/src/__tests__/vector3.test.ts
+++ b/packages/geometry/src/__tests__/vector3.test.ts
@@ -118,15 +118,21 @@ describe(Vector3.eulerTo, () => {
     expect(angle3.z).toBeCloseTo(0);
   });
 
-  it('returns an euler angle with no rotation if the vectors if the angle between them is 0 degrees', () => {
+  it('returns an euler angle with no rotation if the vectors if the angle between them is near 0 degrees', () => {
     expect(
-      Vector3.eulerTo(Vector3.create(0, 15, 0), Vector3.up())
+      Vector3.eulerTo(Vector3.create(1e-6, 15, 0), Vector3.up())
+    ).toMatchObject(Euler.create());
+    expect(
+      Vector3.eulerTo(Vector3.create(0, 15, -1e-6), Vector3.up())
     ).toMatchObject(Euler.create());
   });
 
-  it('returns an euler angle with no rotation if the vectors if the angle between them is 180 degrees', () => {
+  it('returns an euler angle with no rotation if the vectors if the angle between them is near 180 degrees', () => {
     expect(
-      Vector3.eulerTo(Vector3.create(15, 0, 0), Vector3.left())
+      Vector3.eulerTo(Vector3.create(15, 1e-6, 0), Vector3.left())
+    ).toMatchObject(Euler.create());
+    expect(
+      Vector3.eulerTo(Vector3.create(15, 0, -1e-6), Vector3.left())
     ).toMatchObject(Euler.create());
   });
 });

--- a/packages/geometry/src/__tests__/vector3.test.ts
+++ b/packages/geometry/src/__tests__/vector3.test.ts
@@ -130,10 +130,10 @@ describe(Vector3.eulerTo, () => {
   it('returns an euler angle with no rotation if the vectors if the angle between them is near 180 degrees', () => {
     expect(
       Vector3.eulerTo(Vector3.create(15, 1e-6, 0), Vector3.left())
-    ).toMatchObject(Euler.create());
+    ).toMatchObject(Euler.create({ x: Math.PI }));
     expect(
       Vector3.eulerTo(Vector3.create(15, 0, -1e-6), Vector3.left())
-    ).toMatchObject(Euler.create());
+    ).toMatchObject(Euler.create({ x: Math.PI }));
   });
 });
 

--- a/packages/geometry/src/quaternion.ts
+++ b/packages/geometry/src/quaternion.ts
@@ -45,6 +45,32 @@ export function fromJson(json: string): Quaternion {
 }
 
 /**
+ * Returns a quaternion with that will have a magnitude of 1.
+ */
+export function normalize(q: Quaternion): Quaternion {
+  return scale(1 / magnitude(q), q);
+}
+
+/**
+ * Returns the magnitude of the provided quaternion.
+ */
+export function magnitude(q: Quaternion): number {
+  return Math.sqrt(q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z);
+}
+
+/**
+ * Returns a quaternion where each component is multiplied by the `scalar`.
+ */
+export function scale(scalar: number, q: Quaternion): Quaternion {
+  return create({
+    w: q.w * scalar,
+    x: q.x * scalar,
+    y: q.y * scalar,
+    z: q.z * scalar,
+  });
+}
+
+/**
  * Creates a `Quaternion` that is rotated the given radians around an axis.
  *
  * @param axis The axis to rotate around.

--- a/packages/geometry/src/vector3.ts
+++ b/packages/geometry/src/vector3.ts
@@ -1,5 +1,7 @@
+import * as Euler from './euler';
 import { lerp as lerpNumber } from './math';
 import * as Matrix4 from './matrix4';
+import * as Quaternion from './quaternion';
 
 /**
  * A `Vector3` represents a vector of 3 dimensions values. It may represent a
@@ -268,6 +270,21 @@ export function angleTo(a: Vector3, b: Vector3): number {
   const theta = dot(a, b) / (magnitude(a) * magnitude(b));
   // Clamp to avoid numerical problems.
   return Math.acos(theta);
+}
+
+/**
+ * Returns the Euler angle, in radians with the `xyz` ordering, between two vectors.
+ */
+export function eulerTo(a: Vector3, b: Vector3): Euler.Euler {
+  const normalizedA = normalize(a);
+  const normalizedB = normalize(b);
+
+  const angle = Math.acos(dot(normalizedA, normalizedB));
+  const axis = normalize(cross(normalizedA, normalizedB));
+
+  return Euler.fromRotationMatrix(
+    Matrix4.makeRotation(Quaternion.fromAxisAngle(axis, angle))
+  );
 }
 
 /**

--- a/packages/geometry/src/vector3.ts
+++ b/packages/geometry/src/vector3.ts
@@ -282,6 +282,15 @@ export function eulerTo(a: Vector3, b: Vector3): Euler.Euler {
   const angle = Math.acos(dot(normalizedA, normalizedB));
   const axis = normalize(cross(normalizedA, normalizedB));
 
+  const vectorsAreParallel = angle === Math.PI || angle === 0;
+  const crossAxisIsDefined = (Object.keys(axis) as Array<keyof Vector3>).every(
+    (key) => !isNaN(axis[key])
+  );
+
+  if (vectorsAreParallel || !crossAxisIsDefined) {
+    return Euler.create();
+  }
+
   return Euler.fromRotationMatrix(
     Matrix4.makeRotation(Quaternion.fromAxisAngle(axis, angle))
   );

--- a/packages/geometry/src/vector3.ts
+++ b/packages/geometry/src/vector3.ts
@@ -282,7 +282,9 @@ export function eulerTo(a: Vector3, b: Vector3): Euler.Euler {
   const angle = Math.acos(dot(normalizedA, normalizedB));
   const axis = normalize(cross(normalizedA, normalizedB));
 
-  const vectorsAreParallel = angle === Math.PI || angle === 0;
+  const closeToParallel = Math.abs(angle) <= 1e-6;
+  const closeToAntiParallel = Math.abs(angle - Math.PI) <= 1e-6;
+  const vectorsAreParallel = closeToParallel || closeToAntiParallel;
   const crossAxisIsDefined = (Object.keys(axis) as Array<keyof Vector3>).every(
     (key) => !isNaN(axis[key])
   );

--- a/packages/geometry/src/vector3.ts
+++ b/packages/geometry/src/vector3.ts
@@ -275,6 +275,9 @@ export function angleTo(a: Vector3, b: Vector3): number {
 
 /**
  * Returns the Euler angle, in radians with the `xyz` ordering, between two vectors.
+ *
+ * This method will normalize both vectors for the calculation, and uses the
+ * algorithm described in https://www.xarg.org/proof/quaternion-from-two-vectors/.
  */
 export function eulerTo(a: Vector3, b: Vector3): Euler.Euler {
   const normalizedA = normalize(a);


### PR DESCRIPTION
## Summary

Adds an `eulerTo` utility for `Vector3`s to support determining the rotation to apply to the `<vertex-viewer-transform-widget>` based on a hit result normal and the global up vector.

## Test Plan

- Verify that the behavior in Connect continues to work as expected (after it has been updated with this version)
- Unit tests

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
