### PR TITLE
[PLAT-4159] Export types for model views

### DIFF
--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -18,6 +18,7 @@ export * from './lib/formatter';
 export * from './lib/interactions/interactionHandler';
 export * from './lib/interactions/keyInteraction';
 export * from './lib/measurement';
+export * from './lib/model-views';
 export * from './lib/pins';
 export {
   Camera,

--- a/packages/viewer/src/lib/model-views/controller.ts
+++ b/packages/viewer/src/lib/model-views/controller.ts
@@ -8,8 +8,8 @@ import { SceneViewAPIClient } from '@vertexvis/scene-view-protos/sceneview/proto
 import { UUID } from '@vertexvis/utils';
 
 import { createMetadata, JwtProvider, requestUnary } from '../grpc';
-import { ModelViewListResponse } from '../types';
 import { mapListItemModelViewsResponseOrThrow } from './mapper';
+import { ModelViewListResponse } from './types';
 
 export interface ListByItemOptions {
   cursor?: string;

--- a/packages/viewer/src/lib/model-views/index.ts
+++ b/packages/viewer/src/lib/model-views/index.ts
@@ -1,0 +1,2 @@
+export * from './controller';
+export * from './types';

--- a/packages/viewer/src/lib/model-views/mapper.ts
+++ b/packages/viewer/src/lib/model-views/mapper.ts
@@ -3,7 +3,7 @@ import { ListItemModelViewsResponse } from '@vertexvis/scene-view-protos/scenevi
 import { Mapper as M } from '@vertexvis/utils';
 
 import { fromPbUuid2l, mapCursor } from '../mappers';
-import { ModelView, ModelViewListResponse } from '../types';
+import { ModelView, ModelViewListResponse } from './types';
 
 const mapModelView: M.Func<PBModelView.AsObject, ModelView> = M.defineMapper(
   M.read(

--- a/packages/viewer/src/lib/model-views/types.ts
+++ b/packages/viewer/src/lib/model-views/types.ts
@@ -1,6 +1,6 @@
 import { UUID } from '@vertexvis/utils';
 
-import { PagingLinks } from './pagination';
+import { PagingLinks } from '../types/pagination';
 
 export interface ModelView {
   id: UUID.UUID;

--- a/packages/viewer/src/lib/types/index.ts
+++ b/packages/viewer/src/lib/types/index.ts
@@ -19,7 +19,6 @@ export * from './entities';
 export * from './featureMap';
 export * from './frame';
 export * from './markup';
-export * from './modelViews';
 export * from './orientation';
 export * from './pagination';
 export * from './standardView';


### PR DESCRIPTION
## Summary

Reorganizes the types for model views to make exports easier to manage.

https://vertexvis.atlassian.net/browse/PLAT-4159