### PR TITLE
[PLAT-4504] Customizable Mouse Related Zoom Interactions

### DIFF
--- a/packages/viewer/src/lib/config.ts
+++ b/packages/viewer/src/lib/config.ts
@@ -34,6 +34,8 @@ export type PartialConfig = DeepPartial<Config>;
 
 export type ConfigProvider = () => Config;
 
+export type InteractionConfigProvider = () => Interactions.InteractionConfig;
+
 const config: Config = {
   network: {
     apiHost: 'https://platform.platprod.vertexvis.io',

--- a/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
@@ -24,6 +24,10 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe(RotateInteraction, () => {
   const api = new InteractionApiMock();
 
@@ -185,7 +189,7 @@ describe(ZoomInteraction, () => {
       interaction.drag(event2, api);
 
       const pt = Point.create(event1.clientX, event1.clientY);
-      expect(api.zoomCameraToPoint).toHaveBeenCalledWith(pt, -5);
+      expect(api.zoomCameraToPoint).toHaveBeenCalledWith(pt, 5);
     });
 
     it('continuous drags zoom camera using delta between calls', () => {
@@ -195,7 +199,7 @@ describe(ZoomInteraction, () => {
       interaction.drag(event3, api);
 
       const pt = Point.create(event1.clientX, event1.clientY);
-      expect(api.zoomCameraToPoint).toHaveBeenNthCalledWith(2, pt, -10);
+      expect(api.zoomCameraToPoint).toHaveBeenNthCalledWith(2, pt, 10);
     });
 
     it('does nothing if begin drag has not been called', () => {
@@ -206,16 +210,36 @@ describe(ZoomInteraction, () => {
     });
 
     it('supports customizing the zoom direction by inverting the delta', () => {
+      jest.useFakeTimers();
+
       const interaction = new ZoomInteraction(() => ({
         ...defaultInteractionConfig,
         reverseMouseWheelDirection: true,
       }));
-      interaction.beginDrag(event1, canvasPoint, api, element);
-      interaction.drag(event2, api);
-      interaction.drag(event3, api);
+      interaction.zoom(10, api);
 
+      jest.advanceTimersToNextTimer();
+
+      expect(api.zoomCamera).toHaveBeenCalledWith(-10);
+
+      jest.useRealTimers();
+    });
+
+    it('supports customizing the zoomToPoint direction by inverting the delta', () => {
+      jest.useFakeTimers();
+
+      const interaction = new ZoomInteraction(() => ({
+        ...defaultInteractionConfig,
+        reverseMouseWheelDirection: true,
+      }));
       const pt = Point.create(event1.clientX, event1.clientY);
-      expect(api.zoomCameraToPoint).toHaveBeenNthCalledWith(2, pt, -10);
+      interaction.zoomToPoint(pt, 10, api);
+
+      jest.advanceTimersToNextTimer();
+
+      expect(api.zoomCameraToPoint).toHaveBeenCalledWith(pt, -10);
+
+      jest.useRealTimers();
     });
   });
 

--- a/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
@@ -215,7 +215,7 @@ describe(ZoomInteraction, () => {
       interaction.drag(event3, api);
 
       const pt = Point.create(event1.clientX, event1.clientY);
-      expect(api.zoomCameraToPoint).toHaveBeenNthCalledWith(2, pt, 10);
+      expect(api.zoomCameraToPoint).toHaveBeenNthCalledWith(2, pt, -10);
     });
   });
 

--- a/packages/viewer/src/lib/interactions/mouseInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractionHandler.ts
@@ -14,7 +14,7 @@ export class MouseInteractionHandler extends BaseInteractionHandler {
     getConfig: ConfigProvider,
     rotateInteraction = new RotateInteraction(),
     rotatePointInteraction = new RotatePointInteraction(),
-    zoomInteraction = new ZoomInteraction(),
+    zoomInteraction = new ZoomInteraction(() => getConfig().interactions),
     panInteraction = new PanInteraction(),
     twistInteraction = new TwistInteraction(),
     pivotInteraction = new PivotInteraction()

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -1,6 +1,7 @@
 import { Point } from '@vertexvis/geometry';
 
 import { getMouseClientPosition } from '../dom';
+import { defaultMouseWheelInteractionEndDebounce } from '../types/interactions';
 import { InteractionType } from './baseInteractionHandler';
 import { InteractionApi, InteractionConfigProvider } from './interactionApi';
 
@@ -114,8 +115,6 @@ export class ZoomInteraction extends MouseInteraction {
   private interactionTimer: number | undefined;
   private startPt?: Point.Point;
 
-  private defaultInteractionDelay = 350;
-
   public constructor(
     private interactionConfigProvider: InteractionConfigProvider
   ) {
@@ -165,7 +164,13 @@ export class ZoomInteraction extends MouseInteraction {
     delta: number,
     api: InteractionApi
   ): void {
-    this.operateWithTimer(api, () => api.zoomCameraToPoint(pt, delta));
+    const deltaWithSetting = this.interactionConfigProvider()
+      .reverseMouseWheelDirection
+      ? -delta
+      : delta;
+    this.operateWithTimer(api, () =>
+      api.zoomCameraToPoint(pt, deltaWithSetting)
+    );
   }
 
   private beginInteraction(api: InteractionApi): void {
@@ -184,10 +189,7 @@ export class ZoomInteraction extends MouseInteraction {
   }
 
   private getInteractionDelay(): number {
-    return (
-      this.interactionConfigProvider().zoomByWheelInteractionDelay ??
-      this.defaultInteractionDelay
-    );
+    return this.interactionConfigProvider().mouseWheelInteractionEndDebounce;
   }
 
   private startInteractionTimer(api: InteractionApi): void {

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -2,7 +2,7 @@ import { Point } from '@vertexvis/geometry';
 
 import { getMouseClientPosition } from '../dom';
 import { InteractionType } from './baseInteractionHandler';
-import { InteractionApi } from './interactionApi';
+import { InteractionApi, InteractionConfigProvider } from './interactionApi';
 
 export abstract class MouseInteraction {
   protected currentPosition: Point.Point | undefined;
@@ -114,7 +114,11 @@ export class ZoomInteraction extends MouseInteraction {
   private interactionTimer: number | undefined;
   private startPt?: Point.Point;
 
-  public constructor(private interactionTimeout = 350) {
+  private defaultInteractionDelay = 350;
+
+  public constructor(
+    private interactionConfigProvider: InteractionConfigProvider
+  ) {
     super();
   }
 
@@ -179,11 +183,18 @@ export class ZoomInteraction extends MouseInteraction {
     this.startInteractionTimer(api);
   }
 
+  private getInteractionDelay(): number {
+    return (
+      this.interactionConfigProvider().zoomByWheelInteractionDelay ??
+      this.defaultInteractionDelay
+    );
+  }
+
   private startInteractionTimer(api: InteractionApi): void {
     this.interactionTimer = window.setTimeout(() => {
       this.interactionTimer = undefined;
       this.endInteraction(api);
-    }, this.interactionTimeout);
+    }, this.getInteractionDelay());
   }
 
   private stopInteractionTimer(): void {

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -114,7 +114,7 @@ export class ZoomInteraction extends MouseInteraction {
   private interactionTimer: number | undefined;
   private startPt?: Point.Point;
 
-  public constructor(private interactionTimeout = 1000) {
+  public constructor(private interactionTimeout = 350) {
     super();
   }
 

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -1,7 +1,6 @@
 import { Point } from '@vertexvis/geometry';
 
 import { getMouseClientPosition } from '../dom';
-import { defaultMouseWheelInteractionEndDebounce } from '../types/interactions';
 import { InteractionType } from './baseInteractionHandler';
 import { InteractionApi, InteractionConfigProvider } from './interactionApi';
 
@@ -142,7 +141,7 @@ export class ZoomInteraction extends MouseInteraction {
       const delta = Point.subtract(position, this.currentPosition);
 
       if (this.startPt != null) {
-        api.zoomCameraToPoint(this.startPt, delta.y);
+        this.zoomCameraToPointWithDirectionConfig(this.startPt, -delta.y, api);
         this.currentPosition = position;
       }
     }
@@ -164,13 +163,21 @@ export class ZoomInteraction extends MouseInteraction {
     delta: number,
     api: InteractionApi
   ): void {
-    const deltaWithSetting = this.interactionConfigProvider()
-      .reverseMouseWheelDirection
-      ? -delta
-      : delta;
     this.operateWithTimer(api, () =>
-      api.zoomCameraToPoint(pt, deltaWithSetting)
+      this.zoomCameraToPointWithDirectionConfig(pt, delta, api)
     );
+  }
+
+  private zoomCameraToPointWithDirectionConfig(
+    pt: Point.Point,
+    givenDelta: number,
+    api: InteractionApi
+  ): Promise<void> {
+    const delta = this.interactionConfigProvider().reverseMouseZoomDirection
+      ? -givenDelta
+      : givenDelta;
+
+    return api.zoomCameraToPoint(pt, delta);
   }
 
   private beginInteraction(api: InteractionApi): void {

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -141,7 +141,7 @@ export class ZoomInteraction extends MouseInteraction {
       const delta = Point.subtract(position, this.currentPosition);
 
       if (this.startPt != null) {
-        this.zoomCameraToPointWithDirectionConfig(this.startPt, -delta.y, api);
+        api.zoomCameraToPoint(this.startPt, delta.y);
         this.currentPosition = position;
       }
     }
@@ -155,7 +155,9 @@ export class ZoomInteraction extends MouseInteraction {
   }
 
   public zoom(delta: number, api: InteractionApi): void {
-    this.operateWithTimer(api, () => api.zoomCamera(delta));
+    this.operateWithTimer(api, () =>
+      api.zoomCamera(this.getDirectionalDelta(delta))
+    );
   }
 
   public zoomToPoint(
@@ -164,20 +166,8 @@ export class ZoomInteraction extends MouseInteraction {
     api: InteractionApi
   ): void {
     this.operateWithTimer(api, () =>
-      this.zoomCameraToPointWithDirectionConfig(pt, delta, api)
+      api.zoomCameraToPoint(pt, this.getDirectionalDelta(delta))
     );
-  }
-
-  private zoomCameraToPointWithDirectionConfig(
-    pt: Point.Point,
-    givenDelta: number,
-    api: InteractionApi
-  ): Promise<void> {
-    const delta = this.interactionConfigProvider().reverseMouseZoomDirection
-      ? -givenDelta
-      : givenDelta;
-
-    return api.zoomCameraToPoint(pt, delta);
   }
 
   private beginInteraction(api: InteractionApi): void {
@@ -193,6 +183,12 @@ export class ZoomInteraction extends MouseInteraction {
   private resetInteractionTimer(api: InteractionApi): void {
     this.stopInteractionTimer();
     this.startInteractionTimer(api);
+  }
+
+  private getDirectionalDelta(delta: number): number {
+    return this.interactionConfigProvider().reverseMouseWheelDirection
+      ? -delta
+      : delta;
   }
 
   private getInteractionDelay(): number {

--- a/packages/viewer/src/lib/interactions/pointerInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/pointerInteractionHandler.ts
@@ -20,7 +20,7 @@ export class PointerInteractionHandler extends MultiElementInteractionHandler {
     getConfig: ConfigProvider,
     rotateInteraction = new RotateInteraction(),
     rotatePointInteraction = new RotatePointInteraction(),
-    zoomInteraction = new ZoomInteraction(),
+    zoomInteraction = new ZoomInteraction(() => getConfig().interactions),
     panInteraction = new PanInteraction(),
     twistInteraction = new TwistInteraction(),
     pivotInteraction = new PivotInteraction()

--- a/packages/viewer/src/lib/types/interactions.ts
+++ b/packages/viewer/src/lib/types/interactions.ts
@@ -28,10 +28,21 @@ export interface InteractionConfig {
   useMinimumPerspectiveZoomDistance: boolean;
 
   /**
-   * The amount of time before a wheel zoom interaction is ended. A final frame will be
-   * requested at the end of the interaction.
+   * The amount of time before a wheel interaction is ended.
+   *
+   * This delay is used to support successive sets of mouse events, and not cause
+   * abrupt and unexpected ending of mouse interactions during natural pauses in mouse
+   * wheel usage.
    */
-  zoomByWheelInteractionDelay: number | undefined;
+  mouseWheelInteractionEndDebounce: number;
+
+  /**
+   * Reverses which direction the mouse wheel considers positive or negative
+   * on mouse wheel events.
+   *
+   * This effectively reverses features like the zoom direction on a mouse wheel event.
+   */
+  reverseMouseWheelDirection: boolean;
 }
 
 export const defaultInteractionConfig: InteractionConfig = {
@@ -39,5 +50,6 @@ export const defaultInteractionConfig: InteractionConfig = {
   coarsePointerThreshold: 3,
   interactionDelay: 75,
   useMinimumPerspectiveZoomDistance: true,
-  zoomByWheelInteractionDelay: 350,
+  mouseWheelInteractionEndDebounce: 350,
+  reverseMouseWheelDirection: false,
 };

--- a/packages/viewer/src/lib/types/interactions.ts
+++ b/packages/viewer/src/lib/types/interactions.ts
@@ -38,10 +38,9 @@ export interface InteractionConfig {
 
   /**
    * Reverses which direction the mouse wheel considers positive or negative
-   * on mouse driven zoom events, such as a mouse wheel event
-   * or a mouse drag when using zoom as a primary interaction.
+   * for zoom interactions.
    */
-  reverseMouseZoomDirection: boolean;
+  reverseMouseWheelDirection: boolean;
 }
 
 export const defaultInteractionConfig: InteractionConfig = {
@@ -50,5 +49,5 @@ export const defaultInteractionConfig: InteractionConfig = {
   interactionDelay: 75,
   useMinimumPerspectiveZoomDistance: true,
   mouseWheelInteractionEndDebounce: 350,
-  reverseMouseZoomDirection: false,
+  reverseMouseWheelDirection: false,
 };

--- a/packages/viewer/src/lib/types/interactions.ts
+++ b/packages/viewer/src/lib/types/interactions.ts
@@ -26,6 +26,12 @@ export interface InteractionConfig {
    * point under the cursor. Defaults to `true`.
    */
   useMinimumPerspectiveZoomDistance: boolean;
+
+  /**
+   * The amount of time before a wheel zoom interaction is ended. A final frame will be
+   * requested at the end of the interaction.
+   */
+  zoomByWheelInteractionDelay: number | undefined;
 }
 
 export const defaultInteractionConfig: InteractionConfig = {
@@ -33,4 +39,5 @@ export const defaultInteractionConfig: InteractionConfig = {
   coarsePointerThreshold: 3,
   interactionDelay: 75,
   useMinimumPerspectiveZoomDistance: true,
+  zoomByWheelInteractionDelay: 350,
 };

--- a/packages/viewer/src/lib/types/interactions.ts
+++ b/packages/viewer/src/lib/types/interactions.ts
@@ -38,11 +38,10 @@ export interface InteractionConfig {
 
   /**
    * Reverses which direction the mouse wheel considers positive or negative
-   * on mouse wheel events.
-   *
-   * This effectively reverses features like the zoom direction on a mouse wheel event.
+   * on mouse driven zoom events, such as a mouse wheel event
+   * or a mouse drag when using zoom as a primary interaction.
    */
-  reverseMouseWheelDirection: boolean;
+  reverseMouseZoomDirection: boolean;
 }
 
 export const defaultInteractionConfig: InteractionConfig = {
@@ -51,5 +50,5 @@ export const defaultInteractionConfig: InteractionConfig = {
   interactionDelay: 75,
   useMinimumPerspectiveZoomDistance: true,
   mouseWheelInteractionEndDebounce: 350,
-  reverseMouseWheelDirection: false,
+  reverseMouseZoomDirection: false,
 };


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes are to introduce a shorter delay in requesting a final frame on a ZoomInteraction. The 350ms was determined by performing a series of interactions from multiple internal users. Ultimately the feedback we received to make the change here is that the Zoom interaction felt slower. This should help a bit so that a final frame gets queued a little sooner.

The delay is not shortened further because the mouse `wheel` events could be invoked by the user in quick succession, which cause this zoom interaction to be "jerky" or "jumpy". This value of 350 appears to be high enough to avoid that, while still requesting the final frame quite a bit sooner. This value is also customizable if a consumer would like to override the default 350 in favor of a different debounce.

These changes also include the ability to reverse the mouse zoom direction as a viewer setting. 

## Test Plan
<!-- How to test changes. -->
Verify that the mouse wheel zoom, and 2 finger touch pad zoom interactions request final frames slightly sooner than the previous implementation

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
