### PR TITLE
[PLAT-4674] Include Scene Item ID when loading a Model View

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -53,7 +53,7 @@
     "@vertexvis/geometry": "0.22.0",
     "@vertexvis/html-templates": "0.22.0",
     "@vertexvis/scene-tree-protos": "^0.1.21",
-    "@vertexvis/scene-view-protos": "^0.4.3",
+    "@vertexvis/scene-view-protos": "^0.4.4",
     "@vertexvis/stream-api": "0.22.0",
     "@vertexvis/utils": "0.22.0",
     "@vertexvis/web-workers": "^0.1.0",

--- a/packages/viewer/src/lib/model-views/__tests__/controller.spec.ts
+++ b/packages/viewer/src/lib/model-views/__tests__/controller.spec.ts
@@ -47,13 +47,17 @@ describe(ModelViewController, () => {
   describe(ModelViewController.prototype.load, () => {
     it('updates the scene view with the provided model view id', async () => {
       const { controller, client } = makeModelViewController(jwt, deviceId);
-      const expected = makeUpdateSceneViewRequest(sceneViewId, modelViewId);
+      const expected = makeUpdateSceneViewRequest(
+        sceneViewId,
+        itemId,
+        modelViewId
+      );
 
       (client.updateSceneView as jest.Mock).mockImplementationOnce(
         mockGrpcUnaryResult({})
       );
 
-      await controller.load(modelViewId);
+      await controller.load(itemId, modelViewId);
 
       expect(client.updateSceneView).toHaveBeenCalledWith(
         expected,

--- a/packages/viewer/src/testing/modelViews.ts
+++ b/packages/viewer/src/testing/modelViews.ts
@@ -1,5 +1,6 @@
 import { ModelView } from '@vertexvis/scene-view-protos/core/protos/model_views_pb';
 import { Uuid2l } from '@vertexvis/scene-view-protos/core/protos/uuid_pb';
+import { ItemModelView } from '@vertexvis/scene-view-protos/sceneview/protos/domain_pb';
 import {
   ListItemModelViewsResponse,
   UpdateSceneViewRequest,
@@ -20,6 +21,7 @@ export function makeListItemModelViewsResponse(
 
 export function makeUpdateSceneViewRequest(
   sceneViewId: UUID.UUID,
+  sceneItemId?: UUID.UUID,
   modelViewId?: UUID.UUID
 ): UpdateSceneViewRequest {
   const req = new UpdateSceneViewRequest();
@@ -30,16 +32,23 @@ export function makeUpdateSceneViewRequest(
   svUuid2l.setLsb(svUuid.lsb);
   req.setSceneViewId(svUuid2l);
 
-  if (modelViewId != null) {
+  if (sceneItemId != null && modelViewId != null) {
+    const siUuid = UUID.toMsbLsb(sceneItemId);
+    const siUuid2l = new Uuid2l();
+    siUuid2l.setMsb(siUuid.msb);
+    siUuid2l.setLsb(siUuid.lsb);
     const mvUuid = UUID.toMsbLsb(modelViewId);
     const mvUuid2l = new Uuid2l();
     mvUuid2l.setMsb(mvUuid.msb);
     mvUuid2l.setLsb(mvUuid.lsb);
-    req.setModelViewId(mvUuid2l);
+    const mv = new ItemModelView();
+    mv.setSceneItemId(siUuid2l);
+    mv.setModelViewId(mvUuid2l);
+    req.setItemModelView(mv);
   }
 
   const mask = new FieldMask();
-  mask.addPaths('model_view_id');
+  mask.addPaths('item_model_view');
   req.setUpdateMask(mask);
 
   return req;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,10 +2239,10 @@
   resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.22.tgz#fbb532b3d3046c2859caf9ae197bc5715f1c2cab"
   integrity sha512-I4tdrquf1jIPyQNtyZGT7itUfN1QfZ+EVlqdXzUa62Z3w79hMmNmPSRg5efZsrSLxzOYyRJaZ4U7Qp2lOcou2g==
 
-"@vertexvis/scene-view-protos@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@vertexvis/scene-view-protos/-/scene-view-protos-0.4.3.tgz#7812a0fc12f4cd00608b1301916d36085a5d076e"
-  integrity sha512-CV/ToNflhSg2FwJvNbRnzRDyZI0/eBDQpa7eg6hAVMXXIXnigIM2Vcx2aE6QRHdrhC0yPXJ0D2kZMOflMvEK/Q==
+"@vertexvis/scene-view-protos@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@vertexvis/scene-view-protos/-/scene-view-protos-0.4.4.tgz#d03deb89b9479663131f1f679c3732cf2a7c5bb0"
+  integrity sha512-n4nwcsefsH2mrk2qwDXl1g77N0KLVIPc7vehqp1S76yK+U7BBPKdL4eLdqO9QoYVMvPG47kGRmiqE0BOGaRyGw==
 
 "@vertexvis/typescript-config-vertexvis@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Summary

Updates the model view controller to require a `sceneItemId` to be passed with the request to load a model view.

## Test Plan

- Verify the payload is generated correctly for a `load` of a model view
- Verify the payload is generated correctly for an `unload` of a model view

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
