### PR TITLE
[PLAT-4349] Support only calculating occlusion and detachment on final frames

### DIFF
--- a/packages/viewer/src/components/viewer-dom-renderer/readme.md
+++ b/packages/viewer/src/components/viewer-dom-renderer/readme.md
@@ -174,7 +174,7 @@ property.
 The renderer supports occluding its elements based on the element's position and
 depth information returned on a frame. If depth buffers are requested for all 
 frames, the occlusion state will be updated on every frame. Conversely, if depth 
-buffers are only requested on final frames, the occlusion state only be calculated
+buffers are only requested on final frames, the occlusion state will only be calculated
 on final frames and will always report occluded on transitional frames.
 
 Occlusion can be enabled or disabled per element by setting its `occlusion-off`
@@ -214,7 +214,7 @@ attribute.
 The renderer supports determining whether an element is detached from geometry based on the element's position and
 depth information returned on a frame. If depth buffers are requested for all
 frames, the detached state will be updated on every frame. Conversely, if depth
-buffers are only requested on final frames, the detached state only be calculated
+buffers are only requested on final frames, the detached state will only be calculated
 on final frames and will always report detached on transitional frames.
 
 Detachment testing can be enabled or disabled per element by setting its `detached-off`

--- a/packages/viewer/src/components/viewer-dom-renderer/readme.md
+++ b/packages/viewer/src/components/viewer-dom-renderer/readme.md
@@ -172,8 +172,10 @@ property.
 
 ## Occlusion
 The renderer supports occluding its elements based on the element's position and
-depth information returned on a frame. **Note:** you must opt-in to requesting
-a depth buffer for all frames in order for occlusion to work.
+depth information returned on a frame. If depth buffers are requested for all 
+frames, the occlusion state will be updated on every frame. Conversely, if depth 
+buffers are only requested on final frames, the occlusion state only be calculated
+on final frames and will always report occluded on transitional frames.
 
 Occlusion can be enabled or disabled per element by setting its `occlusion-off`
 attribute.
@@ -210,8 +212,10 @@ attribute.
 
 ## Detachment
 The renderer supports determining whether an element is detached from geometry based on the element's position and
-depth information returned on a frame. **Note:** you must opt-in to requesting
-a depth buffer for all frames in order for detached determinations to work.
+depth information returned on a frame. If depth buffers are requested for all
+frames, the detached state will be updated on every frame. Conversely, if depth
+buffers are only requested on final frames, the detached state only be calculated
+on final frames and will always report detached on transitional frames.
 
 Detachment testing can be enabled or disabled per element by setting its `detached-off`
 attribute.

--- a/packages/viewer/src/components/viewer-dom-renderer/renderer2d.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/renderer2d.tsx
@@ -32,10 +32,15 @@ export function update2d(
   for (let i = 0; i < elements.length; i++) {
     const { element, worldMatrix, worldPosition } = elements[i];
 
+    const depthBufferIsNull = depthBuffer == null;
     const occluded =
-      !element.occlusionOff && depthBuffer?.isOccluded(worldPosition, viewport);
+      depthBufferIsNull ||
+      (!element.occlusionOff &&
+        depthBuffer?.isOccluded(worldPosition, viewport));
     const detached =
-      !element.detachedOff && depthBuffer?.isDetached(worldPosition, viewport);
+      depthBufferIsNull ||
+      (!element.detachedOff &&
+        depthBuffer?.isDetached(worldPosition, viewport));
     const screenPt = getScreenPosition(
       worldPosition,
       camera.projectionViewMatrix,

--- a/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
@@ -70,11 +70,14 @@ function updateElement(
   const worldMatrix = Matrix4.multiply(parentWorldMatrix, element.matrix);
 
   const positionWorld = Vector3.fromMatrixPosition(worldMatrix);
+  const depthBufferIsNull = depthBuffer == null;
   const occluded =
-    !element.occlusionOff && depthBuffer?.isOccluded(positionWorld, viewport);
+    depthBufferIsNull ||
+    (!element.occlusionOff && depthBuffer?.isOccluded(positionWorld, viewport));
   element.occluded = occluded ?? false;
   const detached =
-    !element.detachedOff && depthBuffer?.isDetached(positionWorld, viewport);
+    depthBufferIsNull ||
+    (!element.detachedOff && depthBuffer?.isDetached(positionWorld, viewport));
   element.detached = detached ?? false;
   element.classList.add('ready');
 

--- a/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.spec.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.spec.tsx
@@ -342,6 +342,7 @@ describe('<vertex-viewer-dom-renderer>', () => {
                   scene: {
                     camera,
                   },
+                  depthBuffer: jest.fn().mockReturnValue(undefined),
                 },
               } as unknown as HTMLVertexViewerElement
             }

--- a/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/viewer-dom-renderer.tsx
@@ -175,10 +175,9 @@ export class ViewerDomRenderer {
   }
 
   private async updatePropsFromViewer(): Promise<void> {
-    const { frame, depthBuffers } = this.viewer || {};
+    const { frame } = this.viewer || {};
 
-    this.depthBuffer =
-      depthBuffers === 'all' ? await frame?.depthBuffer() : undefined;
+    this.depthBuffer = await frame?.depthBuffer();
     this.camera = frame?.scene.camera;
   }
 }


### PR DESCRIPTION
## Summary
Previously, we required users to request depth buffers on every frame in order to use the occlusion and detachment features. This PR adds support for the feature when depth buffers are only requested on final frames.  

If depth buffers are requested for all frames, the occlusion and detached states will be updated on every frame. Conversely, if depth buffers are only requested on final frames, the occlusion and detached states will only be calculated
on final frames and will always report occluded and detached on transitional frames.

## Test Plan
Verify occlusion and detachment features can be used both when depth buffers are requested on every frame and only on final frames

## Release Notes
Support for only calculating occlusion and detachment on final frames 

## Possible Regressions
Occlusion and Detachment

## Dependencies
None