### PR TITLE
[PLAT-4743] Include scene comparison information in stream attributes

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set Node Version
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
@@ -31,7 +31,7 @@ jobs:
       - name: "Build"
         run: "yarn build"
       - name: "Upload build artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifact
           path: |
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set Node Version
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
@@ -65,7 +65,7 @@ jobs:
     needs: [build]
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Download build artifacts"
         uses: actions/download-artifact@v2
         with:
@@ -94,7 +94,7 @@ jobs:
     needs: [build]
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Download build artifacts"
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -16,11 +16,11 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -46,11 +46,11 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -67,7 +67,7 @@ jobs:
       - name: "Checkout changes"
         uses: actions/checkout@v4
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: packages
@@ -75,11 +75,11 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -96,7 +96,7 @@ jobs:
       - name: "Checkout changes"
         uses: actions/checkout@v4
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: packages
@@ -104,11 +104,11 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set Node Version
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
@@ -32,7 +32,7 @@ jobs:
       - name: "Test"
         run: "yarn test:ci"
       - name: "Upload build artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifact
           path: |
@@ -45,7 +45,7 @@ jobs:
       publish: ${{ steps.detect-publish.outputs.publish }}
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Detect publish"
         id: "detect-publish"
         run: |
@@ -58,7 +58,7 @@ jobs:
     needs: [build]
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Download build artifacts"
         uses: actions/download-artifact@v2
         with:
@@ -98,7 +98,7 @@ jobs:
     if: needs.detect-publish-release.outputs.publish == 1
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Download build artifacts"
         uses: actions/download-artifact@v2
         with:
@@ -134,7 +134,7 @@ jobs:
     needs: [publish-release]
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Download build artifacts"
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,11 +15,11 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -60,7 +60,7 @@ jobs:
       - name: "Checkout changes"
         uses: actions/checkout@v4
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: packages
@@ -68,13 +68,13 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
           registry-url: https://registry.npmjs.org
           scope: "@vertexvis"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -100,7 +100,7 @@ jobs:
       - name: "Checkout changes"
         uses: actions/checkout@v4
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: packages
@@ -108,13 +108,13 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
           registry-url: https://registry.npmjs.org
           scope: "@vertexvis"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -136,7 +136,7 @@ jobs:
       - name: "Checkout changes"
         uses: actions/checkout@v4
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: packages
@@ -144,13 +144,13 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
           registry-url: https://registry.npmjs.org
           scope: "@vertexvis"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set Node Version
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
@@ -30,7 +30,7 @@ jobs:
       - name: "Build"
         run: "yarn build"
       - name: "Upload build artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifact
           path: |
@@ -41,7 +41,7 @@ jobs:
     needs: [build]
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Download build artifacts"
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,11 +15,11 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -43,7 +43,7 @@ jobs:
       - name: "Checkout changes"
         uses: actions/checkout@v4
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: packages
@@ -51,13 +51,13 @@ jobs:
         id: nvm
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
           registry-url: https://registry.npmjs.org
           scope: "@vertexvis"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.13.11"
+    "@vertexvis/frame-streaming-protos": "^0.13.12"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.13.12"
+    "@vertexvis/frame-streaming-protos": "^0.13.13"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.13.12",
+    "@vertexvis/frame-streaming-protos": "^0.13.13",
     "@vertexvis/geometry": "0.22.0",
     "@vertexvis/html-templates": "0.22.0",
     "@vertexvis/scene-tree-protos": "^0.1.21",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.13.11",
+    "@vertexvis/frame-streaming-protos": "^0.13.12",
     "@vertexvis/geometry": "0.22.0",
     "@vertexvis/html-templates": "0.22.0",
     "@vertexvis/scene-tree-protos": "^0.1.21",

--- a/packages/viewer/src/interfaces.d.ts
+++ b/packages/viewer/src/interfaces.d.ts
@@ -1,5 +1,5 @@
 import { Euler, Matrix4, Quaternion, Vector3 } from '@vertexvis/geometry';
-import { Color, UUID } from '@vertexvis/utils';
+import { Color } from '@vertexvis/utils';
 
 export type Color3 = Omit<Color.Color, 'a'> | string | number;
 

--- a/packages/viewer/src/interfaces.d.ts
+++ b/packages/viewer/src/interfaces.d.ts
@@ -31,7 +31,7 @@ export interface FrameOptions {
 }
 
 export interface SceneComparisonOptions {
-  sceneIdToCompare?: UUID.UUID;
+  streamKeyToCompare?: string;
 }
 
 export interface HTMLDomRendererPositionableElement {

--- a/packages/viewer/src/interfaces.d.ts
+++ b/packages/viewer/src/interfaces.d.ts
@@ -1,5 +1,5 @@
 import { Euler, Matrix4, Quaternion, Vector3 } from '@vertexvis/geometry';
-import { Color } from '@vertexvis/utils';
+import { Color, UUID } from '@vertexvis/utils';
 
 export type Color3 = Omit<Color.Color, 'a'> | string | number;
 
@@ -31,6 +31,7 @@ export interface FrameOptions {
 }
 
 export interface SceneComparisonOptions {
+  sceneIdToCompare?: UUID.UUID;
   streamKeyToCompare?: string;
 }
 

--- a/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
+++ b/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
@@ -1,6 +1,8 @@
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
-import { Color } from '@vertexvis/utils';
+import { Color, UUID } from '@vertexvis/utils';
+import Long from 'long';
 
+import { random } from '../../../testing/random';
 import { toPbStreamAttributes } from '../streamAttributes';
 
 describe(toPbStreamAttributes, () => {
@@ -163,6 +165,25 @@ describe(toPbStreamAttributes, () => {
       expect(res).toMatchObject({
         sceneComparison: {
           streamKeyToCompare: streamKey,
+        },
+      });
+    });
+
+    it('enables comparing scenes with scene id', () => {
+      const sceneId = random.guid();
+      const sceneId2l = UUID.toMsbLsb(sceneId);
+
+      const res = toPbStreamAttributes({
+        sceneComparison: {
+          sceneIdToCompare: sceneId,
+        },
+      });
+      expect(res).toMatchObject({
+        sceneComparison: {
+          sceneIdToCompare: {
+            msb: Long.fromString(sceneId2l.msb),
+            lsb: Long.fromString(sceneId2l.lsb),
+          },
         },
       });
     });

--- a/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
+++ b/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
@@ -1,8 +1,6 @@
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
-import { Color, UUID } from '@vertexvis/utils';
-import Long from 'long';
+import { Color } from '@vertexvis/utils';
 
-import { random } from '../../../testing/random';
 import { toPbStreamAttributes } from '../streamAttributes';
 
 describe(toPbStreamAttributes, () => {
@@ -155,7 +153,7 @@ describe(toPbStreamAttributes, () => {
 
   describe('scene comparison', () => {
     it('enables comparing scenes if set', () => {
-      const streamKey = "test";
+      const streamKey = 'test';
 
       const res = toPbStreamAttributes({
         sceneComparison: {

--- a/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
+++ b/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
@@ -155,20 +155,16 @@ describe(toPbStreamAttributes, () => {
 
   describe('scene comparison', () => {
     it('enables comparing scenes if set', () => {
-      const sceneId = random.guid();
-      const sceneId2l = UUID.toMsbLsb(sceneId);
+      const streamKey = "test";
 
       const res = toPbStreamAttributes({
         sceneComparison: {
-          sceneIdToCompare: sceneId,
+          streamKeyToCompare: streamKey,
         },
       });
       expect(res).toMatchObject({
         sceneComparison: {
-          sceneIdToCompare: {
-            msb: Long.fromString(sceneId2l.msb),
-            lsb: Long.fromString(sceneId2l.lsb),
-          },
+          streamKeyToCompare: streamKey,
         },
       });
     });

--- a/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
+++ b/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
@@ -164,7 +164,7 @@ describe(toPbStreamAttributes, () => {
       });
       expect(res).toMatchObject({
         sceneComparison: {
-          streamKeyToCompare: streamKey,
+          streamKeyToCompare: { value: streamKey },
         },
       });
     });

--- a/packages/viewer/src/lib/mappers/streamAttributes.ts
+++ b/packages/viewer/src/lib/mappers/streamAttributes.ts
@@ -123,7 +123,7 @@ const toPbSceneComparison: M.Func<
 > = M.defineMapper(
   M.read(
     M.ifDefined(M.mapProp('sceneIdToCompare', M.ifDefined(toPbJsUuid2l))),
-    M.ifDefined(M.getProp('streamKeyToCompare', M.ifDefined(toPbStringValue)))
+    M.ifDefined(M.mapProp('streamKeyToCompare', M.ifDefined(toPbStringValue)))
   ),
   ([sceneIdToCompare, streamKeyToCompare]) => ({
     sceneIdToCompare,

--- a/packages/viewer/src/lib/mappers/streamAttributes.ts
+++ b/packages/viewer/src/lib/mappers/streamAttributes.ts
@@ -12,9 +12,8 @@ import {
   SelectionHighlightingOptions,
   StreamAttributes,
 } from '../../interfaces';
-import { toPbJsUuid2l } from './corePbJs';
 import { toPbRGBi } from './material';
-import { toPbFloatValue } from './scalar';
+import { toPbFloatValue, toPbStringValue } from './scalar';
 
 const toPbFrameType: M.Func<
   FrameType,
@@ -121,7 +120,9 @@ const toPbSceneComparison: M.Func<
   SceneComparisonOptions | undefined,
   vertexvis.protobuf.stream.ISceneComparisonAttributes
 > = M.defineMapper(
-  M.read(M.ifDefined(M.mapProp('streamKeyToCompare'))),
+  M.read(
+    M.ifDefined(M.mapProp('streamKeyToCompare', M.ifDefined(toPbStringValue)))
+  ),
   ([streamKeyToCompare]) => ({
     streamKeyToCompare,
   })

--- a/packages/viewer/src/lib/mappers/streamAttributes.ts
+++ b/packages/viewer/src/lib/mappers/streamAttributes.ts
@@ -12,6 +12,7 @@ import {
   SelectionHighlightingOptions,
   StreamAttributes,
 } from '../../interfaces';
+import { toPbJsUuid2l } from './corePbJs';
 import { toPbRGBi } from './material';
 import { toPbFloatValue, toPbStringValue } from './scalar';
 
@@ -121,9 +122,11 @@ const toPbSceneComparison: M.Func<
   vertexvis.protobuf.stream.ISceneComparisonAttributes
 > = M.defineMapper(
   M.read(
-    M.ifDefined(M.mapProp('streamKeyToCompare', M.ifDefined(toPbStringValue)))
+    M.ifDefined(M.mapProp('sceneIdToCompare', M.ifDefined(toPbJsUuid2l))),
+    M.ifDefined(M.getProp('streamKeyToCompare', M.ifDefined(toPbStringValue)))
   ),
-  ([streamKeyToCompare]) => ({
+  ([sceneIdToCompare, streamKeyToCompare]) => ({
+    sceneIdToCompare,
     streamKeyToCompare,
   })
 );

--- a/packages/viewer/src/lib/mappers/streamAttributes.ts
+++ b/packages/viewer/src/lib/mappers/streamAttributes.ts
@@ -121,9 +121,9 @@ const toPbSceneComparison: M.Func<
   SceneComparisonOptions | undefined,
   vertexvis.protobuf.stream.ISceneComparisonAttributes
 > = M.defineMapper(
-  M.read(M.ifDefined(M.mapProp('sceneIdToCompare', M.ifDefined(toPbJsUuid2l)))),
-  ([sceneIdToCompare]) => ({
-    sceneIdToCompare,
+  M.read(M.ifDefined(M.mapProp('streamKeyToCompare'))),
+  ([streamKeyToCompare]) => ({
+    streamKeyToCompare,
   })
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,10 +2210,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.13.11":
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.11.tgz#a18b01e7f9fc3ec5b933fb73a58ebf032a7f9197"
-  integrity sha512-y2L3+N4Zm7RxeV+hYB8h1ktISMg0aJi7VzJNIFwWkljnGs+MSHIeykWErRw6el/UGqauZnwo8Sm6cOlgrcetcg==
+"@vertexvis/frame-streaming-protos@^0.13.12":
+  version "0.13.12"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.12.tgz#559ba5ed5d38d6341f1e7a0e287edac1325e4498"
+  integrity sha512-dLr2QhpweaAry0cFGphHhBQvMu9vvzc0LddU3bkp8ypV+luAdUSPaMbmT1MtnSX9oO8OfH9pFAgzoyfoobb2+g==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,10 +2210,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.13.12":
-  version "0.13.12"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.12.tgz#559ba5ed5d38d6341f1e7a0e287edac1325e4498"
-  integrity sha512-dLr2QhpweaAry0cFGphHhBQvMu9vvzc0LddU3bkp8ypV+luAdUSPaMbmT1MtnSX9oO8OfH9pFAgzoyfoobb2+g==
+"@vertexvis/frame-streaming-protos@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.13.tgz#82ce87c936fa3bb1a097475c0f543c5cb0c080a2"
+  integrity sha512-MzWNZen/gCd0mAyQ2J+pRmn4vnsOexdfcfNXGjOIzhowRJ9Js2P2qdJMIwPUVCk37heZVkFIGHRUZSSL0tKvNw==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary
This PR updates the scene compare feature to include the a stream key to compare to on the stream attributes as opposed to within the experimental rendering options.

## Test Plan
Verify scenes can be compared by including a stream key in the comparison information in the stream attributes

## Release Notes
None

## Possible Regressions
Comparing scenes

## Dependencies
None
