### PR TITLE
[PLAT-4149] Add support for loading and unloading ModelViews

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -498,7 +498,8 @@ export class Viewer {
     this.modelViews = new ModelViewController(
       client,
       () => this.token,
-      () => this.deviceId
+      () => this.deviceId,
+      () => this.scene()
     );
 
     this.stream =

--- a/packages/viewer/src/lib/model-views/__tests__/controller.spec.ts
+++ b/packages/viewer/src/lib/model-views/__tests__/controller.spec.ts
@@ -2,11 +2,20 @@ jest.mock(
   '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb_service'
 );
 
+import { Dimensions, Point } from '@vertexvis/geometry';
 import { SceneViewAPIClient } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb_service';
+import { StreamApi } from '@vertexvis/stream-api';
 
 import { mockGrpcUnaryResult } from '../../../testing';
-import { makeListItemModelViewsResponse } from '../../../testing/modelViews';
+import { makePerspectiveFrame } from '../../../testing/fixtures';
+import {
+  makeListItemModelViewsResponse,
+  makeUpdateSceneViewRequest,
+} from '../../../testing/modelViews';
 import { random } from '../../../testing/random';
+import { fromPbFrameOrThrow } from '../../mappers';
+import { Scene } from '../../scenes';
+import { Orientation } from '../../types';
 import { ModelViewController } from '../controller';
 import { mapListItemModelViewsResponseOrThrow } from '../mapper';
 
@@ -14,11 +23,14 @@ describe(ModelViewController, () => {
   const jwt = random.string();
   const deviceId = random.string();
 
+  const sceneId = random.guid();
+  const sceneViewId = random.guid();
   const itemId = random.guid();
+  const modelViewId = random.guid();
 
   describe(ModelViewController.prototype.listByItem, () => {
     it('fetches page of model views', async () => {
-      const { controller, client } = makeAnnotationController(jwt, deviceId);
+      const { controller, client } = makeModelViewController(jwt, deviceId);
       const expected = makeListItemModelViewsResponse();
 
       (client.listItemModelViews as jest.Mock).mockImplementationOnce(
@@ -32,18 +44,95 @@ describe(ModelViewController, () => {
     });
   });
 
-  function makeAnnotationController(
+  describe(ModelViewController.prototype.load, () => {
+    it('updates the scene view with the provided model view id', async () => {
+      const { controller, client } = makeModelViewController(jwt, deviceId);
+      const expected = makeUpdateSceneViewRequest(sceneViewId, modelViewId);
+
+      (client.updateSceneView as jest.Mock).mockImplementationOnce(
+        mockGrpcUnaryResult({})
+      );
+
+      await controller.load(modelViewId);
+
+      expect(client.updateSceneView).toHaveBeenCalledWith(
+        expected,
+        expect.anything(),
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe(ModelViewController.prototype.unload, () => {
+    it('updates the scene view with an empty model view id and resets the scene', async () => {
+      const { controller, client, streamApi } = makeModelViewController(
+        jwt,
+        deviceId
+      );
+      const expected = makeUpdateSceneViewRequest(sceneViewId);
+
+      (client.updateSceneView as jest.Mock).mockImplementationOnce(
+        mockGrpcUnaryResult({})
+      );
+      streamApi.resetSceneView = jest.fn();
+
+      await controller.unload();
+
+      expect(client.updateSceneView).toHaveBeenCalledWith(
+        expected,
+        expect.anything(),
+        expect.any(Function)
+      );
+      expect(streamApi.resetSceneView).toHaveBeenCalledWith(
+        expect.objectContaining({
+          includeCamera: true,
+        }),
+        true
+      );
+    });
+  });
+
+  function makeModelViewController(
     jwt: string,
     deviceId: string
-  ): { controller: ModelViewController; client: SceneViewAPIClient } {
+  ): {
+    controller: ModelViewController;
+    client: SceneViewAPIClient;
+    scene: Scene;
+    streamApi: StreamApi;
+  } {
     const client = new SceneViewAPIClient('https://example.com');
+    const { scene, streamApi } = makeScene();
     return {
       client,
       controller: new ModelViewController(
         client,
         () => jwt,
-        () => deviceId
+        () => deviceId,
+        () => Promise.resolve(scene)
       ),
+      scene,
+      streamApi,
+    };
+  }
+
+  function makeScene(): {
+    scene: Scene;
+    streamApi: StreamApi;
+  } {
+    const streamApi = new StreamApi();
+
+    return {
+      scene: new Scene(
+        streamApi,
+        makePerspectiveFrame(),
+        fromPbFrameOrThrow(Orientation.DEFAULT),
+        () => Point.create(1, 1),
+        Dimensions.create(50, 50),
+        sceneId,
+        sceneViewId
+      ),
+      streamApi,
     };
   }
 });

--- a/packages/viewer/src/lib/model-views/controller.ts
+++ b/packages/viewer/src/lib/model-views/controller.ts
@@ -3,11 +3,14 @@ import { Uuid2l } from '@vertexvis/scene-view-protos/core/protos/uuid_pb';
 import {
   ListItemModelViewsRequest,
   ListItemModelViewsResponse,
+  UpdateSceneViewRequest,
 } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb';
 import { SceneViewAPIClient } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb_service';
 import { UUID } from '@vertexvis/utils';
+import { FieldMask } from 'google-protobuf/google/protobuf/field_mask_pb';
 
 import { createMetadata, JwtProvider, requestUnary } from '../grpc';
+import { Scene } from '../scenes';
 import { mapListItemModelViewsResponseOrThrow } from './mapper';
 import { ModelViewListResponse } from './types';
 
@@ -23,7 +26,8 @@ export class ModelViewController {
   public constructor(
     private client: SceneViewAPIClient,
     private jwtProvider: JwtProvider,
-    private deviceIdProvider: () => string | undefined
+    private deviceIdProvider: () => string | undefined,
+    private sceneProvider: () => Promise<Scene>
   ) {}
 
   /**
@@ -62,5 +66,69 @@ export class ModelViewController {
     );
 
     return mapListItemModelViewsResponseOrThrow(res.toObject());
+  }
+
+  /**
+   * Loads the provided model view within the current scene view.
+   *
+   * @param modelViewId The ID of the model view to load.
+   */
+  public async load(modelViewId: UUID.UUID): Promise<void> {
+    const scene = await this.sceneProvider();
+
+    await requestUnary(async (handler) => {
+      const deviceId = this.deviceIdProvider();
+      const meta = await createMetadata(this.jwtProvider, deviceId);
+      const req = new UpdateSceneViewRequest();
+
+      const svUuid = UUID.toMsbLsb(scene.sceneViewId);
+      const svUuid2l = new Uuid2l();
+      svUuid2l.setMsb(svUuid.msb);
+      svUuid2l.setLsb(svUuid.lsb);
+      req.setModelViewId(svUuid2l);
+
+      const mvUuid = UUID.toMsbLsb(modelViewId);
+      const mvUuid2l = new Uuid2l();
+      mvUuid2l.setMsb(mvUuid.msb);
+      mvUuid2l.setLsb(mvUuid.lsb);
+      req.setModelViewId(mvUuid2l);
+
+      const mask = new FieldMask();
+      mask.addPaths('sceneView.modelViewId');
+      req.setUpdateMask(mask);
+
+      this.client.updateSceneView(req, meta, handler);
+    });
+  }
+
+  /**
+   * Unloads any previously loaded model view within the current scene view,
+   * then performs a `reset` on the scene to return to the initial state for
+   * the scene view.
+   */
+  public async unload(): Promise<void> {
+    const scene = await this.sceneProvider();
+
+    await requestUnary(async (handler) => {
+      const deviceId = this.deviceIdProvider();
+      const meta = await createMetadata(this.jwtProvider, deviceId);
+      const req = new UpdateSceneViewRequest();
+
+      const svUuid = UUID.toMsbLsb(scene.sceneViewId);
+      const svUuid2l = new Uuid2l();
+      svUuid2l.setMsb(svUuid.msb);
+      svUuid2l.setLsb(svUuid.lsb);
+      req.setModelViewId(svUuid2l);
+
+      const mask = new FieldMask();
+      mask.addPaths('sceneView.modelViewId');
+      req.setUpdateMask(mask);
+
+      this.client.updateSceneView(req, meta, handler);
+    });
+
+    await scene.reset({
+      includeCamera: true,
+    });
   }
 }

--- a/packages/viewer/src/lib/model-views/controller.ts
+++ b/packages/viewer/src/lib/model-views/controller.ts
@@ -94,7 +94,7 @@ export class ModelViewController {
       req.setModelViewId(mvUuid2l);
 
       const mask = new FieldMask();
-      mask.addPaths('sceneView.modelViewId');
+      mask.addPaths('model_view_id');
       req.setUpdateMask(mask);
 
       this.client.updateSceneView(req, meta, handler);
@@ -121,7 +121,7 @@ export class ModelViewController {
       req.setModelViewId(svUuid2l);
 
       const mask = new FieldMask();
-      mask.addPaths('sceneView.modelViewId');
+      mask.addPaths('model_view_id');
       req.setUpdateMask(mask);
 
       this.client.updateSceneView(req, meta, handler);

--- a/packages/viewer/src/testing/modelViews.ts
+++ b/packages/viewer/src/testing/modelViews.ts
@@ -39,7 +39,7 @@ export function makeUpdateSceneViewRequest(
   }
 
   const mask = new FieldMask();
-  mask.addPaths('sceneView.modelViewId');
+  mask.addPaths('model_view_id');
   req.setUpdateMask(mask);
 
   return req;

--- a/packages/viewer/src/testing/modelViews.ts
+++ b/packages/viewer/src/testing/modelViews.ts
@@ -1,6 +1,11 @@
 import { ModelView } from '@vertexvis/scene-view-protos/core/protos/model_views_pb';
-import { ListItemModelViewsResponse } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb';
+import { Uuid2l } from '@vertexvis/scene-view-protos/core/protos/uuid_pb';
+import {
+  ListItemModelViewsResponse,
+  UpdateSceneViewRequest,
+} from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb';
 import { UUID } from '@vertexvis/utils';
+import { FieldMask } from 'google-protobuf/google/protobuf/field_mask_pb';
 
 import { random } from './random';
 import { makeUuid2l } from './sceneView';
@@ -11,6 +16,33 @@ export function makeListItemModelViewsResponse(
   const res = new ListItemModelViewsResponse();
   res.setModelViewsList(modelViews);
   return res;
+}
+
+export function makeUpdateSceneViewRequest(
+  sceneViewId: UUID.UUID,
+  modelViewId?: UUID.UUID
+): UpdateSceneViewRequest {
+  const req = new UpdateSceneViewRequest();
+
+  const svUuid = UUID.toMsbLsb(sceneViewId);
+  const svUuid2l = new Uuid2l();
+  svUuid2l.setMsb(svUuid.msb);
+  svUuid2l.setLsb(svUuid.lsb);
+  req.setModelViewId(svUuid2l);
+
+  if (modelViewId != null) {
+    const mvUuid = UUID.toMsbLsb(modelViewId);
+    const mvUuid2l = new Uuid2l();
+    mvUuid2l.setMsb(mvUuid.msb);
+    mvUuid2l.setLsb(mvUuid.lsb);
+    req.setModelViewId(mvUuid2l);
+  }
+
+  const mask = new FieldMask();
+  mask.addPaths('sceneView.modelViewId');
+  req.setUpdateMask(mask);
+
+  return req;
 }
 
 export function makeModelView(


### PR DESCRIPTION
## Summary

Updates the ModelViewController to support loading and unloading of ModelViews.

## Test Plan

- Verify that calling `load` on the ModelViewController makes an UpdateSceneView gRPC request with both the current scene view ID and provided model view ID
- Verify that calling `unload` on the ModelViewController makes an UpdateSceneView gRPC request with the current scene view ID, then resets the scene view

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
