### PR TITLE
[PLAT-4743] Remove ability to compare by scene id

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.13.13"
+    "@vertexvis/frame-streaming-protos": "^0.13.14"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.13.13",
+    "@vertexvis/frame-streaming-protos": "^0.13.14",
     "@vertexvis/geometry": "0.22.0",
     "@vertexvis/html-templates": "0.22.0",
     "@vertexvis/scene-tree-protos": "^0.1.21",

--- a/packages/viewer/src/interfaces.d.ts
+++ b/packages/viewer/src/interfaces.d.ts
@@ -1,5 +1,5 @@
 import { Euler, Matrix4, Quaternion, Vector3 } from '@vertexvis/geometry';
-import { Color, UUID } from '@vertexvis/utils';
+import { Color } from '@vertexvis/utils';
 
 export type Color3 = Omit<Color.Color, 'a'> | string | number;
 

--- a/packages/viewer/src/interfaces.d.ts
+++ b/packages/viewer/src/interfaces.d.ts
@@ -31,7 +31,6 @@ export interface FrameOptions {
 }
 
 export interface SceneComparisonOptions {
-  sceneIdToCompare?: UUID.UUID;
   streamKeyToCompare?: string;
 }
 

--- a/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
+++ b/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
@@ -168,24 +168,5 @@ describe(toPbStreamAttributes, () => {
         },
       });
     });
-
-    it('enables comparing scenes with scene id', () => {
-      const sceneId = random.guid();
-      const sceneId2l = UUID.toMsbLsb(sceneId);
-
-      const res = toPbStreamAttributes({
-        sceneComparison: {
-          sceneIdToCompare: sceneId,
-        },
-      });
-      expect(res).toMatchObject({
-        sceneComparison: {
-          sceneIdToCompare: {
-            msb: Long.fromString(sceneId2l.msb),
-            lsb: Long.fromString(sceneId2l.lsb),
-          },
-        },
-      });
-    });
   });
 });

--- a/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
+++ b/packages/viewer/src/lib/mappers/__tests__/streamAttributes.spec.ts
@@ -1,8 +1,6 @@
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
-import { Color, UUID } from '@vertexvis/utils';
-import Long from 'long';
+import { Color } from '@vertexvis/utils';
 
-import { random } from '../../../testing/random';
 import { toPbStreamAttributes } from '../streamAttributes';
 
 describe(toPbStreamAttributes, () => {

--- a/packages/viewer/src/lib/mappers/streamAttributes.ts
+++ b/packages/viewer/src/lib/mappers/streamAttributes.ts
@@ -122,11 +122,9 @@ const toPbSceneComparison: M.Func<
   vertexvis.protobuf.stream.ISceneComparisonAttributes
 > = M.defineMapper(
   M.read(
-    M.ifDefined(M.mapProp('sceneIdToCompare', M.ifDefined(toPbJsUuid2l))),
     M.ifDefined(M.mapProp('streamKeyToCompare', M.ifDefined(toPbStringValue)))
   ),
-  ([sceneIdToCompare, streamKeyToCompare]) => ({
-    sceneIdToCompare,
+  ([streamKeyToCompare]) => ({
     streamKeyToCompare,
   })
 );

--- a/packages/viewer/src/lib/mappers/streamAttributes.ts
+++ b/packages/viewer/src/lib/mappers/streamAttributes.ts
@@ -12,7 +12,6 @@ import {
   SelectionHighlightingOptions,
   StreamAttributes,
 } from '../../interfaces';
-import { toPbJsUuid2l } from './corePbJs';
 import { toPbRGBi } from './material';
 import { toPbFloatValue, toPbStringValue } from './scalar';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,10 +2210,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.13.tgz#82ce87c936fa3bb1a097475c0f543c5cb0c080a2"
-  integrity sha512-MzWNZen/gCd0mAyQ2J+pRmn4vnsOexdfcfNXGjOIzhowRJ9Js2P2qdJMIwPUVCk37heZVkFIGHRUZSSL0tKvNw==
+"@vertexvis/frame-streaming-protos@^0.13.14":
+  version "0.13.14"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.14.tgz#4c315b111508c741248cf0180a5ba482fae56283"
+  integrity sha512-ArKKBdbhruKbGUSfGIzhKFcmWvRBQftOehrve+y4162oRjODhbBjBqFd1X0YF2nppohh0CyaoLND6uJF9xRBKw==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary
We only want to allow users to initiate a scene comparison by providing the stream key. Therefore, this PR removes support for including a scene id to compare to the existing scene.

## Test Plan
Verify version compare works as expected when providing a stream key

## Release Notes
None

## Possible Regressions
Version compare

## Dependencies
None