### PR TITLE
[PLAT-4715] Apply model views using stream payload

### DIFF
--- a/packages/stream-api/src/streamApi.ts
+++ b/packages/stream-api/src/streamApi.ts
@@ -25,6 +25,7 @@ import {
   UpdateCrossSectioningPayload,
   UpdateDimensionsPayload,
   UpdateInteractionPayload,
+  UpdateModelViewPayload,
   UpdateStreamPayload,
 } from './types';
 import { WebSocketClient, WebSocketClientImpl } from './webSocketClient';
@@ -305,6 +306,29 @@ export class StreamApi {
     withResponse = true
   ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
     return this.sendRequest({ updateCrossSectioning: payload }, withResponse);
+  }
+
+  /**
+   * Sends a request to set or clear the model view of the frame.
+   *
+   * The payload accepts an optional `frameCorrelationId` that will be sent
+   * back on the frame that is associated to this request. Use `onRequest` to
+   * add a callback that'll be invoked when the server sends a request to draw
+   * the frame.
+   *
+   * Use `withResponse` to indicate if the server should reply with a response.
+   * If `false`, the returned promise will complete immediately. Otherwise,
+   * it'll complete when a response is received.
+   *
+   * @param payload The payload of the request.
+   * @param withResponse Indicates if the server should reply with a response.
+   * Defaults to `true`.
+   */
+  public updateModelView(
+    payload: UpdateModelViewPayload,
+    withResponse = true
+  ): Promise<vertexvis.protobuf.stream.IStreamResponse> {
+    return this.sendRequest({ updateModelView: payload }, withResponse);
   }
 
   /**

--- a/packages/stream-api/src/types.ts
+++ b/packages/stream-api/src/types.ts
@@ -43,6 +43,11 @@ export type UpdateCrossSectioningPayload = DeepRequired<
   ['frameCorrelationId']
 >;
 
+export type UpdateModelViewPayload = DeepRequired<
+  vertexvis.protobuf.stream.IUpdateModelViewPayload,
+  ['frameCorrelationId']
+>;
+
 export type HitItemsPayload = DeepRequired<
   vertexvis.protobuf.stream.IHitItemsPayload,
   []

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -495,13 +495,6 @@ export class Viewer {
       this.annotationStateChanged.emit(state)
     );
 
-    this.modelViews = new ModelViewController(
-      client,
-      () => this.token,
-      () => this.deviceId,
-      () => this.scene()
-    );
-
     this.stream =
       this.stream ??
       new ViewerStream(new WebSocketClientImpl(), {
@@ -509,6 +502,13 @@ export class Viewer {
         enableTemporalRefinement: this.enableTemporalRefinement,
       });
     this.addStreamListeners();
+
+    this.modelViews = new ModelViewController(
+      client,
+      this.stream,
+      () => this.token,
+      () => this.deviceId
+    );
 
     this.updateStreamAttributes();
     this.stateMap.cursorManager.onChanged.on(() => this.handleCursorChanged());

--- a/packages/viewer/src/lib/mappers/corePbJs.ts
+++ b/packages/viewer/src/lib/mappers/corePbJs.ts
@@ -1,6 +1,7 @@
 import type { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { UUID } from '@vertexvis/utils';
 import { Mapper as M } from '@vertexvis/utils';
+import Long from 'long';
 
 export const fromPbJsUuid: M.Func<vertexvis.protobuf.core.IUuid, UUID.UUID> =
   M.defineMapper(M.read(M.requiredProp('hex')), ([uuid]) => uuid);
@@ -16,3 +17,15 @@ export const fromPbJsUuid2l: M.Func<
     return UUID.fromMsbLsb(m, l);
   }
 );
+
+export const toPbJsUuid2l: M.Func<string, vertexvis.protobuf.core.IUuid2l> =
+  M.defineMapper(
+    M.compose(
+      (str) => UUID.toMsbLsb(str),
+      M.read(
+        M.mapProp('msb', Long.fromString),
+        M.mapProp('lsb', Long.fromString)
+      )
+    ),
+    ([msb, lsb]) => ({ msb, lsb })
+  );

--- a/packages/viewer/src/lib/model-views/mapper.ts
+++ b/packages/viewer/src/lib/model-views/mapper.ts
@@ -1,22 +1,21 @@
+import type { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { ModelView as PBModelView } from '@vertexvis/scene-view-protos/core/protos/model_views_pb';
 import { ListItemModelViewsResponse } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb';
-import { Mapper as M } from '@vertexvis/utils';
+import { Mapper as M, UUID } from '@vertexvis/utils';
 
-import { fromPbCamera, fromPbUuid2l, mapCursor } from '../mappers';
+import { fromPbUuid2l, mapCursor, toPbJsUuid2l } from '../mappers';
 import { ModelView, ModelViewListResponse } from './types';
 
 const mapModelView: M.Func<PBModelView.AsObject, ModelView> = M.defineMapper(
   M.read(
     M.mapRequiredProp('id', fromPbUuid2l),
     M.getProp('displayName'),
-    M.mapRequiredProp('partRevisionId', fromPbUuid2l),
-    M.mapRequiredProp('camera', fromPbCamera)
+    M.mapRequiredProp('partRevisionId', fromPbUuid2l)
   ),
-  ([id, displayName, partRevisionId, camera]) => ({
+  ([id, displayName, partRevisionId]) => ({
     id,
     displayName,
     partRevisionId,
-    camera,
   })
 );
 
@@ -34,3 +33,16 @@ const mapListItemModelViewsResponse: M.Func<
 export const mapListItemModelViewsResponseOrThrow = M.ifInvalidThrow(
   mapListItemModelViewsResponse
 );
+
+const mapItemModelView: M.Func<
+  { modelViewId: UUID.UUID; sceneItemId: UUID.UUID },
+  vertexvis.protobuf.core.IItemModelView
+> = M.defineMapper(
+  M.read(
+    M.mapProp('modelViewId', toPbJsUuid2l),
+    M.mapProp('sceneItemId', toPbJsUuid2l)
+  ),
+  ([modelViewId, sceneItemId]) => ({ modelViewId, sceneItemId })
+);
+
+export const mapItemModelViewOrThrow = M.ifInvalidThrow(mapItemModelView);

--- a/packages/viewer/src/lib/model-views/types.ts
+++ b/packages/viewer/src/lib/model-views/types.ts
@@ -1,13 +1,11 @@
 import { UUID } from '@vertexvis/utils';
 
-import { FrameCamera } from '../types';
 import { PagingLinks } from '../types/pagination';
 
 export interface ModelView {
   id: UUID.UUID;
   displayName: string;
   partRevisionId: UUID.UUID;
-  camera: FrameCamera.FrameCamera;
 }
 
 export interface ModelViewListResponse {

--- a/packages/viewer/src/testing/modelViews.ts
+++ b/packages/viewer/src/testing/modelViews.ts
@@ -1,19 +1,9 @@
-import {
-  Camera,
-  PerspectiveCamera,
-} from '@vertexvis/scene-view-protos/core/protos/camera_pb';
 import { ModelView } from '@vertexvis/scene-view-protos/core/protos/model_views_pb';
-import { Uuid2l } from '@vertexvis/scene-view-protos/core/protos/uuid_pb';
-import { ItemModelView } from '@vertexvis/scene-view-protos/sceneview/protos/domain_pb';
-import {
-  ListItemModelViewsResponse,
-  UpdateSceneViewRequest,
-} from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb';
+import { ListItemModelViewsResponse } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb';
 import { UUID } from '@vertexvis/utils';
-import { FieldMask } from 'google-protobuf/google/protobuf/field_mask_pb';
 
 import { random } from './random';
-import { makeUuid2l, makeVector3 } from './sceneView';
+import { makeUuid2l } from './sceneView';
 
 export function makeListItemModelViewsResponse(
   modelViews: ModelView[] = [makeModelView(), makeModelView()]
@@ -21,41 +11,6 @@ export function makeListItemModelViewsResponse(
   const res = new ListItemModelViewsResponse();
   res.setModelViewsList(modelViews);
   return res;
-}
-
-export function makeUpdateSceneViewRequest(
-  sceneViewId: UUID.UUID,
-  sceneItemId?: UUID.UUID,
-  modelViewId?: UUID.UUID
-): UpdateSceneViewRequest {
-  const req = new UpdateSceneViewRequest();
-
-  const svUuid = UUID.toMsbLsb(sceneViewId);
-  const svUuid2l = new Uuid2l();
-  svUuid2l.setMsb(svUuid.msb);
-  svUuid2l.setLsb(svUuid.lsb);
-  req.setSceneViewId(svUuid2l);
-
-  if (sceneItemId != null && modelViewId != null) {
-    const siUuid = UUID.toMsbLsb(sceneItemId);
-    const siUuid2l = new Uuid2l();
-    siUuid2l.setMsb(siUuid.msb);
-    siUuid2l.setLsb(siUuid.lsb);
-    const mvUuid = UUID.toMsbLsb(modelViewId);
-    const mvUuid2l = new Uuid2l();
-    mvUuid2l.setMsb(mvUuid.msb);
-    mvUuid2l.setLsb(mvUuid.lsb);
-    const mv = new ItemModelView();
-    mv.setSceneItemId(siUuid2l);
-    mv.setModelViewId(mvUuid2l);
-    req.setItemModelView(mv);
-  }
-
-  const mask = new FieldMask();
-  mask.addPaths('item_model_view');
-  req.setUpdateMask(mask);
-
-  return req;
 }
 
 export function makeModelView(
@@ -67,11 +22,5 @@ export function makeModelView(
   modelView.setId(makeUuid2l(id));
   modelView.setPartRevisionId(makeUuid2l(partRevisionId));
   modelView.setDisplayName(displayName);
-  const camera = new Camera();
-  const perspective = new PerspectiveCamera();
-  perspective.setUp(makeVector3());
-  perspective.setPosition(makeVector3());
-  perspective.setLookAt(makeVector3());
-  modelView.setCamera(camera);
   return modelView;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2211,9 +2211,9 @@
     prettier "^2.5.1"
 
 "@vertexvis/frame-streaming-protos@^0.13.2":
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.5.tgz#b9b04a1d67c4ffe1fa81fe2493ef977cdfd79bf6"
-  integrity sha512-QTSEn/Mxrda/QJuLeUljw0k6aumIbw6obPnSXV/oJIhRLsmsrRWPisSJ/P6nILZfb8LWzuZwaoaRYHO1EG8tvw==
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.9.tgz#250c9bec3fbe1abc927f8bd3f3eb4dd505cee18b"
+  integrity sha512-oozmHFz8fTIPIK7iph1EhfErhm52aQSwFXRHxbpu+cfZxM1QDpgURhvotqsC+sSAXuWXvH716ypRhrNZ/EP6VA==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"
@@ -2235,14 +2235,14 @@
   integrity sha512-5pJbF5/nMdqybxpZW2yBIQ9lF3P61ziaC3APTfHXU9APhnVfp+3jdW5PkrWGc45zFn1wCkuwEFhD+ORv3LEePw==
 
 "@vertexvis/scene-tree-protos@^0.1.21":
-  version "0.1.23"
-  resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.23.tgz#d0d43f14419db18543c78398d72dcf06efce74e0"
-  integrity sha512-Utb58aiV+k5A+ZPrEUKK4F5ckSRHJyLmLVwHJXVh7iHWNCwXATUaiu9k/YJ6kxUomOSGwL+zIs1lkgRtLDScGw==
+  version "0.1.25"
+  resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.25.tgz#e41223ed3a5aef9609c7e42c2687649c968c0fd1"
+  integrity sha512-MjeVWG41f6p4en9dtYdV852POeDMMoyqhdTIYJMuUBJvXlW9YjINWXHB+Vd5uNZ1xumU6Rahx1KqTxcOYkPxhw==
 
 "@vertexvis/scene-view-protos@^0.4.5":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@vertexvis/scene-view-protos/-/scene-view-protos-0.4.5.tgz#a4ac4681ca4176f436afadea91ce86dcaaceb3a7"
-  integrity sha512-DPBo3KEaFZl+J/DfWHM4FT5IKbpAG8KEjkp7YCTlCFKzE2NoDJ2VTUdbtYbwsTCxkAX5txEA3uu4dmwlkM3LCA==
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@vertexvis/scene-view-protos/-/scene-view-protos-0.4.7.tgz#e0e16fc9e53fec8e92eb664e5d9a04e8d33cf7c0"
+  integrity sha512-R3RULrnqR6l9aCMWRWcctmzxt4l9Sa2Blo/YqBvdAfWuss4VjaZxMgrGOuzcu9RbwCbg9pWDr9p32rvn7UHF3A==
 
 "@vertexvis/typescript-config-vertexvis@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Summary

This changes the implementation for applying model views to use the new stream payload, instead of the gRPC-Web endpoint.

https://vertexvis.atlassian.net/browse/PLAT-4715