### PR TITLE
[PLAT-5550] Update scene tree table resize divider

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-resize-divider/scene-tree-table-resize-divider.css
+++ b/packages/viewer/src/components/scene-tree-table-resize-divider/scene-tree-table-resize-divider.css
@@ -9,14 +9,10 @@
 .divider {
   width: 1px;
   height: 100%;
-  background-color: var(--neutral-600);
+  background-color: var(--neutral-300);
   cursor: col-resize;
 }
 
-.divider.dragging {
-  background-color: var(--blue-600);
-}
-
-:host:hover .divider {
+.divider.highlighted {
   background-color: var(--blue-600);
 }

--- a/packages/viewer/src/components/scene-tree-table-resize-divider/scene-tree-table-resize-divider.tsx
+++ b/packages/viewer/src/components/scene-tree-table-resize-divider/scene-tree-table-resize-divider.tsx
@@ -8,15 +8,22 @@ import classNames from 'classnames';
 })
 export class SceneTreeTableResizeDivider {
   @State()
+  private hovering = false;
+
+  @State()
   private dragging = false;
 
   public render(): h.JSX.IntrinsicElements {
+    const isHighlighted = !!this.hovering || !!this.dragging;
+
     return (
       <Host
         onPointerDown={this.handlePointerDown}
+        onPointerEnter={this.handleCellPointerEnter}
+        onPointerLeave={this.handleCellPointerLeave}
         style={{
-          height: this.dragging ? '100%' : 'var(--header-height)',
-          padding: this.dragging
+          height: isHighlighted ? '100%' : 'var(--header-height)',
+          padding: isHighlighted
             ? '0 calc(var(--scene-tree-table-column-gap) / 2)'
             : 'calc(var(--header-height) / 8) calc(var(--scene-tree-table-column-gap) / 2)',
         }}
@@ -24,7 +31,7 @@ export class SceneTreeTableResizeDivider {
         <slot name="divider">
           <div
             class={classNames('divider', {
-              dragging: this.dragging,
+              highlighted: isHighlighted,
             })}
           />
         </slot>
@@ -42,5 +49,13 @@ export class SceneTreeTableResizeDivider {
     this.dragging = false;
 
     window.removeEventListener('pointerup', this.handlePointerUp);
+  };
+
+  private handleCellPointerEnter = (): void => {
+    this.hovering = true;
+  };
+
+  private handleCellPointerLeave = (): void => {
+    this.hovering = false;
   };
 }


### PR DESCRIPTION
## Summary
This PR updates the scene tree table resize divider to appear a lighter gray by default and show the full blue divider on both hover and drag.

## Test Plan
Verify the scene tree table resize divider appears as expected

## Release Notes
None

## Possible Regressions
Appearance of scene tree table resize divider

## Dependencies
None
