### PR TITLE
[PLAT-4258] Fix positioning of 2d rendered elements

### DIFF
--- a/packages/viewer/src/components/viewer-dom-renderer/renderer2d.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/renderer2d.tsx
@@ -57,7 +57,7 @@ function getElementDepths(
   const results = [] as ElementData[];
 
   for (let i = 0; i < element.children.length; i++) {
-    const child = element.children[i];
+    const child = element.children[i] as HTMLElement;
 
     if (isVertexViewerDomGroup(child)) {
       const worldMatrix = Matrix4.multiply(parentWorldMatrix, child.matrix);
@@ -75,6 +75,8 @@ function getElementDepths(
         worldPosition,
         distanceToCamera,
       });
+    } else {
+      results.push(...getElementDepths(child, parentWorldMatrix, camera));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the positioning of 2D rendered elements inside a `<vertex-viewer-dom-renderer>` that was caused by scoping changes in #596.

https://vertexvis.atlassian.net/browse/PLAT-4258