### PR TITLE
[PLAT-4665] Add model view ID onto frame attributes

### DIFF
--- a/packages/viewer/src/lib/mappers/__tests__/frameStream.spec.ts
+++ b/packages/viewer/src/lib/mappers/__tests__/frameStream.spec.ts
@@ -1,0 +1,28 @@
+import { vertexvis } from '@vertexvis/frame-streaming-protos';
+import { UUID } from '@vertexvis/utils';
+import Long from 'long';
+
+import { drawFramePayloadPerspective } from '../../../testing/fixtures';
+import { Orientation } from '../../types';
+import { fromPbFrame, fromPbFrameOrThrow } from '../frameStreaming';
+
+describe(fromPbFrame, () => {
+  it('should decode model view id', () => {
+    const id = UUID.create();
+    const msbLsb = UUID.toMsbLsb(id);
+
+    const payload: vertexvis.protobuf.stream.IDrawFramePayload = {
+      ...drawFramePayloadPerspective,
+      sceneAttributes: {
+        ...drawFramePayloadPerspective.sceneAttributes,
+        modelViewId: {
+          msb: Long.fromString(msbLsb.msb),
+          lsb: Long.fromString(msbLsb.lsb),
+        },
+      },
+    };
+
+    const frame = fromPbFrameOrThrow(Orientation.DEFAULT)(payload);
+    expect(frame.scene.modelViewId).toBe(id);
+  });
+});

--- a/packages/viewer/src/lib/mappers/corePbJs.ts
+++ b/packages/viewer/src/lib/mappers/corePbJs.ts
@@ -1,5 +1,18 @@
 import type { vertexvis } from '@vertexvis/frame-streaming-protos';
+import { UUID } from '@vertexvis/utils';
 import { Mapper as M } from '@vertexvis/utils';
 
-export const fromPbUuid: M.Func<vertexvis.protobuf.core.IUuid, string> =
+export const fromPbJsUuid: M.Func<vertexvis.protobuf.core.IUuid, UUID.UUID> =
   M.defineMapper(M.read(M.requiredProp('hex')), ([uuid]) => uuid);
+
+export const fromPbJsUuid2l: M.Func<
+  vertexvis.protobuf.core.IUuid2l,
+  UUID.UUID
+> = M.defineMapper(
+  M.read(M.requiredProp('msb'), M.requiredProp('lsb')),
+  ([msb, lsb]) => {
+    const m = BigInt(typeof msb === 'number' ? msb : msb.toString());
+    const l = BigInt(typeof lsb === 'number' ? lsb : lsb.toString());
+    return UUID.fromMsbLsb(m, l);
+  }
+);

--- a/packages/viewer/src/lib/mappers/frameStreaming.ts
+++ b/packages/viewer/src/lib/mappers/frameStreaming.ts
@@ -1,7 +1,7 @@
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { BoundingBox, Dimensions, Vector3 } from '@vertexvis/geometry';
 import { protoToDate } from '@vertexvis/stream-api';
-import { Mapper as M } from '@vertexvis/utils';
+import { Mapper as M, UUID } from '@vertexvis/utils';
 
 import { Token } from '../token';
 import {
@@ -15,7 +15,7 @@ import {
   Orientation,
   SceneViewSummary,
 } from '../types';
-import { fromPbUuid } from './corePbJs';
+import { fromPbJsUuid, fromPbJsUuid2l } from './corePbJs';
 import {
   fromPbBoundingBox3f,
   fromPbDim,
@@ -196,30 +196,31 @@ const fromPbSceneAttributes: M.Func<
     crossSectioning: CrossSectioning.CrossSectioning;
     hasChanged: boolean;
     displayListSummary: SceneViewSummary.SceneViewSummary;
+    modelViewId: UUID.UUID | undefined;
   }
 > = M.defineMapper(
   M.read(
-    M.mapProp('camera', M.compose(M.required('camera'), fromPbCamera)),
-    M.mapProp(
-      'visibleBoundingBox',
-      M.compose(M.required('visibleBoundingBox'), fromPbBoundingBox3f)
-    ),
-    M.mapProp(
-      'crossSectioning',
-      M.compose(M.required('crossSectioning'), fromPbCrossSectioning)
-    ),
+    M.mapRequiredProp('camera', fromPbCamera),
+    M.mapRequiredProp('visibleBoundingBox', fromPbBoundingBox3f),
+    M.mapRequiredProp('crossSectioning', fromPbCrossSectioning),
     M.requiredProp('hasChanged'),
-    M.mapProp(
-      'displayListSummary',
-      M.compose(M.required('displayListSummary'), fromPbDisplayListSummary)
-    )
+    M.mapRequiredProp('displayListSummary', fromPbDisplayListSummary),
+    M.mapProp('modelViewId', M.ifDefined(fromPbJsUuid2l))
   ),
-  ([camera, boundingBox, crossSectioning, hasChanged, displayListSummary]) => ({
+  ([
     camera,
     boundingBox,
     crossSectioning,
     hasChanged,
     displayListSummary,
+    modelViewId,
+  ]) => ({
+    camera,
+    boundingBox,
+    crossSectioning,
+    hasChanged,
+    displayListSummary,
+    modelViewId: modelViewId != null ? modelViewId : undefined,
   })
 );
 
@@ -231,6 +232,7 @@ const fromPbFrameSceneAttributes: M.Func<
     crossSectioning: CrossSectioning.CrossSectioning;
     hasChanged: boolean;
     displayListSummary: SceneViewSummary.SceneViewSummary;
+    modelViewId: UUID.UUID | undefined;
   }
 > = M.defineMapper(
   M.read(
@@ -267,7 +269,8 @@ function fromPbFrameScene(
         sceneAttr.crossSectioning,
         worldOrientation,
         sceneAttr.hasChanged,
-        sceneAttr.displayListSummary
+        sceneAttr.displayListSummary,
+        sceneAttr.modelViewId
       )
   );
 }
@@ -285,7 +288,7 @@ export function fromPbFrame(
       M.mapProp('depthBuffer', fromPbBytesValue),
       M.mapProp('featureMap', fromPbBytesValue),
       M.mapProp('temporalRefinementCorrelationId', (id) =>
-        id != null ? fromPbUuid(id) : null
+        id != null ? fromPbJsUuid(id) : null
       )
     ),
     ([cIds, seq, fd, s, i, db, fm, trci]) =>
@@ -383,19 +386,19 @@ export const fromPbStartStreamResponse: M.Func<
   M.read(
     M.compose(
       M.requiredProp('startStream'),
-      M.mapRequiredProp('streamId', fromPbUuid)
+      M.mapRequiredProp('streamId', fromPbJsUuid)
     ),
     M.compose(
       M.requiredProp('startStream'),
-      M.mapRequiredProp('sceneId', fromPbUuid)
+      M.mapRequiredProp('sceneId', fromPbJsUuid)
     ),
     M.compose(
       M.requiredProp('startStream'),
-      M.mapRequiredProp('sceneViewId', fromPbUuid)
+      M.mapRequiredProp('sceneViewId', fromPbJsUuid)
     ),
     M.compose(
       M.requiredProp('startStream'),
-      M.mapRequiredProp('sessionId', fromPbUuid)
+      M.mapRequiredProp('sessionId', fromPbJsUuid)
     ),
     M.compose(
       M.requiredProp('startStream'),

--- a/packages/viewer/src/lib/types/frame.ts
+++ b/packages/viewer/src/lib/types/frame.ts
@@ -130,7 +130,8 @@ export class FrameScene {
     public readonly crossSection: CrossSectioning.CrossSectioning,
     public readonly worldOrientation: Orientation,
     public readonly hasChanged: boolean,
-    public readonly sceneViewSummary: SceneViewSummary.SceneViewSummary
+    public readonly sceneViewSummary: SceneViewSummary.SceneViewSummary,
+    public readonly modelViewId: UUID.UUID | undefined
   ) {}
 
   public copy({
@@ -140,6 +141,7 @@ export class FrameScene {
     worldOrientation,
     hasChanged,
     sceneViewSummary,
+    modelViewId,
   }: Partial<{
     camera: FrameCameraBase;
     boundingBox: BoundingBox.BoundingBox;
@@ -147,6 +149,7 @@ export class FrameScene {
     worldOrientation: Orientation;
     hasChanged: boolean;
     sceneViewSummary: SceneViewSummary.SceneViewSummary;
+    modelViewId: UUID.UUID | undefined;
   }>): FrameScene {
     return new FrameScene(
       camera ?? this.camera,
@@ -154,7 +157,8 @@ export class FrameScene {
       crossSection ?? this.crossSection,
       worldOrientation ?? this.worldOrientation,
       hasChanged ?? this.hasChanged,
-      sceneViewSummary ?? this.sceneViewSummary
+      sceneViewSummary ?? this.sceneViewSummary,
+      modelViewId ?? this.modelViewId
     );
   }
 }

--- a/packages/viewer/src/testing/fixtures.ts
+++ b/packages/viewer/src/testing/fixtures.ts
@@ -19,6 +19,7 @@ import {
   StencilBuffer,
   Viewport,
 } from '../lib/types';
+import { random } from './random';
 
 const baseDrawFramePayload: Partial<DrawFramePayload> = {
   sequenceNumber: 1,
@@ -43,6 +44,7 @@ const baseDrawFramePayload: Partial<DrawFramePayload> = {
         count: 0,
       },
     },
+    modelViewId: { msb: random.integer(), lsb: random.integer() },
   },
   imageAttributes: {
     frameDimensions: { width: 100, height: 50 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,7 +2048,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18", "@types/react@^18.2.48":
+"@types/react@*", "@types/react@^18.2.48":
   version "18.3.3"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
   integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
@@ -2211,9 +2211,9 @@
     prettier "^2.5.1"
 
 "@vertexvis/frame-streaming-protos@^0.13.2":
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.3.tgz#f241a5965f3ff667cea3ad534d1a8d232d741288"
-  integrity sha512-HU+DWXsxGagNE6VWqkAfEWzZ5cxVIdTMwioTelz0MZRp2KD7z3rxDQ8rQshMXC8dpQjFtjqWc0H+p8XWnItPgw==
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.5.tgz#b9b04a1d67c4ffe1fa81fe2493ef977cdfd79bf6"
+  integrity sha512-QTSEn/Mxrda/QJuLeUljw0k6aumIbw6obPnSXV/oJIhRLsmsrRWPisSJ/P6nILZfb8LWzuZwaoaRYHO1EG8tvw==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"
@@ -2235,9 +2235,9 @@
   integrity sha512-5pJbF5/nMdqybxpZW2yBIQ9lF3P61ziaC3APTfHXU9APhnVfp+3jdW5PkrWGc45zFn1wCkuwEFhD+ORv3LEePw==
 
 "@vertexvis/scene-tree-protos@^0.1.21":
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.22.tgz#fbb532b3d3046c2859caf9ae197bc5715f1c2cab"
-  integrity sha512-I4tdrquf1jIPyQNtyZGT7itUfN1QfZ+EVlqdXzUa62Z3w79hMmNmPSRg5efZsrSLxzOYyRJaZ4U7Qp2lOcou2g==
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.23.tgz#d0d43f14419db18543c78398d72dcf06efce74e0"
+  integrity sha512-Utb58aiV+k5A+ZPrEUKK4F5ckSRHJyLmLVwHJXVh7iHWNCwXATUaiu9k/YJ6kxUomOSGwL+zIs1lkgRtLDScGw==
 
 "@vertexvis/scene-view-protos@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
## Summary

Adds decoding of model view ID for the rendered frame. Clients can use this to know which model view is currently being rendered.

https://vertexvis.atlassian.net/browse/PLAT-4665