### PR TITLE
[PLAT-4506] Replacing unpkg with JSDelivr

### DIFF
--- a/examples/align-two-surfaces/main.js
+++ b/examples/align-two-surfaces/main.js
@@ -1,4 +1,4 @@
-import { TransformationDelta } from 'https://unpkg.com/@vertexvis/viewer@0.17.x/dist/esm/index.mjs';
+import { TransformationDelta } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/esm/index.mjs';
 import { loadViewerWithQueryParams } from '../helpers.js';
 
 window.addEventListener('DOMContentLoaded', () => {

--- a/examples/camera-manipulations/main.js
+++ b/examples/camera-manipulations/main.js
@@ -1,6 +1,6 @@
 import { loadViewerWithQueryParams } from '../helpers.js';
-import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@0.17.x/dist/esm/loader.mjs';
-import { Vector3 } from 'https://unpkg.com/@vertexvis/geometry@0.17.x/dist/cdn/bundle.esm.js';
+import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/esm/loader.mjs';
+import { Vector3 } from 'https://cdn.jsdelivr.net/npm/@vertexvis/geometry@0.17.x/dist/cdn/bundle.esm.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   defineCustomElements(window).then(() => main());

--- a/examples/custom-interactions/main.js
+++ b/examples/custom-interactions/main.js
@@ -1,5 +1,5 @@
 import { loadViewerWithQueryParams } from '../helpers.js';
-import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
+import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@latest/dist/esm/loader.mjs';
 
 class CustomInteractionHandler {
   constructor() {

--- a/examples/loading-models/main.js
+++ b/examples/loading-models/main.js
@@ -1,5 +1,5 @@
 import { getStreamKey } from '../helpers.js';
-import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@0.17.x/dist/esm/loader.mjs';
+import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/esm/loader.mjs';
 
 document.addEventListener('DOMContentLoaded', () => {
   defineCustomElements(window).then(() => main());

--- a/examples/metadata-operations/main.js
+++ b/examples/metadata-operations/main.js
@@ -1,5 +1,5 @@
 import { loadViewerWithQueryParams } from '../helpers.js';
-import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@0.17.x/dist/esm/loader.mjs';
+import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/esm/loader.mjs';
 
 document.addEventListener('DOMContentLoaded', () => {
   defineCustomElements(window).then(() => main());

--- a/examples/work-instructions/instructions.js
+++ b/examples/work-instructions/instructions.js
@@ -1,4 +1,4 @@
-import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/esm/index.mjs';
+import { ColorMaterial } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.9.x/dist/esm/index.mjs';
 import steps from './steps.js';
 
 /**

--- a/examples/work-instructions/main.js
+++ b/examples/work-instructions/main.js
@@ -4,7 +4,7 @@ import {
   applyWorkInstruction,
   initializeWorkInstructions,
 } from './instructions.js';
-import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
+import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@latest/dist/esm/loader.mjs';
 
 document.addEventListener('DOMContentLoaded', () => {
   defineCustomElements(window).then(() => main());

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -24,7 +24,7 @@ viewer.
   </head>
   <body>
     <script type="module">
-      import { Vector3 } from 'https://unpkg.com/@vertexvis/geometry@0.21.0/dist/cdn/bundle.esm.js';
+      import { Vector3 } from 'https://cdn.jsdelivr.net/npm/@vertexvis/geometry@0.21.0/dist/cdn/bundle.esm.js';
 
       async function main() {
         const viewer = document.querySelector('#viewer');

--- a/packages/geometry/README.template.md
+++ b/packages/geometry/README.template.md
@@ -24,7 +24,7 @@ viewer.
   </head>
   <body>
     <script type="module">
-      import { Vector3 } from 'https://unpkg.com/@vertexvis/geometry@{{version}}/dist/cdn/bundle.esm.js';
+      import { Vector3 } from 'https://cdn.jsdelivr.net/npm/@vertexvis/geometry@{{version}}/dist/cdn/bundle.esm.js';
 
       async function main() {
         const viewer = document.querySelector('#viewer');

--- a/packages/viewer/README.template.md
+++ b/packages/viewer/README.template.md
@@ -27,11 +27,11 @@ file that references our published JS bundles from a CDN.
   <head>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@{{version}}/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@{{version}}/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@{{version}}/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@{{version}}/dist/viewer/viewer.esm.js"
     ></script>
   </head>
 
@@ -53,7 +53,7 @@ These utilities can be imported from a CDN as shown below:
   </head>
   <body>
     <script type="module">
-      import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@{{version}}/dist/esm/index.mjs';
+      import { ColorMaterial } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@{{version}}/dist/esm/index.mjs';
 
       function main() {
         const color = ColorMaterial.fromHex('#ff0000');

--- a/packages/viewer/readme.md
+++ b/packages/viewer/readme.md
@@ -27,11 +27,11 @@ file that references our published JS bundles from a CDN.
   <head>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.21.0/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.21.0/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.21.0/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.21.0/dist/viewer/viewer.esm.js"
     ></script>
   </head>
 
@@ -53,7 +53,7 @@ These utilities can be imported from a CDN as shown below:
   </head>
   <body>
     <script type="module">
-      import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.21.0/dist/esm/index.mjs';
+      import { ColorMaterial } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.21.0/dist/esm/index.mjs';
 
       function main() {
         const color = ColorMaterial.fromHex('#ff0000');

--- a/packages/viewer/src/components/viewer-dom-renderer/readme.md
+++ b/packages/viewer/src/components/viewer-dom-renderer/readme.md
@@ -93,7 +93,7 @@ is a helper library for common 3D math operations.
     </vertex-viewer>
 
     <script type="module">
-      import { Vector3 } from 'https://unpkg.com/@vertexvis/geometry@latest/dist/cdn/bundle.esm.js';
+      import { Vector3 } from 'https://cdn.jsdelivr.net/npm/@vertexvis/geometry@latest/dist/cdn/bundle.esm.js';
 
       const pin = document.getElementById('my-pin');
 

--- a/packages/viewer/src/components/viewer-markup/readme.md
+++ b/packages/viewer/src/components/viewer-markup/readme.md
@@ -77,7 +77,7 @@ as children, provide a unique ID to the element.
   </vertex-viewer>
 
   <script type="module">
-    import { ArrowMarkup } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/index.esm.js'
+    import { ArrowMarkup } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@latest/dist/viewer/index.esm.js'
 
     const markup = document.getElementById('markup');
     const button = document.getElementById('add-markup-btn');


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
Modifies all of the cdn packages to use Js deliver instead of unpkg. I did do some smoke testing with these and these assets do appear to load a lot faster than unpkg.

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
