### PR TITLE
[PLAT-4149] Fix setting of the sceneViewId in the ModelViewController

### DIFF
--- a/packages/viewer/src/lib/model-views/controller.ts
+++ b/packages/viewer/src/lib/model-views/controller.ts
@@ -85,7 +85,7 @@ export class ModelViewController {
       const svUuid2l = new Uuid2l();
       svUuid2l.setMsb(svUuid.msb);
       svUuid2l.setLsb(svUuid.lsb);
-      req.setModelViewId(svUuid2l);
+      req.setSceneViewId(svUuid2l);
 
       const mvUuid = UUID.toMsbLsb(modelViewId);
       const mvUuid2l = new Uuid2l();
@@ -118,7 +118,7 @@ export class ModelViewController {
       const svUuid2l = new Uuid2l();
       svUuid2l.setMsb(svUuid.msb);
       svUuid2l.setLsb(svUuid.lsb);
-      req.setModelViewId(svUuid2l);
+      req.setSceneViewId(svUuid2l);
 
       const mask = new FieldMask();
       mask.addPaths('model_view_id');

--- a/packages/viewer/src/testing/modelViews.ts
+++ b/packages/viewer/src/testing/modelViews.ts
@@ -28,7 +28,7 @@ export function makeUpdateSceneViewRequest(
   const svUuid2l = new Uuid2l();
   svUuid2l.setMsb(svUuid.msb);
   svUuid2l.setLsb(svUuid.lsb);
-  req.setModelViewId(svUuid2l);
+  req.setSceneViewId(svUuid2l);
 
   if (modelViewId != null) {
     const mvUuid = UUID.toMsbLsb(modelViewId);


### PR DESCRIPTION
## Summary

Fixes a typo where the `load` and `unload` method of the ModelViewController were using `setModelViewId` rather than `setSceneViewId` to set the sceneViewId, resulting in an incorrect payload.

## Test Plan

- Verify the `UpdateSceneViewRequest` payloads are correct

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
