### PR TITLE
[PLAT-1780] Blur scene-tree-table-cell elements on action pointerup

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.tsx
@@ -1,3 +1,5 @@
+jest.mock('./utils');
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { h } from '@stencil/core';
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
@@ -7,12 +9,17 @@ import Chance from 'chance';
 
 import { SceneTreeCellHoverController } from '../scene-tree-table-layout/lib/hover-controller';
 import { SceneTreeTableCell } from './scene-tree-table-cell';
+import { blurElement } from './utils';
 
 const random = new Chance();
 
 describe('<vertex-scene-tree-table-cell>', () => {
   const pointerDownEvent = new MouseEvent('pointerdown', {
     button: 0,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('renders empty element if node is undefined', async () => {
@@ -544,6 +551,31 @@ describe('<vertex-scene-tree-table-cell>', () => {
     disposable.dispose();
 
     expect(hovered).toHaveBeenCalledWith(undefined);
+  });
+
+  it('blurs the element when an action button is clicked', async () => {
+    const node = createNode({ selected: true });
+    const { cell } = await newComponentSpec({
+      html: `
+        <vertex-scene-tree-table-cell expand-toggle isolate-button visibility-toggle></vertex-scene-tree-table-cell>
+      `,
+      node,
+    });
+
+    const expand = cell.shadowRoot?.querySelector('.expand-btn');
+    const visibility = cell.shadowRoot?.querySelector('.visibility-btn');
+    const isolate = cell.shadowRoot?.querySelector('.isolate-btn');
+
+    console.log(expand);
+
+    expand?.dispatchEvent(new MouseEvent('pointerup'));
+    expect(blurElement).toHaveBeenCalledTimes(1);
+
+    visibility?.dispatchEvent(new MouseEvent('pointerup'));
+    expect(blurElement).toHaveBeenCalledTimes(2);
+
+    isolate?.dispatchEvent(new MouseEvent('pointerup'));
+    expect(blurElement).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.spec.tsx
@@ -566,8 +566,6 @@ describe('<vertex-scene-tree-table-cell>', () => {
     const visibility = cell.shadowRoot?.querySelector('.visibility-btn');
     const isolate = cell.shadowRoot?.querySelector('.isolate-btn');
 
-    console.log(expand);
-
     expand?.dispatchEvent(new MouseEvent('pointerup'));
     expect(blurElement).toHaveBeenCalledTimes(1);
 

--- a/packages/viewer/src/components/scene-tree-table-cell/utils.ts
+++ b/packages/viewer/src/components/scene-tree-table-cell/utils.ts
@@ -4,3 +4,7 @@ export function isSceneTreeTableCellElement(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return el != null && (el as any).nodeName === 'VERTEX-SCENE-TREE-TABLE-CELL';
 }
+
+export function blurElement(element: HTMLElement): void {
+  element.blur();
+}


### PR DESCRIPTION
## Summary

Adds a `this.hostEl.blur()` when handling `pointerup` events for scene-tree actions (toggle expansion, isolate, toggle visibility). Because we call `preventDefault` on the `pointerup` event, this was causing the `document.activeElement` to remain as the `<vertex-scene-tree-table-cell>` element, rather than returning focus to the `<body>` element. Because of this, key presses would result in a focus outline appearing on the last pressed action button, which this PR corrects.

As a side-note, the above behavior can be tested by setting a `pointerup` breakpoint in Chrome, and checking the value of `document.activeElement` before and after the event handlers have run.

## Test Plan

- Click a scene-tree action button
- Without focusing another element, press a number or letter key
- Verify that no blue focus outline appears on the button that was clicked

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
