### PR TITLE
[PLAT-5573] Partial apply SVS shading support

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.13.15"
+    "@vertexvis/frame-streaming-protos": "^0.13.16"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,7 +49,7 @@
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
     "@types/classnames": "^2.3.1",
-    "@vertexvis/frame-streaming-protos": "^0.13.15",
+    "@vertexvis/frame-streaming-protos": "^0.13.16",
     "@vertexvis/geometry": "0.22.0",
     "@vertexvis/html-templates": "0.22.0",
     "@vertexvis/scene-tree-protos": "^0.1.21",

--- a/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/mapper.spec.ts
@@ -180,6 +180,7 @@ describe(toPbSceneViewStateFeatures, () => {
         'transforms',
         'cross_section',
         'phantom',
+        'shading',
       ])
     ).toMatchObject([
       vertexvis.protobuf.stream.SceneViewStateFeature
@@ -196,6 +197,8 @@ describe(toPbSceneViewStateFeatures, () => {
         .SCENE_VIEW_STATE_FEATURE_CROSS_SECTION,
       vertexvis.protobuf.stream.SceneViewStateFeature
         .SCENE_VIEW_STATE_FEATURE_PHANTOM,
+      vertexvis.protobuf.stream.SceneViewStateFeature
+        .SCENE_VIEW_STATE_FEATURE_SHADING,
     ]);
   });
 

--- a/packages/viewer/src/lib/scenes/mapper.ts
+++ b/packages/viewer/src/lib/scenes/mapper.ts
@@ -479,6 +479,9 @@ export function toPbSceneViewStateFeatures(
       case 'phantom':
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_PHANTOM;
+      case 'shading':
+        return vertexvis.protobuf.stream.SceneViewStateFeature
+          .SCENE_VIEW_STATE_FEATURE_SHADING;
       default:
         return vertexvis.protobuf.stream.SceneViewStateFeature
           .SCENE_VIEW_STATE_FEATURE_INVALID;

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -817,7 +817,8 @@ export type SceneViewStateFeature =
   | 'selection'
   | 'transforms'
   | 'visibility'
-  | 'phantom';
+  | 'phantom'
+  | 'shading';
 
 /**
  * A class that represents the `Scene` that has been loaded into the viewer. On

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,10 +2210,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.13.15":
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.15.tgz#797cff2af7dbf6a2fd916feb0ea2f791611d4f54"
-  integrity sha512-5fA2hjeKsCCkI+nPsKUKd/lZlwz9l1QrPM/2PekKYv79e7Qtu1IRFvopt2qZOmjMyrzug8EP+vHnyBWvB4tl9g==
+"@vertexvis/frame-streaming-protos@^0.13.16":
+  version "0.13.16"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.16.tgz#daeef727022647d72146c9c04c00e667c9a76e21"
+  integrity sha512-7PhFKSshsAo/On7k5ONBSMcPqfp+v7I+aeNm8qAgnDIk6UwVqwQyt/EiX3IH1R0JjlXiiRlYnFa6R+/+eoVg4w==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary

Adds support for passing `shading` as an element when performing a partial apply of a scene view state. When passed, this value will apply the `noDefaultLights` value present in a scene view state.

## Test Plan

- Verify that passing `shading` when partially applying a scene view state properly applies the shading

## Release Notes

Added support for partially applying the shading saved in a scene view state

## Possible Regressions

N/A

## Dependencies

https://github.com/Vertexvis/frame-streaming-service/pull/450
