### PR TITLE
[PLAT-4258] Fix view cube in WebKit browsers

### DIFF
--- a/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.tsx
+++ b/packages/viewer/src/components/viewer-dom-group/viewer-dom-group.tsx
@@ -17,7 +17,8 @@ import { HTMLDomRendererPositionableElement } from '../../interfaces';
 @Component({
   tag: 'vertex-viewer-dom-group',
   styleUrl: 'viewer-dom-group.css',
-  shadow: true,
+  shadow: false,
+  scoped: true,
 })
 export class ViewerDomGroup implements HTMLDomRendererPositionableElement {
   /**

--- a/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
@@ -43,7 +43,7 @@ export function update3d(
   depthBuffer: DepthBuffer | undefined
 ): void {
   for (let i = 0; i < element.children.length; i++) {
-    const el = element.children[i];
+    const el = element.children[i] as HTMLElement;
     if (isVertexViewerDomElement(el)) {
       updateElement(
         el as HTMLVertexViewerDomElementElement,
@@ -54,6 +54,8 @@ export function update3d(
       );
     } else if (isVertexViewerDomGroup(el)) {
       updateGroup(el, parentWorldMatrix, viewport, camera, depthBuffer);
+    } else {
+      update3d(el, parentWorldMatrix, viewport, camera, depthBuffer);
     }
   }
 }

--- a/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
@@ -25,7 +25,8 @@ export type ViewerDomRendererDrawMode = '2d' | '3d';
 @Component({
   tag: 'vertex-viewer-dom-renderer',
   styleUrl: 'viewer-dom-renderer.css',
-  shadow: true,
+  shadow: false,
+  scoped: true,
 })
 export class ViewerDomRenderer {
   /**

--- a/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.css
+++ b/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.css
@@ -69,7 +69,7 @@
   position: unset;
   width: 100%;
   height: 100%;
-  overflow: visible;
+  overflow: visible !important;
 }
 
 .reference-point {
@@ -218,6 +218,12 @@
   background-color: black;
   opacity: 0.12;
   filter: blur(4px);
+}
+
+.cube-side-face,
+.cube-corner-face,
+.cube-edge-face {
+  pointer-events: initial;
 }
 
 .cube-corner .cube-corner-face,


### PR DESCRIPTION
## Summary

Fixes an issue in WebKit based browsers where the view cube is flattened. This appears to happen because of a bug in WebKit with the `transform-style: preserve-3d` behavior not cascading through to `<slot>` children. Fix is to have the 3D renderers and elements not use shadow DOM and instead use scoped styles.

https://vertexvis.atlassian.net/browse/PLAT-4258