### PR TITLE
[PLAT-4344] Consolidate camera calculations for perspective and orthographic cameras

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "nextVersionBump": "patch",
+  "nextVersionBump": "minor",
   "devDependencies": {
     "eslint": "^8.17.0",
     "http-server": "^14.1.1",

--- a/packages/viewer/src/components/viewer-dom-renderer/renderer2d.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/renderer2d.tsx
@@ -3,7 +3,7 @@ import { FunctionalComponent, h } from '@stencil/core';
 import { Matrix4, Point, Vector3 } from '@vertexvis/geometry';
 
 import { DepthBuffer, Viewport } from '../../lib/types';
-import { FrameCameraWithMatrices } from '../../lib/types/frame';
+import { FrameCameraBase } from '../../lib/types/frame';
 import { isVertexViewerDomElement } from '../viewer-dom-element/utils';
 import { isVertexViewerDomGroup } from '../viewer-dom-group/utils';
 
@@ -22,7 +22,7 @@ export function update2d(
   hostEl: HTMLElement,
   parentWorldMatrix: Matrix4.Matrix4,
   viewport: Viewport,
-  camera: FrameCameraWithMatrices,
+  camera: FrameCameraBase,
   depthBuffer: DepthBuffer | undefined
 ): void {
   const elements = getElementDepths(hostEl, parentWorldMatrix, camera).sort(
@@ -60,7 +60,7 @@ export function update2d(
 function getElementDepths(
   element: HTMLElement,
   parentWorldMatrix: Matrix4.Matrix4,
-  camera: FrameCameraWithMatrices
+  camera: FrameCameraBase
 ): ElementData[] {
   const results = [] as ElementData[];
 

--- a/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
+++ b/packages/viewer/src/components/viewer-dom-renderer/renderer3d.tsx
@@ -3,12 +3,12 @@ import { FunctionalComponent, h } from '@stencil/core';
 import { Matrix4, Vector3 } from '@vertexvis/geometry';
 
 import { DepthBuffer, Viewport } from '../../lib/types';
-import { FrameCameraWithMatrices } from '../../lib/types/frame';
+import { FrameCameraBase } from '../../lib/types/frame';
 import { isVertexViewerDomElement } from '../viewer-dom-element/utils';
 import { isVertexViewerDomGroup } from '../viewer-dom-group/utils';
 
 interface Props {
-  camera: FrameCameraWithMatrices;
+  camera: FrameCameraBase;
   viewport: Viewport;
 }
 
@@ -39,7 +39,7 @@ export function update3d(
   element: HTMLElement,
   parentWorldMatrix: Matrix4.Matrix4,
   viewport: Viewport,
-  camera: FrameCameraWithMatrices,
+  camera: FrameCameraBase,
   depthBuffer: DepthBuffer | undefined
 ): void {
   for (let i = 0; i < element.children.length; i++) {
@@ -64,7 +64,7 @@ function updateElement(
   element: HTMLVertexViewerDomElementElement,
   parentWorldMatrix: Matrix4.Matrix4,
   viewport: Viewport,
-  camera: FrameCameraWithMatrices,
+  camera: FrameCameraBase,
   depthBuffer: DepthBuffer | undefined
 ): void {
   const worldMatrix = Matrix4.multiply(parentWorldMatrix, element.matrix);
@@ -104,7 +104,7 @@ function updateGroup(
   element: HTMLVertexViewerDomGroupElement,
   parentWorldMatrix: Matrix4.Matrix4,
   viewport: Viewport,
-  camera: FrameCameraWithMatrices,
+  camera: FrameCameraBase,
   depthBuffer: DepthBuffer | undefined
 ): void {
   const worldMatrix = Matrix4.multiply(parentWorldMatrix, element.matrix);

--- a/packages/viewer/src/components/viewer-measurement-distance/__tests__/hitTest.spec.ts
+++ b/packages/viewer/src/components/viewer-measurement-distance/__tests__/hitTest.spec.ts
@@ -15,7 +15,7 @@ describe(PointToPointHitTester, () => {
     const viewport = new Viewport(100, 100);
     const depthBuffer = makeDepthBuffer(100, 100, undefined, camera);
     const depth = camera.far - camera.near;
-    const ray = viewport.transformPointToOrthographicRay(
+    const ray = viewport.transformPointToRay(
       Point.create(10, 10),
       depthBuffer,
       camera

--- a/packages/viewer/src/components/viewer-measurement-distance/hitTest.ts
+++ b/packages/viewer/src/components/viewer-measurement-distance/hitTest.ts
@@ -42,16 +42,9 @@ export class PointToPointHitTester {
     const buffer = this.pickDepthBuffer(pt);
 
     if (buffer != null) {
-      return this.camera == null || this.camera.isPerspective()
-        ? this.viewport.transformPointToWorldSpace(pt, buffer)
-        : this.viewport.transformPointToOrthographicWorldSpace(pt, buffer);
+      return this.viewport.transformPointToWorldSpace(pt, buffer);
     } else if (ignoreHitTest) {
-      return this.camera == null || this.camera.isPerspective()
-        ? this.viewport.transformPointToWorldSpace(pt, this.depthBuffer)
-        : this.viewport.transformPointToOrthographicWorldSpace(
-            pt,
-            this.depthBuffer
-          );
+      return this.viewport.transformPointToWorldSpace(pt, this.depthBuffer);
     }
   }
 

--- a/packages/viewer/src/components/viewer-transform-widget/util.ts
+++ b/packages/viewer/src/components/viewer-transform-widget/util.ts
@@ -44,12 +44,13 @@ export function convertCanvasPointToWorld(
     transform != null ? Vector3.fromMatrixPosition(transform) : undefined;
 
   if (point != null && frame != null && viewport != null && position != null) {
+    const ray = viewport.transformPointToRay(
+      point,
+      frame.image,
+      frame.scene.camera
+    );
+
     if (frame.scene.camera.isOrthographic()) {
-      const ray = viewport.transformPointToOrthographicRay(
-        point,
-        frame.image,
-        frame.scene.camera
-      );
       // Offset the point to past the bounding sphere of the model to
       // adjust the position plane location.
       const offsetPoint = Ray.at(
@@ -68,12 +69,6 @@ export function convertCanvasPointToWorld(
         )
       );
     } else {
-      const ray = viewport.transformPointToRay(
-        point,
-        frame.image,
-        frame.scene.camera
-      );
-
       return Ray.intersectPlane(
         ray,
         Plane.fromNormalAndCoplanarPoint(frame.scene.camera.direction, position)

--- a/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
@@ -83,11 +83,9 @@ describe(InteractionApiOrthographic, () => {
     () => {
       it('uses an orthographic ray to determine a world point', async () => {
         const depthBuffer = (await frame.depthBuffer()) as DepthBuffer;
-        jest
-          .spyOn(depthBuffer, 'getOrthographicDepthAtPoint')
-          .mockImplementation(() => 0);
+        jest.spyOn(depthBuffer, 'getDepthAtPoint').mockImplementation(() => 0);
 
-        const expectedRay = viewport.transformPointToOrthographicRay(
+        const expectedRay = viewport.transformPointToRay(
           Point.create(1, 1),
           frame.image,
           frame.scene.camera

--- a/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
+++ b/packages/viewer/src/lib/interactions/interactionApiOrthographic.ts
@@ -68,7 +68,7 @@ export class InteractionApiOrthographic extends InteractionApi<OrthographicCamer
 
     const depthBuffer = await frame.depthBuffer();
     return depthBuffer != null
-      ? viewport.transformPointToOrthographicWorldSpace(point, depthBuffer, 0.5)
+      ? viewport.transformPointToWorldSpace(point, depthBuffer, 0.5)
       : undefined;
   }
 
@@ -118,7 +118,7 @@ export class InteractionApiOrthographic extends InteractionApi<OrthographicCamer
         const startingCamera = camera.toFrameCamera();
         const direction = startingCamera.direction;
 
-        const ray = viewport.transformPointToOrthographicRay(
+        const ray = viewport.transformPointToRay(
           screenPt,
           frame.image,
           startingCamera
@@ -143,7 +143,7 @@ export class InteractionApiOrthographic extends InteractionApi<OrthographicCamer
 
         // Use a ray that originates at the screen and intersects with the hit
         // plane to determine the move distance.
-        const ray = viewport.transformPointToOrthographicRay(
+        const ray = viewport.transformPointToRay(
           screenPt,
           frame.image,
           startingCamera
@@ -177,7 +177,7 @@ export class InteractionApiOrthographic extends InteractionApi<OrthographicCamer
         ) {
           const frameCam = camera.toFrameCamera();
           const dir = frameCam.direction;
-          const ray = viewport.transformPointToOrthographicRay(
+          const ray = viewport.transformPointToRay(
             point,
             frame.image,
             frameCam
@@ -302,7 +302,7 @@ export class InteractionApiOrthographic extends InteractionApi<OrthographicCamer
     const framePt = viewport.transformPointToFrame(point, depthBuffer);
     const hasDepth = depthBuffer.hitTest(framePt);
     return hasDepth
-      ? viewport.transformPointToOrthographicWorldSpace(point, depthBuffer)
+      ? viewport.transformPointToWorldSpace(point, depthBuffer)
       : fallbackPoint;
   }
 }

--- a/packages/viewer/src/lib/transforms/hits.ts
+++ b/packages/viewer/src/lib/transforms/hits.ts
@@ -48,13 +48,11 @@ export function testTriangle(
   point: Point.Point
 ): boolean {
   if (points.length === 3) {
-    const ray = frame.scene.camera.isOrthographic()
-      ? viewport.transformPointToOrthographicRay(
-          point,
-          frame.image,
-          frame.scene.camera
-        )
-      : viewport.transformPointToRay(point, frame.image, frame.scene.camera);
+    const ray = viewport.transformPointToRay(
+      point,
+      frame.image,
+      frame.scene.camera
+    );
 
     const edge1 = Vector3.subtract(points[1], points[0]);
     const edge2 = Vector3.subtract(points[2], points[0]);

--- a/packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts
@@ -38,6 +38,31 @@ describe(DepthBuffer, () => {
     makeDepthImageBytes(100, 100, (2 ** 16 - 1) / 2)
   );
 
+  function createDepthBufferWithDepth(
+    cameraToConsider: FrameCameraBase,
+    depthValue: number
+  ): {
+    ray: Ray.Ray;
+    depthBuffer: DepthBuffer;
+    pt: Point.Point;
+  } {
+    const depthBuffer = new DepthBuffer(
+      cameraToConsider,
+      {
+        frameDimensions: Dimensions.create(100, 100),
+        imageRect: Rectangle.create(0, 0, 100, 100),
+        imageScale: 1,
+      },
+      makeDepthImageBytes(100, 100, depthValue)
+    );
+
+    const viewport = new Viewport(100, 100);
+    const pt = Point.create(50, 50);
+    const ray = viewport.transformPointToRay(pt, depthBuffer, cameraToConsider);
+
+    return { ray, depthBuffer, pt };
+  }
+
   describe(DepthBuffer.prototype.getDepthAtPoint, () => {
     it('returns depth between near and far plane for perspective', () => {
       const depth = depthBuffer.getDepthAtPoint(Point.create(1, 1));
@@ -95,7 +120,7 @@ describe(DepthBuffer, () => {
 
   describe(DepthBuffer.prototype.getWorldPoint, () => {
     describe('with perspective camera', () => {
-      const camera = new FramePerspectiveCamera(
+      const perspectiveCamera = new FramePerspectiveCamera(
         { x: 0, y: 0, z: 5 },
         Vector3.origin(),
         Vector3.up(),
@@ -105,36 +130,18 @@ describe(DepthBuffer, () => {
         45
       );
 
-      function createDepthBufferWithDepth(depthValue: number): {
-        ray: Ray.Ray;
-        depthBuffer: DepthBuffer;
-        pt: Point.Point;
-      } {
-        const depthBuffer = new DepthBuffer(
-          camera,
-          {
-            frameDimensions: Dimensions.create(100, 100),
-            imageRect: Rectangle.create(0, 0, 100, 100),
-            imageScale: 1,
-          },
-          makeDepthImageBytes(100, 100, depthValue)
-        );
-
-        const viewport = new Viewport(100, 100);
-        const pt = Point.create(50, 50);
-        const ray = viewport.transformPointToRay(pt, depthBuffer, camera);
-
-        return { ray, depthBuffer, pt };
-      }
-
       it('returns correct world position for near plane', () => {
-        const { ray, depthBuffer, pt } = createDepthBufferWithDepth(0);
+        const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
+          perspectiveCamera,
+          0
+        );
         const pos = depthBuffer.getWorldPoint(pt, ray);
         expect(pos.z).toBe(4);
       });
 
       it('returns correct world position for far plane', () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
+          perspectiveCamera,
           DepthBuffer.MAX_DEPTH_VALUE
         );
         const pos = depthBuffer.getWorldPoint(pt, ray);
@@ -143,6 +150,7 @@ describe(DepthBuffer, () => {
 
       it('returns correct world position between near and far plane', () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
+          perspectiveCamera,
           DepthBuffer.MAX_DEPTH_VALUE / 2
         );
         const pos = depthBuffer.getWorldPoint(pt, ray);
@@ -151,7 +159,7 @@ describe(DepthBuffer, () => {
     });
 
     describe('with orthographic camera', () => {
-      const camera = new FrameOrthographicCamera(
+      const orthographicCamera = new FrameOrthographicCamera(
         { x: 0, y: 0, z: 100 },
         Vector3.origin(),
         Vector3.up(),
@@ -161,36 +169,18 @@ describe(DepthBuffer, () => {
         1
       );
 
-      function createDepthBufferWithDepth(depthValue: number): {
-        ray: Ray.Ray;
-        depthBuffer: DepthBuffer;
-        pt: Point.Point;
-      } {
-        const depthBuffer = new DepthBuffer(
-          camera,
-          {
-            frameDimensions: Dimensions.create(100, 100),
-            imageRect: Rectangle.create(0, 0, 100, 100),
-            imageScale: 1,
-          },
-          makeDepthImageBytes(100, 100, depthValue)
-        );
-
-        const viewport = new Viewport(100, 100);
-        const pt = Point.create(50, 50);
-        const ray = viewport.transformPointToRay(pt, depthBuffer, camera);
-
-        return { ray, depthBuffer, pt };
-      }
-
       it('returns correct world position for near plane', () => {
-        const { ray, depthBuffer, pt } = createDepthBufferWithDepth(0);
+        const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
+          orthographicCamera,
+          0
+        );
         const pos = depthBuffer.getWorldPoint(pt, ray);
         expect(pos.z).toBe(-100);
       });
 
       it('returns correct world position for far plane', () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
+          orthographicCamera,
           DepthBuffer.MAX_DEPTH_VALUE
         );
         const pos = depthBuffer.getWorldPoint(pt, ray);
@@ -199,6 +189,7 @@ describe(DepthBuffer, () => {
 
       it('returns correct world position between near and far plane', () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
+          orthographicCamera,
           DepthBuffer.MAX_DEPTH_VALUE / 2
         );
         const pos = depthBuffer.getWorldPoint(pt, ray);

--- a/packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/depthBuffer.spec.ts
@@ -38,19 +38,19 @@ describe(DepthBuffer, () => {
     makeDepthImageBytes(100, 100, (2 ** 16 - 1) / 2)
   );
 
-  describe(DepthBuffer.prototype.getLinearDepthAtPoint, () => {
-    it('returns depth between near and far plane', () => {
-      const depth = depthBuffer.getLinearDepthAtPoint(Point.create(1, 1));
+  describe(DepthBuffer.prototype.getDepthAtPoint, () => {
+    it('returns depth between near and far plane for perspective', () => {
+      const depth = depthBuffer.getDepthAtPoint(Point.create(1, 1));
       expect(depth).toBeCloseTo(camera.near + (camera.far - camera.near) / 2);
     });
 
-    it('returns far plane if point outside viewport', () => {
-      const depth = depthBuffer.getLinearDepthAtPoint(Point.create(-1, -1));
+    it('returns far plane if point outside viewport for perspective', () => {
+      const depth = depthBuffer.getDepthAtPoint(Point.create(-1, -1));
       expect(depth).toBeCloseTo(camera.far);
     });
 
-    it('returns fallback depth', () => {
-      const depth = depthBuffer.getLinearDepthAtPoint(Point.create(-1, -1), 0);
+    it('returns fallback depth for perspective', () => {
+      const depth = depthBuffer.getDepthAtPoint(Point.create(-1, -1), 0);
       expect(depth).toBeCloseTo(camera.near);
     });
   });
@@ -178,18 +178,14 @@ describe(DepthBuffer, () => {
 
         const viewport = new Viewport(100, 100);
         const pt = Point.create(50, 50);
-        const ray = viewport.transformPointToOrthographicRay(
-          pt,
-          depthBuffer,
-          camera
-        );
+        const ray = viewport.transformPointToRay(pt, depthBuffer, camera);
 
         return { ray, depthBuffer, pt };
       }
 
       it('returns correct world position for near plane', () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(0);
-        const pos = depthBuffer.getOrthographicWorldPoint(pt, ray);
+        const pos = depthBuffer.getWorldPoint(pt, ray);
         expect(pos.z).toBe(-100);
       });
 
@@ -197,7 +193,7 @@ describe(DepthBuffer, () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
           DepthBuffer.MAX_DEPTH_VALUE
         );
-        const pos = depthBuffer.getOrthographicWorldPoint(pt, ray);
+        const pos = depthBuffer.getWorldPoint(pt, ray);
         expect(pos.z).toBe(100);
       });
 
@@ -205,7 +201,7 @@ describe(DepthBuffer, () => {
         const { ray, depthBuffer, pt } = createDepthBufferWithDepth(
           DepthBuffer.MAX_DEPTH_VALUE / 2
         );
-        const pos = depthBuffer.getOrthographicWorldPoint(pt, ray);
+        const pos = depthBuffer.getWorldPoint(pt, ray);
         expect(pos.z).toBeCloseTo(0);
       });
     });

--- a/packages/viewer/src/lib/types/__tests__/viewport.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/viewport.spec.ts
@@ -7,13 +7,45 @@ import * as FrameCamera from '../frameCamera';
 import { Viewport } from '../viewport';
 
 describe('viewport utilities', () => {
+  const perspective = FrameCameraBase.fromBoundingBox(
+    FrameCamera.createPerspective(),
+    BoundingBox.create(Vector3.create(-1, -1, -1), Vector3.create(1, 1, 1)),
+    1
+  );
   const orthographic = FrameCameraBase.fromBoundingBox(
     FrameCamera.createOrthographic(),
     BoundingBox.create(Vector3.create(-1, -1, -1), Vector3.create(1, 1, 1)),
     1
   );
 
-  describe(Viewport.prototype.transformPointToOrthographicRay, () => {
+  describe(Viewport.prototype.transformPointToRay, () => {
+    it('creates an perspective ray', () => {
+      const viewport = new Viewport(100, 100);
+
+      const expectedOrigin = Vector3.create(0, 0, -1);
+      const lookAtPoint = Vector3.transformMatrix(
+        Vector3.transformMatrix(
+          Vector3.create(-0.8, 0.8, 0.5),
+          perspective.projectionMatrixInverse
+        ),
+        perspective.worldMatrix
+      );
+      const expectedDirection = Vector3.normalize(
+        Vector3.subtract(lookAtPoint, expectedOrigin)
+      );
+
+      expect(
+        viewport.transformPointToRay(
+          Point.create(10, 10),
+          makeDepthBuffer(100, 100),
+          perspective
+        )
+      ).toMatchObject({
+        origin: expectedOrigin,
+        direction: expectedDirection,
+      });
+    });
+
     it('creates an orthographic ray', () => {
       const viewport = new Viewport(100, 100);
 
@@ -26,7 +58,7 @@ describe('viewport utilities', () => {
       );
 
       expect(
-        viewport.transformPointToOrthographicRay(
+        viewport.transformPointToRay(
           Point.create(10, 10),
           makeDepthBuffer(100, 100),
           orthographic
@@ -36,23 +68,58 @@ describe('viewport utilities', () => {
         direction: Vector3.normalize(orthographic.viewVector),
       });
     });
+  });
+
+  describe(Viewport.prototype.transformPointToWorldSpace, () => {
+    it('computes an perspective world position', () => {
+      const viewport = new Viewport(100, 100);
+      const desiredDepthPercentageToTest = 0.5;
+
+      const buffer = makeDepthBuffer(100, 100, undefined, perspective);
+      const depth =
+        desiredDepthPercentageToTest * (perspective.far - perspective.near) +
+        perspective.near;
+      const ray = viewport.transformPointToRay(
+        Point.create(10, 10),
+        buffer,
+        perspective
+      );
+
+      const worldPt = Ray.at(ray, perspective.far);
+      const eyeToWorldPt = Vector3.subtract(worldPt, perspective.position);
+
+      const angle =
+        Vector3.dot(perspective.viewVector, eyeToWorldPt) /
+        (Vector3.magnitude(perspective.viewVector) *
+          Vector3.magnitude(eyeToWorldPt));
+
+      expect(
+        viewport.transformPointToWorldSpace(
+          Point.create(10, 10),
+          buffer,
+          desiredDepthPercentageToTest * DepthBuffer.MAX_DEPTH_VALUE
+        )
+      ).toMatchObject(Ray.at(ray, depth / angle));
+    });
 
     it('computes an orthographic world position', () => {
       const viewport = new Viewport(100, 100);
+      const desiredDepthPercentageToTest = 0.5;
 
       const buffer = makeDepthBuffer(100, 100, undefined, orthographic);
-      const depth = 0.5 * (orthographic.far - orthographic.near);
-      const ray = viewport.transformPointToOrthographicRay(
+      const depth =
+        desiredDepthPercentageToTest * (orthographic.far - orthographic.near);
+      const ray = viewport.transformPointToRay(
         Point.create(10, 10),
         buffer,
         orthographic
       );
 
       expect(
-        viewport.transformPointToOrthographicWorldSpace(
+        viewport.transformPointToWorldSpace(
           Point.create(10, 10),
           buffer,
-          0.5 * DepthBuffer.MAX_DEPTH_VALUE
+          desiredDepthPercentageToTest * DepthBuffer.MAX_DEPTH_VALUE
         )
       ).toMatchObject(Ray.at(ray, depth));
     });

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -167,28 +167,7 @@ interface FrameCameraMatrices {
   readonly worldMatrix: Matrix4.Matrix4;
 }
 
-interface FrameCameraLike {
-  readonly position: Vector3.Vector3;
-  readonly lookAt: Vector3.Vector3;
-  readonly up: Vector3.Vector3;
-  readonly near: number;
-  readonly far: number;
-  readonly aspectRatio: number;
-}
-
-interface FramePerspectiveCameraLike {
-  readonly fovY: number;
-}
-
-interface FrameOrthographicCameraLike {
-  readonly fovHeight: number;
-  readonly top: number;
-  readonly bottom: number;
-  readonly right: number;
-  readonly left: number;
-}
-
-export class FrameCameraBase implements FrameCameraLike {
+export class FrameCameraBase {
   protected cameraMatrices?: FrameCameraMatrices;
 
   public constructor(
@@ -354,10 +333,7 @@ export interface FrameCameraWithMatrices extends FrameCameraBase {
   readonly projectionViewMatrix: Matrix4.Matrix4;
 }
 
-export class FramePerspectiveCamera
-  extends FrameCameraBase
-  implements FramePerspectiveCameraLike
-{
+export class FramePerspectiveCamera extends FrameCameraBase {
   public constructor(
     public readonly position: Vector3.Vector3,
     public readonly lookAt: Vector3.Vector3,
@@ -420,10 +396,7 @@ export class FramePerspectiveCamera
   }
 }
 
-export class FrameOrthographicCamera
-  extends FrameCameraBase
-  implements FrameOrthographicCameraLike
-{
+export class FrameOrthographicCamera extends FrameCameraBase {
   public readonly top: number;
   public readonly bottom: number;
   public readonly right: number;

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -162,9 +162,9 @@ export class FrameScene {
 interface FrameCameraMatrices {
   readonly projectionMatrix: Matrix4.Matrix4;
   readonly projectionMatrixInverse: Matrix4.Matrix4;
-  readonly worldMatrix: Matrix4.Matrix4;
-  readonly viewMatrix: Matrix4.Matrix4;
   readonly projectionViewMatrix: Matrix4.Matrix4;
+  readonly viewMatrix: Matrix4.Matrix4;
+  readonly worldMatrix: Matrix4.Matrix4;
 }
 
 interface FrameCameraLike {
@@ -356,7 +356,7 @@ export interface FrameCameraWithMatrices extends FrameCameraBase {
 
 export class FramePerspectiveCamera
   extends FrameCameraBase
-  implements FrameCameraWithMatrices, FramePerspectiveCameraLike
+  implements FramePerspectiveCameraLike
 {
   public constructor(
     public readonly position: Vector3.Vector3,
@@ -422,7 +422,7 @@ export class FramePerspectiveCamera
 
 export class FrameOrthographicCamera
   extends FrameCameraBase
-  implements FrameCameraWithMatrices, FrameOrthographicCameraLike
+  implements FrameOrthographicCameraLike
 {
   public readonly top: number;
   public readonly bottom: number;


### PR DESCRIPTION
## Summary
This PR includes several improvements consolidate logic around camera calculations from individual methods for perspective and orthographic cameras into single methods.  This should reduce errors in the future where a user selected the incorrect method for their camera type.

## Test Plan
Verify both perspective and orthographic cameras work as expected

## Release Notes
Improvements to consolidate logic around camera calculations from individual methods for perspective and orthographic cameras into single methods. Specifically,
- Removes `viewport.transformPointToOrthographicRay` in favor of `viewport.transformPointToRay`
- Removes `viewport.transformPointToOrthographicWorldSpace` in favor of `viewport.transformPointToWorldSpace`
- Removes `depthBuffer.getLinearDepthAtPoint` and `depthBuffer.getOrthographicDepthAtPoint` in favor of `depthBuffer.getDepthAtPoint`

## Possible Regressions
Camera calculations

## Dependencies
None