### PR TITLE
[PLAT-5083] Correctly convert pmi annotation id

### DIFF
--- a/packages/viewer/src/lib/pmi/mapper.ts
+++ b/packages/viewer/src/lib/pmi/mapper.ts
@@ -5,7 +5,7 @@ import { Mapper as M } from '@vertexvis/utils';
 import { fromPbUuid2l, mapCursor } from '../mappers';
 import { PmiAnnotation, PmiAnnotationListResponse } from './types';
 
-const mapModelView: M.Func<PBPmiAnnotation.AsObject, PmiAnnotation> =
+const mapPmiAnnotation: M.Func<PBPmiAnnotation.AsObject, PmiAnnotation> =
   M.defineMapper(
     M.read(M.mapRequiredProp('id', fromPbUuid2l), M.getProp('displayName')),
     ([id, displayName]) => ({ id, displayName })
@@ -16,7 +16,7 @@ const mapListPmiAnnotationsResponse: M.Func<
   PmiAnnotationListResponse
 > = M.defineMapper(
   M.read(
-    M.mapProp('annotationsList', M.mapArray(mapModelView)),
+    M.mapProp('annotationsList', M.mapArray(mapPmiAnnotation)),
     M.mapProp('nextPageCursor', mapCursor)
   ),
   ([annotations, next]) => ({ annotations, paging: { next } })

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -2,6 +2,7 @@ import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { Dimensions } from '@vertexvis/geometry';
 import { RepresentationPredefinedId } from '@vertexvis/scene-view-protos/core/protos/representation_pb';
 import { UUID } from '@vertexvis/utils';
+import Long from 'long';
 
 import { random } from '../../../testing/random';
 import {
@@ -111,8 +112,8 @@ describe(buildSceneElementOperationOnAnnotation, () => {
               operand: {
                 annotation: {
                   id: {
-                    msb: parseFloat(annotationId1Msb),
-                    lsb: parseFloat(annotationId1Lsb),
+                    msb: Long.fromString(annotationId1Msb),
+                    lsb: Long.fromString(annotationId1Lsb),
                   },
                 },
               },
@@ -121,8 +122,8 @@ describe(buildSceneElementOperationOnAnnotation, () => {
               operand: {
                 annotation: {
                   id: {
-                    msb: parseFloat(annotationId2Msb),
-                    lsb: parseFloat(annotationId2Lsb),
+                    msb: Long.fromString(annotationId2Msb),
+                    lsb: Long.fromString(annotationId2Lsb),
                   },
                 },
               },
@@ -153,8 +154,8 @@ describe(buildSceneElementOperationOnAnnotation, () => {
           operand: {
             annotation: {
               id: {
-                msb: parseFloat(annotationId1Msb),
-                lsb: parseFloat(annotationId1Lsb),
+                msb: Long.fromString(annotationId1Msb),
+                lsb: Long.fromString(annotationId1Lsb),
               },
             },
           },

--- a/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/scene.spec.ts
@@ -1,3 +1,5 @@
+import Long from 'long';
+
 jest.mock('@vertexvis/stream-api');
 
 import { vertexvis } from '@vertexvis/frame-streaming-protos';
@@ -586,8 +588,8 @@ describe(Scene, () => {
                 operand: {
                   annotation: {
                     id: {
-                      msb: parseFloat(msb),
-                      lsb: parseFloat(lsb),
+                      msb: Long.fromString(msb),
+                      lsb: Long.fromString(lsb),
                     },
                   },
                 },

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -3,6 +3,7 @@ import { Dimensions } from '@vertexvis/geometry';
 import { RepresentationPredefinedId } from '@vertexvis/scene-view-protos/core/protos/representation_pb';
 import { toProtoDuration } from '@vertexvis/stream-api';
 import { UUID } from '@vertexvis/utils';
+import Long from 'long';
 
 import {
   Animation,
@@ -232,8 +233,8 @@ export function buildAnnotationQueryExpression(
         operand: {
           annotation: {
             id: new vertexvis.protobuf.core.Uuid2l({
-              msb: parseFloat(msb),
-              lsb: parseFloat(lsb),
+              msb: Long.fromString(msb),
+              lsb: Long.fromString(lsb),
             }),
           },
         },


### PR DESCRIPTION
## Summary
This PR fixes a bug that was incorrectly converting PMI annotations ids to UUID2l.

## Test Plan
Verify a user can operate on individual PMI annotations

## Release Notes
None

## Possible Regressions
Operating on PMI annotations

## Dependencies
None
