### PR TITLE
[PLAT-4008] Re-add tagging and viewer package check

### DIFF
--- a/scripts/detect_release.sh
+++ b/scripts/detect_release.sh
@@ -7,7 +7,7 @@
 set -e
 
 version=$(get_version)
-published_version=`npm view @vertexvis/utils --json versions | jq --arg version "$version" -r '.[] | select(. == $version)'`
+published_version=`npm view @vertexvis/viewer --json versions | jq --arg version "$version" -r '.[] | select(. == $version)'`
 
 if test -z "$published_version"
 then

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -11,15 +11,15 @@ sha="$(git rev-parse HEAD)"
 
 npx lerna publish from-package --yes
 
-# curl -s -X POST https://api.github.com/repos/$REPOSITORY/releases \
-# -H "Authorization: token $GITHUB_TOKEN" \
-# -d @- <<EOF
-# {
-#   "tag_name": "$version",
-#   "target_commitish": "$sha",
-#   "name": "$version",
-#   "body": "Automated release for $version\n",
-#   "draft": false,
-#   "prelease": false
-# }
-# EOF
+curl -s -X POST https://api.github.com/repos/$REPOSITORY/releases \
+-H "Authorization: token $GITHUB_TOKEN" \
+-d @- <<EOF
+{
+  "tag_name": "$version",
+  "target_commitish": "$sha",
+  "name": "$version",
+  "body": "Automated release for $version\n",
+  "draft": false,
+  "prelease": false
+}
+EOF


### PR DESCRIPTION
## Summary

Re-adds the tagging behavior on release along with the check on the `@vertexvis/viewer` package for detecting releases rather than the `@vertexvis/utils` package.

## Test Plan

- Verify the next release correctly creates a Github tag and uses the `@vertexvis/viewer` package to detect releases

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
