### PR TITLE
[PLAT-3897] Update filter results

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -52,7 +52,7 @@
     "@vertexvis/frame-streaming-protos": "^0.13.2",
     "@vertexvis/geometry": "0.20.3",
     "@vertexvis/html-templates": "0.20.0",
-    "@vertexvis/scene-tree-protos": "^0.1.20",
+    "@vertexvis/scene-tree-protos": "^0.1.21",
     "@vertexvis/scene-view-protos": "^0.2.1",
     "@vertexvis/stream-api": "0.20.3",
     "@vertexvis/utils": "0.20.0",

--- a/packages/viewer/src/components/scene-tree/lib/controller.ts
+++ b/packages/viewer/src/components/scene-tree/lib/controller.ts
@@ -878,6 +878,14 @@ export class SceneTreeController {
 
         const { change } = msg.toObject();
 
+        // Update the number of filtered results if changed
+        if (change?.filterChange != null) {
+          this.updateState({
+            ...this.state,
+            totalFilteredRows: change.filterChange.numberOfResults,
+          });
+        }
+
         if (change?.listChange != null) {
           this.log('Received list change', change.listChange.start);
           this.invalidateAfterOffset(change.listChange.start);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,9 +2049,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^18", "@types/react@^18.2.48":
-  version "18.2.48"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.48.tgz#11df5664642d0bd879c1f58bc1d37205b064e8f1"
-  integrity sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==
+  version "18.2.64"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.64.tgz#3700fbb6b2fa60a6868ec1323ae4cbd446a2197d"
+  integrity sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2240,10 +2240,10 @@
   resolved "https://registry.yarnpkg.com/@vertexvis/rollup-plugin-web-workers/-/rollup-plugin-web-workers-0.1.0.tgz#53c0981df8127125e3fd3c67ddc0169693efec58"
   integrity sha512-5pJbF5/nMdqybxpZW2yBIQ9lF3P61ziaC3APTfHXU9APhnVfp+3jdW5PkrWGc45zFn1wCkuwEFhD+ORv3LEePw==
 
-"@vertexvis/scene-tree-protos@^0.1.20":
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.20.tgz#d68d60bd282e890b90311f0a734dbf2842ce29cf"
-  integrity sha512-oYK998gBqpA1t03XerD08dgVprEsGgGgfPqtfFcBnbsxMLfeNVNPTBjsRQne/oRXyde3Q7GBRgfMc7JuzSlCCQ==
+"@vertexvis/scene-tree-protos@^0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.21.tgz#a52c0476483609d2d927934cdd55c10a219a7c38"
+  integrity sha512-HuV0B5k3ujypeDJBsNUQCN1zeOOe8/IkNyi7E7uEQiR0sTGmjPtGhmlmOEPeYhkbxhptb+ZCFzN5n01WIyeZxw==
 
 "@vertexvis/scene-view-protos@^0.2.1":
   version "0.2.1"


### PR DESCRIPTION
## Summary
We now update the scene tree filter results immediately when visibility changes and the filter is set to remove hidden parts. Therefore, this PR listens for the current number of filter results and updates the state accordingly.

## Test Plan
Verify scene tree filters work as expected, particularly when removing hidden parts

## Release Notes
None

## Possible Regressions
Scene tree filtering

## Dependencies
https://github.com/Vertexvis/scene-tree-service/pull/202
