### PR TITLE
[PLAT-3943] Hide detached pins

### DIFF
--- a/packages/viewer/src/components/viewer-pin-group/pin-renderer.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/pin-renderer.tsx
@@ -26,7 +26,8 @@ export const PinRenderer: FunctionalComponent<PinRendererProps> = ({
           id="pin-anchor"
           class={classNames('pin-anchor', {
             selected: selected,
-            'pin-occluded': occluded || detached,
+            'pin-occluded': occluded,
+            'pin-detached': detached,
           })}
           style={{
             background: primaryColor,
@@ -40,7 +41,8 @@ export const PinRenderer: FunctionalComponent<PinRendererProps> = ({
           size="lg"
           class={classNames('pin', {
             'pin-selected': selected,
-            'pin-occluded': occluded || detached,
+            'pin-occluded': occluded,
+            'pin-detached': detached,
           })}
           style={{
             color: primaryColor,

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.css
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.css
@@ -101,3 +101,7 @@
   opacity: .3;
   transition: opacity 0.3s ease-in;
 }
+
+.pin-detached {
+  visibility: hidden;
+}

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
@@ -155,7 +155,7 @@ export class ViewerPinGroup {
           />
         </vertex-viewer-dom-element>
 
-        {isTextPin(this.pin) && !this.occluded && (
+        {isTextPin(this.pin) && !this.occluded && !this.detached && (
           <Fragment>
             <vertex-viewer-pin-label-line
               id={`pin-label-line-${this.pin?.id}`}

--- a/packages/viewer/src/lib/types/depthBuffer.ts
+++ b/packages/viewer/src/lib/types/depthBuffer.ts
@@ -283,7 +283,7 @@ export class DepthBuffer implements FrameImageLike {
       viewport
     );
 
-    // If depthDifference is 0, then the point is directly on the surface of the
+    // If distanceFromClosestGeometryToPoint is 0, then the point is directly on the surface of the
     // closest geometry and is not detached. This method allows for a small rounding
     // error when the point is slightly closer to the camera than the geometry.
     const distanceFromClosestGeometryToPoint =


### PR DESCRIPTION
## Summary
Detached pins and markers should be hidden from the viewer. This PR also updates the method to determine whether a point is detached to ensure that it returns the correct result.

## Test Plan
Verify detached pins are hidden

## Release Notes
Improvements to determining whether a point is detached

## Possible Regressions
Determining whether a point is detached from geometry

## Dependencies
None
