### PR TITLE
[PLAT-4005] Update utils package peer dependency

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "@vertexvis/utils": ">=0.22.0",
+    "@vertexvis/utils": ">=0.23.0",
     "protobufjs": ">=6.9.0 <7.0.0",
     "tslib": ">=2.1.0"
   }

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "@vertexvis/utils": "^0.20.3",
+    "@vertexvis/utils": ">=0.23.0",
     "protobufjs": ">=6.9.0 <7.0.0",
     "tslib": ">=2.1.0"
   }

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "@vertexvis/utils": ">=0.23.0",
+    "@vertexvis/utils": ">=0.22.0",
     "protobufjs": ">=6.9.0 <7.0.0",
     "tslib": ">=2.1.0"
   }


### PR DESCRIPTION
## Summary

Updates the semver range of the `@vertexvis/utils` peer dependency within the `@vertexvis/stream-api` package to allow for anything above or equal to the latest release. Prior to this change, it was not possible to pin the version and remove NPM warnings, as the version included in the `@vertexvis/viewer` dependencies was generally higher than `^0.20.3`, but almost never within a patch version range. This would result in warnings related to the peer dependency not matching, requiring a specific installation of `"@vertexvis/utils": 0.20.3` to resolve the warning, which didn't line up with the latest version of the `@vertexvis/viewer` package being installed.

This change should allow for latest release versions of `@vertexvis/viewer` to install without warnings (as it installs the latest release version of `@vertexvis/utils`), but I haven't been able to confirm that prior to releasing with this change. Failing that however, with this change we should also be able to pin `@vertexvis/utils` to the same version as `@vertexvis/viewer` in the consuming project and continue to keep those versions coupled without running into these same warnings.

One downside here is that the `>=` semver syntax could pick up future breaking changes to the utils package. As we primarily intend for the `@vertexvis/stream-api` to be managed internally, this shouldn't cause too much of an issue however, as we can update that peer dependency range when making that breaking change, causing warnings to appear if an earlier version is still installed when updating `@vertexvis/viewer`.

## Test Plan

- Once released, verify `@vertexvis/viewer` installs without `@vertexvis/utils` peer dependency warnings

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
