### PR TITLE
[PLAT-6059] Dependency warning fixes

### DIFF
--- a/packages/html-templates/package.json
+++ b/packages/html-templates/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",
-    "@types/lodash.isequal": "^4.5.6",
     "@types/uuid": "^8.3.4",
     "@vertexvis/eslint-config-vertexvis-typescript": "^0.5.0",
     "@vertexvis/jest-config-vertexvis": "^0.5.4",

--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -46,7 +46,7 @@
     "@vertexwebsdk/build": "0.23.1",
     "eslint": "^8.17.0",
     "jest": "^27.5.1",
-    "protobufjs": "^6.9.0",
+    "protobufjs": "^7.2.4",
     "rollup": "^2.75.6",
     "ts-jest": "^27.1.4",
     "tslib": "^2.1.0",
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@vertexvis/utils": ">=0.23.0",
-    "protobufjs": ">=6.9.0 <7.0.0",
+    "protobufjs": ">=6.9.0 <8.0.0",
     "tslib": ">=2.1.0"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,13 +37,12 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
+    "fast-deep-equal": "^3.1.3",
     "is-plain-object": "^3.0.0",
-    "lodash.isequal": "^4.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",
-    "@types/lodash.isequal": "^4.5.6",
     "@types/uuid": "^8.3.4",
     "@vertexvis/eslint-config-vertexvis-typescript": "^0.5.0",
     "@vertexvis/jest-config-vertexvis": "^0.5.4",

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -1,5 +1,5 @@
+import fastDeepEqual from 'fast-deep-equal';
 import isSimpleObject from 'is-plain-object';
-import areEqual from 'lodash.isequal';
 
 /* eslint-disable padding-line-between-statements */
 /**
@@ -82,7 +82,7 @@ export function isPlainObject(obj: unknown): boolean {
  * @returns `true` if the two objects are equal. Otherwise `false`.
  */
 export function isEqual(a: unknown, b: unknown): boolean {
-  return areEqual(a, b);
+  return fastDeepEqual(a, b);
 }
 
 /* eslint-disable padding-line-between-statements */

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
-    "@types/classnames": "^2.3.1",
     "@vertexvis/frame-streaming-protos": "^0.13.16",
     "@vertexvis/geometry": "0.23.1",
     "@vertexvis/html-templates": "0.23.1",
@@ -64,6 +63,7 @@
     "fast-png": "^6.1.0",
     "google-protobuf": "3.19.4",
     "jwt-decode": "^3.1.2",
+    "long": "^5.3.1",
     "param-case": "^3.0.4",
     "protobufjs": "^7.2.4",
     "regl": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,13 +1949,6 @@
   resolved "https://registry.yarnpkg.com/@types/chance/-/chance-1.1.3.tgz#d19fe9391288d60fdccd87632bfc9ab2b4523fea"
   integrity sha512-X6c6ghhe4/sQh4XzcZWSFaTAUOda38GQHmq9BUanYkOE/EO7ZrkazwKmtsj3xzTjkLWmwULE++23g3d3CCWaWw==
 
-"@types/classnames@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.3.1.tgz#3c2467aa0f1a93f1f021e3b9bcf938bd5dfdc0dd"
-  integrity sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==
-  dependencies:
-    classnames "*"
-
 "@types/estree@*":
   version "0.0.46"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
@@ -2016,23 +2009,6 @@
   integrity sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==
   dependencies:
     "@types/node" "*"
-
-"@types/lodash.isequal@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz#ff42a1b8e20caa59a97e446a77dc57db923bc02b"
-  integrity sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.171"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.171.tgz#f01b3a5fe3499e34b622c362a46a609fdb23573b"
-  integrity sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==
-
-"@types/long@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
-  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
 "@types/minimatch@^3.0.3":
   version "3.0.3"
@@ -3035,7 +3011,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@*, classnames@^2.3.1:
+classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -5920,11 +5896,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
@@ -5965,15 +5936,15 @@ lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
 long@^5.0.0:
   version "5.2.3"
   resolved "https://registry.npmjs.org/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
+
+long@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.1.tgz#9d4222d3213f38a5ec809674834e0f0ab21abe96"
+  integrity sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -7143,25 +7114,6 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
-
-protobufjs@^6.9.0:
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
-  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
-    "@types/node" ">=13.7.0"
-    long "^4.0.0"
 
 protobufjs@^7.2.4:
   version "7.2.4"


### PR DESCRIPTION
## Summary

Follow up from #649 to fix a couple other dependency related issues:
* The `protobufjs` peer dependency range for `@vertexvis/stream-api` has been updated to `<8.0.0`
  * The viewer already installs `7.2.4`, which it has been compatible with for some time
* The `@types/classnames` dependency has been removed as it is deprecated and unnecessary
* The `long` package has been added as a viewer dependency
  * This was previously being pulled in by an outdated version of `protobufjs`, and required for parsing the `Long` metadata type
* The `lodash.isequal` dependency has been removed in favor of `fast-deep-equal` as it was deprecated

## Test Plan

- Once released, verify the package.json dependencies specified in [PLAT-6059](https://vertexvis.atlassian.net/jira/software/c/projects/PLAT/boards/112?selectedIssue=PLAT-6059) no longer produces peer dependency or deprecation warnings

## Release Notes

N/A

## Possible Regressions

* Object deep equals functionality - nothing specific expected here, but this behavior was modified
* Stream API interaction - nothing specific expected here either, as this was relying on the viewer installation anyway

## Dependencies

N/A


[PLAT-6059]: https://vertexvis.atlassian.net/browse/PLAT-6059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ