### PR TITLE
[PLAT-4084] Add deep equality check for stream attributes

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -60,6 +60,7 @@
     "camel-case": "^4.1.2",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
+    "fast-deep-equal": "^3.1.3",
     "fast-png": "^6.1.0",
     "google-protobuf": "3.19.4",
     "jwt-decode": "^3.1.2",

--- a/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
+++ b/packages/viewer/src/lib/stream/__tests__/stream.spec.ts
@@ -493,6 +493,32 @@ describe(ViewerStream, () => {
       expect(updateStream).toHaveBeenCalled();
     });
 
+    it('does not update stream attributes if equal', async () => {
+      const { stream, ws } = makeStream();
+
+      jest
+        .spyOn(stream, 'startStream')
+        .mockResolvedValue(Fixtures.Responses.startStream().response);
+      jest
+        .spyOn(stream, 'syncTime')
+        .mockResolvedValue(Fixtures.Responses.syncTime().response);
+
+      const updateStream = jest.spyOn(stream, 'updateStream');
+      const connected123 = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connected' && s.resource.resource.id === '123'
+      );
+      stream.load(urn123, clientId, deviceId, config);
+      await simulateFrame(ws);
+      await connected123;
+
+      stream.update({ streamAttributes: { featureLines: { width: 1 } } });
+      expect(updateStream).toHaveBeenCalled();
+      updateStream.mockClear();
+
+      stream.update({ streamAttributes: { featureLines: { width: 1 } } });
+      expect(updateStream).not.toHaveBeenCalled();
+    });
+
     it('updates dimensions if defined', async () => {
       const { stream, ws } = makeStream();
 
@@ -516,6 +542,32 @@ describe(ViewerStream, () => {
 
       stream.update({ dimensions: Dimensions.create(100, 100) });
       expect(updateDimensions).toHaveBeenCalled();
+    });
+
+    it('does not update dimensions if equal', async () => {
+      const { stream, ws } = makeStream();
+
+      jest
+        .spyOn(stream, 'startStream')
+        .mockResolvedValue(Fixtures.Responses.startStream().response);
+      jest
+        .spyOn(stream, 'syncTime')
+        .mockResolvedValue(Fixtures.Responses.syncTime().response);
+
+      const updateDimensions = jest.spyOn(stream, 'updateDimensions');
+      const connected123 = stream.stateChanged.onceWhen(
+        (s) => s.type === 'connected' && s.resource.resource.id === '123'
+      );
+      stream.load(urn123, clientId, deviceId, config);
+      await simulateFrame(ws);
+      await connected123;
+
+      stream.update({ dimensions: Dimensions.create(100, 100) });
+      expect(updateDimensions).toHaveBeenCalled();
+      updateDimensions.mockClear();
+
+      stream.update({ dimensions: Dimensions.create(100, 100) });
+      expect(updateDimensions).not.toHaveBeenCalled();
     });
 
     it('always request at least a 1x1 image', async () => {

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -17,6 +17,7 @@ import {
   Objects,
   Uri,
 } from '@vertexvis/utils';
+import deepEqual from 'fast-deep-equal';
 
 import { Color3, StreamAttributes } from '../../interfaces';
 import { Config, parseConfig } from '../config';
@@ -170,7 +171,10 @@ export class ViewerStream extends StreamApi {
       ? fields.frameBgColor
       : this.frameBgColor;
 
-    if (fields.dimensions != null && fields.dimensions !== this.dimensions) {
+    if (
+      fields.dimensions != null &&
+      !deepEqual(fields.dimensions, this.dimensions)
+    ) {
       this.dimensions = fields.dimensions;
       this.ifState('connected', () =>
         this.updateDimensions({ dimensions: this.getDimensions() })
@@ -179,7 +183,7 @@ export class ViewerStream extends StreamApi {
 
     if (
       fields.streamAttributes != null &&
-      this.streamAttributes !== fields.streamAttributes
+      !deepEqual(this.streamAttributes, fields.streamAttributes)
     ) {
       this.streamAttributes = fields.streamAttributes;
       this.ifState('connected', () =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,7 +2048,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18", "@types/react@^18.2.48":
+"@types/react@*", "@types/react@^18.2.48":
   version "18.2.64"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.64.tgz#3700fbb6b2fa60a6868ec1323ae4cbd446a2197d"
   integrity sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==


### PR DESCRIPTION
## Summary

Adds a deep equality check for the `streamAttributes` and `dimensions` of the stream. This prevents issues where equal but separate instances of an object would trigger an update and a new frame without any changes.

## Test Plan

- Verify that providing new instances of an equal object for properties like `featureLines` does not result in an update and new frame
- Verify that providing new instances of a different object still does trigger an update and new frame

## Release Notes

N/A

## Possible Regressions

Stream attribute changes, resizing

## Dependencies

N/A
