### PR TITLE
[PLAT-4038] Dispose of measurement cursor when the mode is not replace or edit

### DIFF
--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
@@ -478,6 +478,12 @@ export class ViewerMeasurementDistance {
   protected handleModeChanged(): void {
     this.warnIfDepthBuffersDisabled();
 
+    // If we're not in edit or replace mode, ensure that the measurement
+    // cursor is removed.
+    if (this.mode === '') {
+      this.stateMap.hoverCursor?.dispose();
+    }
+
     if (this.viewer != null) {
       this.removeInteractionListeners(this.viewer);
       this.addInteractionListeners(this.viewer);


### PR DESCRIPTION
## Summary

Updates the `<vertex-viewer-measurement-distance>` component to dispose of its hover cursor when the mode changes from `edit` or `replace` to `''` to prevent an issue where the cursor would persist if the mode changed while hovering over geometry.

## Test Plan

- Verify that changing the mode of the `<vertex-viewer-measurement-distance>` when the cursor is over geometry properly disposes of the cursor and returns it to the default

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
