### PR TITLE
[PLAT-3841] Automatic release note population

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,16 @@ You can then create a PR from the release branch. Once your PR has been approved
 and merged, the CI pipeline will automatically publish packages to NPM, tag the
 release, and create a release in Github.
 
-If the publishing, open a new PR with any fixes and merge your changes. CI will
+If the publishing fails, open a new PR with any fixes and merge your changes. CI will
 attempt to republish the previous release that failed.
+
+### Release Notes
+
+Releases will be populated with release notes automatically based on the contents of
+the PR description. The release notes are generated using the contents of the `Summary`
+section of the PR, or the entirety of the body if that section is not present, and will
+take any items that are in a list format. This can also be edited after the release has
+been created.
 
 ## Test Releases
 

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ attempt to republish the previous release that failed.
 ### Release Notes
 
 Releases will be populated with release notes automatically based on the contents of
-the PR description. The release notes are generated using the contents of the `Summary`
-section of the PR, or the entirety of the body if that section is not present, and will
-take any items that are in a list format. This can also be edited after the release has
-been created.
+the release PR description. The release notes are generated using the contents of the
+`Summary` section of the PR, or the entirety of the body if that section is not present,
+and will take any items that are in a list format. This can also be edited after the release
+has been created.
 
 ## Test Releases
 

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -5,8 +5,10 @@
 set -e
 
 . "$(pwd)"/scripts/utils.sh
+. "$(pwd)"/scripts/release_notes.sh
 
 version="v$(get_version)"
+notes="$(get_release_notes)"
 sha="$(git rev-parse HEAD)"
 
 npx lerna publish from-package --yes
@@ -18,7 +20,7 @@ curl -s -X POST https://api.github.com/repos/$REPOSITORY/releases \
   "tag_name": "$version",
   "target_commitish": "$sha",
   "name": "$version",
-  "body": "Automated release for $version\n",
+  "body": "Automated release for $version<br/><br/>$notes",
   "draft": false,
   "prelease": false
 }

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -20,7 +20,7 @@ curl -s -X POST https://api.github.com/repos/$REPOSITORY/releases \
   "tag_name": "$version",
   "target_commitish": "$sha",
   "name": "$version",
-  "body": "Automated release for $version<br/><br/>$notes",
+  "body": "Automated release for $version\n\n$notes",
   "draft": false,
   "prelease": false
 }

--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -6,17 +6,20 @@ set -e
 
 function __read_summary() {
   READING_SUMMARY=1
-  LINE_REGEX="^[ ]*-.*"
-  SUMMARY_CONTENTS=""
+  LIST_ITEM_REGEX="^[ ]*-.*"
+  RELEASE_SUMMARY=""
+
   while IFS="" read -r line; do
     if [[ "$line" == "##"* ]] && [[ ! "$line" == *"## Summary"* ]]; then
+      # If we encounter another header after the Summary header, ignore future lines
       READING_SUMMARY=0
-    elif [[ "$line" =~ $LINE_REGEX ]] && [[ $READING_SUMMARY -ne 0 ]]; then
-      SUMMARY_CONTENTS="$SUMMARY_CONTENTS\n${line//$'\r'/}"
+    elif [[ "$line" =~ $LIST_ITEM_REGEX ]] && [[ $READING_SUMMARY -ne 0 ]]; then
+      # If we encounter a list item in the summary, append it to the release summary
+      RELEASE_SUMMARY="$RELEASE_SUMMARY\n${line//$'\r'/}"
     fi
   done < <(printf "$1")
 
-  echo "$SUMMARY_CONTENTS"
+  echo "$RELEASE_SUMMARY"
 }
 
 function get_release_notes() {
@@ -30,9 +33,9 @@ function get_release_notes() {
         | jq '.body'
     )
 
-    SUMMARY=$(__read_summary "$DESC")
+    RELEASE_SUMMARY=$(__read_summary "$DESC")
     
-    echo "Release Notes:$SUMMARY\n"
+    echo "Release Notes:$RELEASE_SUMMARY\n"
   else
     echo ""
   fi

--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+. "$(pwd)"/scripts/utils.sh
+
+function trim_comments() {
+  echo $1 | sed -r "s/(^\")|(\"$)//g" | sed -r 's/(<!--[^->]*-->)//g'
+}
+
+function get_release_notes() {
+  PR_NUMBER=$(git log -1 | grep -oE '(\(#)([0-9]*)[)]' | grep -oE '[0-9]*')
+
+  DESC=$(
+    curl -L https://api.github.com/repos/$REPOSITORY/pulls/$PR_NUMBER \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      | jq '.body'
+  )
+
+  DESC=$(trim_comments "$DESC")
+  RELEASE_NOTES=$(echo $DESC | grep -oE '[#]{2} Summary.*' | grep -oE '[-]([^\\])*')
+
+  echo "Release Notes:<br/>"$RELEASE_NOTES | sed -r 's/[-]/<br\/>-/g'
+}


### PR DESCRIPTION
## Summary

Adds a `release_notes` script that will pull the `body` of the previous PR when a release is published, and generate release notes based on the contents of that PR. The generation of these release notes will attempt to read specifically the `Summary` section of the PR body, but will fall back to reading the full PR body up until the next heading (`##`) that is not the `Summary`. The script expects that the items to be included in the release notes are in a list format.

## Test Plan

- Verify that releases are published with notes from the release PR

## Release Notes

N/A

## Possible Regressions

Releases

## Dependencies

N/A
