### PR TITLE
[PLAT-4360] Update orthographic camera after bounding box changes

### DIFF
--- a/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
@@ -155,7 +155,7 @@ describe(InteractionApiOrthographic, () => {
       expect(update.mock.calls[1][0].lookAt).toMatchObject({
         x: -1,
         y: 0,
-        z: 24.999999999999996,
+        z: expect.closeTo(25, 5),
       });
     });
   });

--- a/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
@@ -155,7 +155,7 @@ describe(InteractionApiOrthographic, () => {
       expect(update.mock.calls[1][0].lookAt).toMatchObject({
         x: -1,
         y: 0,
-        z: 0,
+        z: 24.999999999999996,
       });
     });
   });
@@ -189,6 +189,31 @@ describe(InteractionApiOrthographic, () => {
         (update.mock.calls[0][0] as FrameCamera.OrthographicFrameCamera)
           .fovHeight
       ).toBe(5);
+    });
+  });
+
+  describe(InteractionApiOrthographic.prototype.rotateCamera, () => {
+    it('changes the fovHeight and lookAt of the orthographic camera', async () => {
+      const data = FrameCamera.createOrthographic();
+      const mockOrthographicCamera = new OrthographicCamera(
+        streamApi,
+        1,
+        data,
+        BoundingBox.create(Vector3.create(), Vector3.create(50, 50, 100)),
+        fromPbFrameOrThrow(Orientation.DEFAULT)
+      );
+      jest
+        .spyOn(scene, 'camera')
+        .mockImplementation(() => mockOrthographicCamera);
+      const update = jest.spyOn(mockOrthographicCamera, 'update');
+
+      await api.beginInteraction();
+      await api.rotateCamera(Point.create(10, 0));
+      await api.endInteraction();
+
+      expect(update.mock.calls[0][0].lookAt?.x).toBeCloseTo(0);
+      expect(update.mock.calls[0][0].lookAt?.y).toBeCloseTo(0);
+      expect(update.mock.calls[0][0].lookAt?.z).toBe(0);
     });
   });
 });

--- a/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
+++ b/packages/viewer/src/lib/interactions/flyToPositionKeyInteraction.ts
@@ -2,6 +2,7 @@ import { BoundingBox, Point, Vector3 } from '@vertexvis/geometry';
 import { StreamApi, toProtoDuration } from '@vertexvis/stream-api';
 
 import { ConfigProvider } from '../config';
+import { updateLookAtRelativeToBoundingBoxCenter } from '../rendering/vectors';
 import { ImageScaleProvider, Scene } from '../scenes';
 import { FrameCamera } from '../types';
 import { KeyInteraction } from './keyInteraction';
@@ -94,17 +95,11 @@ export class FlyToPositionKeyInteraction
       // Update the lookAt point to take the center of the model into account
       // This change helps ensure that the lookAt point is consistent between
       // the SDK and back-end system such that the calculated depth buffer is correct.
-
-      const updatedCenterPoint = Vector3.subtract(
-        BoundingBox.center(scene.boundingBox()),
-        hitPoint
+      return updateLookAtRelativeToBoundingBoxCenter(
+        hitPoint,
+        viewVector,
+        BoundingBox.center(scene.boundingBox())
       );
-      const orthogonalOffset = Vector3.dot(viewVector, updatedCenterPoint);
-      const viewVectorMagnitudeSquared = Vector3.magnitudeSquared(viewVector);
-      const offset = orthogonalOffset / viewVectorMagnitudeSquared;
-
-      const scaledViewVector = Vector3.scale(offset, viewVector);
-      return Vector3.add(scaledViewVector, hitPoint);
     } else {
       // For perspective, just return the hit point
       return hitPoint;

--- a/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
+++ b/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
@@ -4,6 +4,7 @@ import { StreamApi } from '@vertexvis/stream-api';
 
 import { ReceivedFrame } from '../..';
 import { CursorManager } from '../cursors';
+import { updateLookAtRelativeToBoundingBoxCenter } from '../rendering/vectors';
 import { OrthographicCamera } from '../scenes';
 import { DepthBuffer, Viewport } from '../types';
 import { ZoomData } from './interactionApi';
@@ -278,21 +279,11 @@ export class InteractionApiOrthographic extends InteractionApi<OrthographicCamer
       // Update the lookAt point to take the center of the model into account
       // This change helps ensure that the lookAt point is consistent between
       // the SDK and back-end system such that the calculated depth buffer is correct.
-      const updatedCenterPoint = Vector3.subtract(
-        BoundingBox.center(boundingBox),
-        updated.lookAt
-      );
-      const orthogonalOffset = Vector3.dot(
+      const newLookAt = updateLookAtRelativeToBoundingBoxCenter(
+        updated.lookAt,
         updated.viewVector,
-        updatedCenterPoint
+        BoundingBox.center(boundingBox)
       );
-      const viewVectorMagnitudeSquared = Vector3.magnitudeSquared(
-        updated.viewVector
-      );
-      const offset = orthogonalOffset / viewVectorMagnitudeSquared;
-
-      const scaledViewVector = Vector3.scale(offset, updated.viewVector);
-      const newLookAt = Vector3.add(scaledViewVector, updated.lookAt);
 
       // Update only the lookAt point. The rotationPoint should remain
       // constant until a different type of interaction is performed.

--- a/packages/viewer/src/lib/rendering/__tests__/vectors.spec.ts
+++ b/packages/viewer/src/lib/rendering/__tests__/vectors.spec.ts
@@ -1,6 +1,9 @@
 import { BoundingBox, BoundingSphere, Vector3 } from '@vertexvis/geometry';
 
-import { constrainViewVector } from '../vectors';
+import {
+  constrainViewVector,
+  updateLookAtRelativeToBoundingBoxCenter,
+} from '../vectors';
 
 describe(constrainViewVector, () => {
   it('scales up the provided view vector to the radius of the provided bounding sphere', () => {
@@ -32,6 +35,26 @@ describe(constrainViewVector, () => {
       x: 0,
       y: 0,
       z: Math.sqrt(30000),
+    });
+  });
+});
+
+describe(updateLookAtRelativeToBoundingBoxCenter, () => {
+  it('updates the lookAt point relative to the provided view vector and center point', () => {
+    const originalLookAt = Vector3.create(1, 2, 3);
+    const viewVector = Vector3.create(5, 5, 5);
+    const boundingSphereCenter = Vector3.create(0, 0, 0);
+
+    expect(
+      updateLookAtRelativeToBoundingBoxCenter(
+        originalLookAt,
+        viewVector,
+        boundingSphereCenter
+      )
+    ).toMatchObject({
+      x: -1,
+      y: 0,
+      z: 1,
     });
   });
 });

--- a/packages/viewer/src/lib/rendering/vectors.ts
+++ b/packages/viewer/src/lib/rendering/vectors.ts
@@ -9,3 +9,20 @@ export function constrainViewVector(
 
   return Vector3.scale(scale, viewVector);
 }
+
+export function updateLookAtRelativeToBoundingBoxCenter(
+  originalLookAt: Vector3.Vector3,
+  viewVector: Vector3.Vector3,
+  boundingSphereCenter: Vector3.Vector3
+): Vector3.Vector3 {
+  const updatedCenterPoint = Vector3.subtract(
+    boundingSphereCenter,
+    originalLookAt
+  );
+  const orthogonalOffset = Vector3.dot(viewVector, updatedCenterPoint);
+  const viewVectorMagnitudeSquared = Vector3.magnitudeSquared(viewVector);
+  const offset = orthogonalOffset / viewVectorMagnitudeSquared;
+
+  const scaledViewVectorForOffset = Vector3.scale(offset, viewVector);
+  return Vector3.add(scaledViewVectorForOffset, originalLookAt);
+}

--- a/packages/viewer/src/lib/scenes/camera.ts
+++ b/packages/viewer/src/lib/scenes/camera.ts
@@ -10,7 +10,10 @@ import { StreamApi } from '@vertexvis/stream-api';
 import { UUID } from '@vertexvis/utils';
 
 import { FrameDecoder } from '../mappers';
-import { constrainViewVector } from '../rendering/vectors';
+import {
+  constrainViewVector,
+  updateLookAtRelativeToBoundingBoxCenter,
+} from '../rendering/vectors';
 import { DEFAULT_TIMEOUT_IN_MS } from '../stream/dispatcher';
 import {
   Animation,
@@ -772,12 +775,17 @@ export class OrthographicCamera
   }
 
   public toFrameCamera(): FrameOrthographicCamera {
-    return new FrameOrthographicCamera(
-      constrainViewVector(
-        this.viewVector,
-        BoundingSphere.create(this.boundingBox)
-      ),
+    const boundingSphere = BoundingSphere.create(this.boundingBox);
+    const viewVector = constrainViewVector(this.viewVector, boundingSphere);
+    const lookAt = updateLookAtRelativeToBoundingBoxCenter(
       this.lookAt,
+      viewVector,
+      boundingSphere.center
+    );
+
+    return new FrameOrthographicCamera(
+      viewVector,
+      lookAt,
       this.up,
       this.near,
       this.far,

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -11,7 +11,10 @@ import {
 import { UUID } from '@vertexvis/utils';
 
 import { decodePng } from '../../workers/png-decoder-pool';
-import { constrainViewVector } from '../rendering/vectors';
+import {
+  constrainViewVector,
+  updateLookAtRelativeToBoundingBoxCenter,
+} from '../rendering/vectors';
 import * as ClippingPlanes from './clippingPlanes';
 import * as CrossSectioning from './crossSectioning';
 import { DepthBuffer } from './depthBuffer';
@@ -240,12 +243,17 @@ export class FrameCameraBase implements FrameCameraLike {
     );
 
     if (FrameCamera.isOrthographicFrameCamera(camera)) {
-      return new FrameOrthographicCamera(
-        constrainViewVector(
-          camera.viewVector,
-          BoundingSphere.create(boundingBox)
-        ),
+      const boundingSphere = BoundingSphere.create(boundingBox);
+      const viewVector = constrainViewVector(camera.viewVector, boundingSphere);
+      const lookAt = updateLookAtRelativeToBoundingBoxCenter(
         camera.lookAt,
+        viewVector,
+        boundingSphere.center
+      );
+
+      return new FrameOrthographicCamera(
+        viewVector,
+        lookAt,
         camera.up,
         near,
         far,


### PR DESCRIPTION
## Summary
We were not correctly updating the orthographic camera after the bounding box of a model changed, for example after a large transform. This PR correctly updates the camera to ensure subsequent interactions with the model behave as expected.

## Test Plan
Verify orthographic cameras work as expected. Specifically, perform transforms that alter the model's bounding box and then interact with the model using rotation, panning, zooming, and fitting to specific parts.

## Release Notes
Orthographic camera improvements

## Possible Regressions
Interactions with orthographic cameras

## Dependencies
None
