### PR TITLE
[PLAT-5800] Support camera type overrides

### DIFF
--- a/packages/stream-api/package.json
+++ b/packages/stream-api/package.json
@@ -36,7 +36,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@vertexvis/frame-streaming-protos": "^0.13.16"
+    "@vertexvis/frame-streaming-protos": "^0.13.17"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/utils/src/mapper.ts
+++ b/packages/utils/src/mapper.ts
@@ -247,7 +247,7 @@ export function isInvalid(obj: unknown): obj is Invalid {
 }
 
 /**
- * Returns a function that throws an error if the input is invalid. Otherwise
+ * Returns a function that throws an error if the input is invalid. Otherwise,
  * returns the result.
  *
  * @param mapper A mapper that will be invoked with the input.

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.15.0",
     "@stencil/core": "^2.16.1",
-    "@vertexvis/frame-streaming-protos": "^0.13.16",
+    "@vertexvis/frame-streaming-protos": "^0.13.17",
     "@vertexvis/geometry": "0.23.2",
     "@vertexvis/html-templates": "0.23.2",
     "@vertexvis/scene-tree-protos": "^0.1.21",

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -586,8 +586,12 @@ export namespace Components {
     /**
      * Loads the given scene into the viewer and return a `Promise` that resolves when the scene has been loaded. The specified scene is provided as a URN in the following format:   * `urn:vertex:scene:<sceneid>`
      * @param urn The URN of the resource to load.
+     * @param cameraType (Optional) The camera type to load. If not included, the default camera type for the resource will be used.
      */
-    load: (urn: string) => Promise<void>;
+    load: (
+      urn: string,
+      cameraType?: FrameCameraType | undefined
+    ) => Promise<void>;
     /**
      * The controller for accessing model views associated with the scene view.
      * @readonly

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -56,7 +56,7 @@ import {
 import { ModelViewController } from './lib/model-views/controller';
 import { PmiController } from './lib/pmi';
 import { TapEventDetails } from './lib/interactions/tapEventDetails';
-import { ConnectionStatus } from './components/viewer/viewer';
+import { ConnectionStatus, LoadOptions } from './components/viewer/viewer';
 import {
   Dimensions,
   Euler,
@@ -586,12 +586,9 @@ export namespace Components {
     /**
      * Loads the given scene into the viewer and return a `Promise` that resolves when the scene has been loaded. The specified scene is provided as a URN in the following format:   * `urn:vertex:scene:<sceneid>`
      * @param urn The URN of the resource to load.
-     * @param cameraType (Optional) The camera type to load. If not included, the default camera type for the resource will be used.
+     * @param options Optional configurations when loading the scene. cameraType (Optional) The camera type to load. If not included, the default camera type for the resource will be used.
      */
-    load: (
-      urn: string,
-      cameraType?: FrameCameraType | undefined
-    ) => Promise<void>;
+    load: (urn: string, options?: LoadOptions | undefined) => Promise<void>;
     /**
      * The controller for accessing model views associated with the scene view.
      * @readonly

--- a/packages/viewer/src/components/viewer-transform-widget/readme.md
+++ b/packages/viewer/src/components/viewer-transform-widget/readme.md
@@ -68,6 +68,7 @@ The widget expects a part selected, which also occurs on a valid hit result.
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
 | Property                       | Attribute                                  | Description                                                                                                                                                  | Type                                                                          | Default         |
@@ -88,6 +89,7 @@ The widget expects a part selected, which also occurs on a valid hit result.
 | `zRotationDisabled`            | `z-rotation-disabled`                      | Determines whether or not the z-rotation is disabled on the widget                                                                                           | `boolean`                                                                     | `false`         |
 | `zTranslationDisabled`         | `z-translation-disabled`                   | Determines whether or not the z-translation is disabled on the widget                                                                                        | `boolean`                                                                     | `false`         |
 
+
 ## Events
 
 | Event                | Description                                                         | Type                                                                                                                                                         |
@@ -96,6 +98,7 @@ The widget expects a part selected, which also occurs on a valid hit result.
 | `interactionStarted` | An event that is emitted an interaction with the widget has started | `CustomEvent<void>`                                                                                                                                          |
 | `positionChanged`    | An event that is emitted when the position of the widget changes.   | `CustomEvent<Vector3 \| undefined>`                                                                                                                          |
 | `rotationChanged`    | An event that is emitted when the rotation of the widget changes.   | `CustomEvent<Euler \| undefined>`                                                                                                                            |
+
 
 ## Methods
 
@@ -115,6 +118,9 @@ the history is lost.
 
 Type: `Promise<void>`
 
+
+
+
 ## CSS Custom Properties
 
 | Name                                            | Description                                                                               |
@@ -124,6 +130,7 @@ Type: `Promise<void>`
 | `--viewer-transform-widget-x-axis-arrow-color`  | A CSS color for the arrow at the end of the X axis on this widget. Defaults to `#ea3324`. |
 | `--viewer-transform-widget-y-axis-arrow-color`  | A CSS color for the arrow at the end of the Y axis on this widget. Defaults to `#4faf32`. |
 | `--viewer-transform-widget-z-axis-arrow-color`  | A CSS color for the arrow at the end of the Z axis on this widget. Defaults to `#0000ff`. |
+
 
 ----------------------------------------------
 

--- a/packages/viewer/src/components/viewer/readme.md
+++ b/packages/viewer/src/components/viewer/readme.md
@@ -112,7 +112,7 @@ Type: `Promise<boolean>`
 
 
 
-### `load(urn: string) => Promise<void>`
+### `load(urn: string, cameraType?: FrameCamera.FrameCameraType | undefined) => Promise<void>`
 
 Loads the given scene into the viewer and return a `Promise` that
 resolves when the scene has been loaded. The specified scene is

--- a/packages/viewer/src/components/viewer/readme.md
+++ b/packages/viewer/src/components/viewer/readme.md
@@ -112,7 +112,7 @@ Type: `Promise<boolean>`
 
 
 
-### `load(urn: string, cameraType?: FrameCamera.FrameCameraType | undefined) => Promise<void>`
+### `load(urn: string, options?: LoadOptions | undefined) => Promise<void>`
 
 Loads the given scene into the viewer and return a `Promise` that
 resolves when the scene has been loaded. The specified scene is

--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -416,7 +416,8 @@ describe('vertex-viewer', () => {
         expect.anything(),
         expect.anything(),
         deviceId,
-        expect.anything()
+        expect.anything(),
+        undefined
       );
     });
 
@@ -438,7 +439,8 @@ describe('vertex-viewer', () => {
         expect.anything(),
         expect.anything(),
         viewer.deviceId,
-        expect.anything()
+        expect.anything(),
+        undefined
       );
     });
   });

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -546,7 +546,7 @@ export class Viewer {
     }
 
     if (this.src != null) {
-      this.load(this.src).catch((e) => {
+      this.load(this.src, this.cameraType).catch((e) => {
         console.error('Error loading scene', e);
       });
     }
@@ -768,7 +768,7 @@ export class Viewer {
   @Watch('src')
   public handleSrcChanged(src: string | undefined): void {
     if (src != null) {
-      this.load(src);
+      this.load(src, this.cameraType);
     } else {
       this.unload();
     }
@@ -861,9 +861,10 @@ export class Viewer {
    *  * `urn:vertex:scene:<sceneid>`
    *
    * @param urn The URN of the resource to load.
+   * @param cameraType (Optional) The camera type to load. If not included, the default camera type for the resource will be used.
    */
   @Method()
-  public async load(urn: string): Promise<void> {
+  public async load(urn: string, cameraType?: FrameCameraType): Promise<void> {
     if (this.stream != null && this.dimensions != null) {
       const { EXPERIMENTAL_annotationPollingIntervalInMs } =
         this.getResolvedConfig();
@@ -880,7 +881,8 @@ export class Viewer {
         urn,
         this.clientId,
         this.getDeviceId(),
-        this.getResolvedConfig()
+        this.getResolvedConfig(),
+        cameraType
       );
       this.sceneReady.emit();
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -112,6 +112,10 @@ interface ConnectionFailedStatus {
   errorMessage: string;
 }
 
+export interface LoadOptions {
+  cameraType?: FrameCameraType;
+}
+
 /**
  * Internal state values for the component. Used to preserve values across live
  * reload refreshes.
@@ -546,7 +550,7 @@ export class Viewer {
     }
 
     if (this.src != null) {
-      this.load(this.src, this.cameraType).catch((e) => {
+      this.load(this.src, { cameraType: this.cameraType }).catch((e) => {
         console.error('Error loading scene', e);
       });
     }
@@ -768,7 +772,7 @@ export class Viewer {
   @Watch('src')
   public handleSrcChanged(src: string | undefined): void {
     if (src != null) {
-      this.load(src, this.cameraType);
+      this.load(src, { cameraType: this.cameraType });
     } else {
       this.unload();
     }
@@ -861,10 +865,11 @@ export class Viewer {
    *  * `urn:vertex:scene:<sceneid>`
    *
    * @param urn The URN of the resource to load.
-   * @param cameraType (Optional) The camera type to load. If not included, the default camera type for the resource will be used.
+   * @param options Optional configurations when loading the scene.
+   *    cameraType (Optional) The camera type to load. If not included, the default camera type for the resource will be used.
    */
   @Method()
-  public async load(urn: string, cameraType?: FrameCameraType): Promise<void> {
+  public async load(urn: string, options?: LoadOptions): Promise<void> {
     if (this.stream != null && this.dimensions != null) {
       const { EXPERIMENTAL_annotationPollingIntervalInMs } =
         this.getResolvedConfig();
@@ -882,7 +887,7 @@ export class Viewer {
         this.clientId,
         this.getDeviceId(),
         this.getResolvedConfig(),
-        cameraType
+        options?.cameraType
       );
       this.sceneReady.emit();
 

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -55,7 +55,7 @@ import { PointerInteractionHandler } from '../../lib/interactions/pointerInterac
 import { TapEventDetails } from '../../lib/interactions/tapEventDetails';
 import { TapInteractionHandler } from '../../lib/interactions/tapInteractionHandler';
 import { TouchInteractionHandler } from '../../lib/interactions/touchInteractionHandler';
-import { fromPbFrameOrThrow } from '../../lib/mappers';
+import { fromPbFrameOrThrow, toPbCameraTypeOrThrow } from '../../lib/mappers';
 import { paintTime, Timing } from '../../lib/meters';
 import { ModelViewController } from '../../lib/model-views/controller';
 import { PmiController } from '../../lib/pmi';
@@ -1412,12 +1412,15 @@ export class Viewer {
   private async createScene(): Promise<Scene> {
     const state = await this.waitForConnectedState();
 
+    const cameraTypeMapper = toPbCameraTypeOrThrow();
+
     const { frame, sceneId, sceneViewId, worldOrientation } = state;
 
     return new Scene(
       this.getStream(),
       frame,
       fromPbFrameOrThrow(worldOrientation),
+      cameraTypeMapper,
       () => this.getImageScale(),
       this.viewport,
       sceneId,

--- a/packages/viewer/src/interfaces.d.ts
+++ b/packages/viewer/src/interfaces.d.ts
@@ -5,6 +5,8 @@ export type Color3 = Omit<Color.Color, 'a'> | string | number;
 
 export type FrameType = 'final' | 'all' | undefined;
 
+export type CameraType = 'perspective' | 'orthographic' | undefined;
+
 export interface FeatureLineOptions {
   width: number;
   color?: Color3;

--- a/packages/viewer/src/lib/interactions/__tests__/interactionApi.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/interactionApi.spec.ts
@@ -12,7 +12,7 @@ import {
   makePerspectiveFrame,
 } from '../../../testing/fixtures';
 import { CursorManager } from '../../cursors';
-import { fromPbFrameOrThrow } from '../../mappers';
+import { fromPbFrameOrThrow, toPbCameraTypeOrThrow } from '../../mappers';
 import { Scene } from '../../scenes';
 import { Interactions, Orientation, Viewport } from '../../types';
 import { Frame } from '../../types/frame';
@@ -36,10 +36,13 @@ describe(InteractionApi, () => {
   const sceneId = random.guid();
   const sceneViewId = random.guid();
   const frame = makePerspectiveFrame();
+  const cameraTypeMapper = toPbCameraTypeOrThrow();
+
   const scene = new Scene(
     streamApi,
     frame,
     fromPbFrameOrThrow(Orientation.DEFAULT),
+    cameraTypeMapper,
     () => Point.create(1, 1),
     Dimensions.create(50, 50),
     sceneId,
@@ -272,6 +275,7 @@ describe(InteractionApi, () => {
             streamApi,
             closeFrameX,
             fromPbFrameOrThrow(Orientation.DEFAULT),
+            cameraTypeMapper,
             () => Point.create(1, 1),
             Dimensions.create(50, 50),
             sceneId,
@@ -294,6 +298,7 @@ describe(InteractionApi, () => {
             streamApi,
             closeFrameY,
             fromPbFrameOrThrow(Orientation.DEFAULT),
+            cameraTypeMapper,
             () => Point.create(1, 1),
             Dimensions.create(50, 50),
             sceneId,
@@ -316,6 +321,7 @@ describe(InteractionApi, () => {
             streamApi,
             closeFrameZ,
             fromPbFrameOrThrow(Orientation.DEFAULT),
+            cameraTypeMapper,
             () => Point.create(1, 1),
             Dimensions.create(50, 50),
             sceneId,

--- a/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/interactionApiOrthographic.spec.ts
@@ -14,9 +14,8 @@ import { StreamApi } from '@vertexvis/stream-api';
 import { random } from '../../../testing';
 import { makeOrthographicFrame } from '../../../testing/fixtures';
 import { CursorManager } from '../../cursors';
-import { fromPbFrameOrThrow } from '../../mappers';
+import { fromPbFrameOrThrow, toPbCameraTypeOrThrow } from '../../mappers';
 import { OrthographicCamera, Scene } from '../../scenes';
-import * as ColorMaterial from '../../scenes/colorMaterial';
 import {
   DepthBuffer,
   FrameCamera,
@@ -40,15 +39,17 @@ describe(InteractionApiOrthographic, () => {
   const sceneViewId = random.guid();
   const frame = makeOrthographicFrame();
   const viewport = new Viewport(100, 100);
+  const cameraTypeMapper = toPbCameraTypeOrThrow();
+
   const scene = new Scene(
     streamApi,
     frame,
     fromPbFrameOrThrow(Orientation.DEFAULT),
+    cameraTypeMapper,
     () => Point.create(1, 1),
     Dimensions.create(50, 50),
     sceneId,
-    sceneViewId,
-    ColorMaterial.fromHex('#ffffff')
+    sceneViewId
   );
   const frameProvider = (): Frame | undefined => frame;
   const sceneProvider = (): Scene => scene;

--- a/packages/viewer/src/lib/mappers/camera.ts
+++ b/packages/viewer/src/lib/mappers/camera.ts
@@ -1,0 +1,30 @@
+import { vertexvis } from '@vertexvis/frame-streaming-protos';
+import { Mapper as M } from '@vertexvis/utils';
+
+import { CameraType } from '../../interfaces';
+
+export const toPbCameraType: M.Func<
+  CameraType,
+  vertexvis.protobuf.stream.CameraType
+> = M.defineMapper(
+  (cameraType) => {
+    switch (cameraType) {
+      case 'perspective':
+        return vertexvis.protobuf.stream.CameraType.CAMERA_TYPE_PERSPECTIVE;
+      case 'orthographic':
+        return vertexvis.protobuf.stream.CameraType.CAMERA_TYPE_ORTHOGRAPHIC;
+      default:
+        return vertexvis.protobuf.stream.CameraType.CAMERA_TYPE_INVALID;
+    }
+  },
+  (cameraType) => cameraType
+);
+
+export type CameraTypeEncoder = M.ThrowIfInvalidFunc<
+  CameraType,
+  vertexvis.protobuf.stream.CameraType
+>;
+
+export function toPbCameraTypeOrThrow(): CameraTypeEncoder {
+  return M.ifInvalidThrow(toPbCameraType);
+}

--- a/packages/viewer/src/lib/mappers/index.ts
+++ b/packages/viewer/src/lib/mappers/index.ts
@@ -1,3 +1,4 @@
+export * from './camera';
 export * from './corePb';
 export * from './corePbJs';
 export * from './frameStreaming';

--- a/packages/viewer/src/lib/scenes/__tests__/sceneViewStateLoader.spec.ts
+++ b/packages/viewer/src/lib/scenes/__tests__/sceneViewStateLoader.spec.ts
@@ -4,7 +4,7 @@ import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { StreamApi } from '@vertexvis/stream-api';
 
 import { random } from '../../../testing';
-import { fromPbFrameOrThrow } from '../../mappers';
+import { fromPbFrameOrThrow, toPbCameraTypeOrThrow } from '../../mappers';
 import { Orientation } from '../../types';
 import { SceneViewStateLoader } from '../sceneViewStateLoader';
 
@@ -12,9 +12,12 @@ describe('SceneViewStateLoader', () => {
   const sceneId = random.guid();
   const sceneViewId = random.guid();
   const streamApi = new StreamApi();
+  const cameraTypeMapper = toPbCameraTypeOrThrow();
+
   const loader = new SceneViewStateLoader(
     streamApi,
     fromPbFrameOrThrow(Orientation.DEFAULT),
+    cameraTypeMapper,
     sceneId,
     sceneViewId
   );

--- a/packages/viewer/src/lib/scenes/camera.ts
+++ b/packages/viewer/src/lib/scenes/camera.ts
@@ -101,7 +101,7 @@ export interface FlyToParams {
  * It also provides utility methods to update orientation of the camera and
  * rerender the scene.
  *
- * This class in intended to treated as an immutable type. Any mutations return
+ * This class in intended to be treated as an immutable type. Any mutations return
  * a new instance of the class with the updated properties.
  */
 export abstract class Camera {

--- a/packages/viewer/src/lib/scenes/scene.ts
+++ b/packages/viewer/src/lib/scenes/scene.ts
@@ -3,8 +3,9 @@ import { BoundingBox, Dimensions, Point } from '@vertexvis/geometry';
 import { StreamApi } from '@vertexvis/stream-api';
 import { UUID } from '@vertexvis/utils';
 
+import { CameraType } from '../../interfaces';
 import { InvalidArgumentError, InvalidCameraError } from '../errors';
-import { FrameDecoder } from '../mappers';
+import { CameraTypeEncoder, FrameDecoder } from '../mappers';
 import { SceneViewStateIdentifier } from '../types';
 import { Frame } from '../types/frame';
 import {
@@ -61,10 +62,12 @@ export interface ApplySceneViewStateOptions
   extends SceneElementsExecutionOptions,
     CameraRenderOptions {
   waitForAnimation?: boolean;
+  cameraTypeOverride?: CameraType;
 }
 
 export interface ResetViewOptions {
   includeCamera?: boolean;
+  cameraTypeOverride?: CameraType;
   suppliedCorrelationId?: string;
 }
 
@@ -858,6 +861,7 @@ export class Scene {
     private stream: StreamApi,
     private frame: Frame,
     private decodeFrame: FrameDecoder,
+    private encodeCameraType: CameraTypeEncoder,
     private imageScaleProvider: ImageScaleProvider,
     private dimensions: Dimensions.Dimensions,
     public readonly sceneId: UUID.UUID,
@@ -866,6 +870,7 @@ export class Scene {
     this.sceneViewStateLoader = new SceneViewStateLoader(
       stream,
       decodeFrame,
+      encodeCameraType,
       sceneId,
       sceneViewId
     );
@@ -914,6 +919,9 @@ export class Scene {
         includeCamera: opts.includeCamera,
         frameCorrelationId: opts.suppliedCorrelationId
           ? { value: opts.suppliedCorrelationId }
+          : undefined,
+        cameraType: opts.cameraTypeOverride
+          ? this.encodeCameraType(opts.cameraTypeOverride)
           : undefined,
       },
       true

--- a/packages/viewer/src/lib/scenes/sceneViewStateLoader.ts
+++ b/packages/viewer/src/lib/scenes/sceneViewStateLoader.ts
@@ -2,7 +2,7 @@ import { vertexvis } from '@vertexvis/frame-streaming-protos';
 import { StreamApi, toProtoDuration } from '@vertexvis/stream-api';
 import { UUID } from '@vertexvis/utils';
 
-import { FrameDecoder } from '../mappers';
+import { CameraTypeEncoder, FrameDecoder } from '../mappers';
 import { DEFAULT_TIMEOUT_IN_MS } from '../stream/dispatcher';
 import { SceneViewStateIdentifier } from '../types';
 import { ApplySceneViewStateOptions, SceneViewStateFeature } from '.';
@@ -16,6 +16,7 @@ export class SceneViewStateLoader {
   public constructor(
     private stream: StreamApi,
     private decodeFrame: FrameDecoder,
+    private encodeCameraType: CameraTypeEncoder,
     public readonly sceneId: UUID.UUID,
     public readonly sceneViewId: UUID.UUID
   ) {}
@@ -35,6 +36,9 @@ export class SceneViewStateLoader {
         ...pbIdField,
         frameCorrelationId: opts.suppliedCorrelationId
           ? { value: opts.suppliedCorrelationId }
+          : undefined,
+        cameraType: opts.cameraTypeOverride
+          ? this.encodeCameraType(opts.cameraTypeOverride)
           : undefined,
       },
       true
@@ -62,6 +66,9 @@ export class SceneViewStateLoader {
           ? { value: opts.suppliedCorrelationId }
           : undefined,
         sceneViewStateFeatureSubset: pbFeatures,
+        cameraType: opts.cameraTypeOverride
+          ? this.encodeCameraType(opts.cameraTypeOverride)
+          : undefined,
       },
       true
     );

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -32,6 +32,7 @@ import {
   fromPbRefreshTokenResponseOrThrow,
   fromPbStartStreamResponseOrThrow,
   fromPbSyncTimeResponseOrThrow,
+  toPbCameraType,
   toPbRGBi,
   toPbStreamAttributes,
 } from '../mappers';
@@ -43,7 +44,11 @@ import {
   Orientation,
   SynchronizedClock,
 } from '../types';
-import { Resource, SuppliedIdQueryValue } from '../types/loadableResource';
+import {
+  CameraTypeQueryValue,
+  Resource,
+  SuppliedIdQueryValue,
+} from '../types/loadableResource';
 import {
   Connected,
   Connecting,
@@ -425,6 +430,9 @@ export class ViewerStream extends StreamApi {
     const suppliedIdQuery = resource.queries.find(
       (q) => q.type === 'supplied-id'
     ) as SuppliedIdQueryValue | undefined;
+    const cameraTypeQuery = resource.queries.find(
+      (q) => q.type === 'camera-type'
+    ) as CameraTypeQueryValue | undefined;
 
     const res = fromPbStartStreamResponseOrThrow(
       await this.startStream({
@@ -442,6 +450,10 @@ export class ViewerStream extends StreamApi {
           resource.subResource?.type === 'scene-view-state' &&
           suppliedIdQuery != null
             ? { value: suppliedIdQuery.id }
+            : undefined,
+        cameraType:
+          cameraTypeQuery != null
+            ? toPbCameraTypeOrThrow(cameraTypeQuery.camera)
             : undefined,
       })
     );
@@ -651,6 +663,7 @@ export class ViewerStream extends StreamApi {
 
 const toPbStreamAttributesOrThrow = Mapper.ifInvalidThrow(toPbStreamAttributes);
 const toPbColorOrThrow = Mapper.ifInvalidThrow(toPbRGBi);
+const toPbCameraTypeOrThrow = Mapper.ifInvalidThrow(toPbCameraType);
 
 function getStreamSettings(config: Config): Settings {
   return {

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -45,7 +45,7 @@ import {
   SynchronizedClock,
 } from '../types';
 import {
-  CameraTypeQueryValue,
+  LoadCameraTypeQueryValue,
   Resource,
   SuppliedIdQueryValue,
 } from '../types/loadableResource';
@@ -225,9 +225,6 @@ export class ViewerStream extends StreamApi {
     const isConnecting =
       state.type === 'connecting' || state.type === 'reconnecting';
     const isConnected = state.type === 'connected';
-    const suppliedIdQuery = resource.queries.find(
-      (q) => q.type === 'supplied-id'
-    ) as SuppliedIdQueryValue | undefined;
 
     if (hasResourceChanged || (isConnecting && hasSubResourceChanged)) {
       this.disconnect();
@@ -237,12 +234,22 @@ export class ViewerStream extends StreamApi {
       hasSubResourceChanged &&
       resource.subResource?.type === 'scene-view-state'
     ) {
+      const suppliedIdQuery = resource.queries.find(
+        (q) => q.type === 'supplied-id'
+      ) as SuppliedIdQueryValue | undefined;
+      const cameraTypeQuery = resource.queries.find(
+        (q) => q.type === 'load-camera-type'
+      ) as LoadCameraTypeQueryValue | undefined;
+
       const payload = {
         ...(resource.subResource.id != null
           ? { sceneViewStateId: { hex: resource.subResource.id } }
           : {}),
         ...(suppliedIdQuery != null
           ? { sceneViewStateSuppliedId: { value: suppliedIdQuery.id } }
+          : {}),
+        ...(cameraTypeQuery != null
+          ? { cameraType: toPbCameraTypeOrThrow(cameraTypeQuery.cameraType) }
           : {}),
       };
 
@@ -431,8 +438,8 @@ export class ViewerStream extends StreamApi {
       (q) => q.type === 'supplied-id'
     ) as SuppliedIdQueryValue | undefined;
     const cameraTypeQuery = resource.queries.find(
-      (q) => q.type === 'camera-type'
-    ) as CameraTypeQueryValue | undefined;
+      (q) => q.type === 'load-camera-type'
+    ) as LoadCameraTypeQueryValue | undefined;
 
     const res = fromPbStartStreamResponseOrThrow(
       await this.startStream({
@@ -453,7 +460,7 @@ export class ViewerStream extends StreamApi {
             : undefined,
         cameraType:
           cameraTypeQuery != null
-            ? toPbCameraTypeOrThrow(cameraTypeQuery.camera)
+            ? toPbCameraTypeOrThrow(cameraTypeQuery.cameraType)
             : undefined,
       })
     );

--- a/packages/viewer/src/lib/types/__tests__/loadableResource.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/loadableResource.spec.ts
@@ -53,13 +53,13 @@ describe(LoadableResource.fromUrn, () => {
 
   it('parses a camera type override for a URN', () => {
     const urn =
-      'urn:vertex:stream-key:123?scene-view-state=234&camera-type=orthographic';
+      'urn:vertex:stream-key:123?scene-view-state=234&load-camera-type=orthographic';
     const { resource, subResource, queries } = LoadableResource.fromUrn(urn);
     expect(resource).toEqual({ type: 'stream-key', id: '123' });
     expect(subResource).toEqual({ type: 'scene-view-state', id: '234' });
     expect(queries![0]).toEqual({
-      type: 'camera-type',
-      camera: 'orthographic',
+      type: 'load-camera-type',
+      cameraType: 'orthographic',
     });
   });
 });

--- a/packages/viewer/src/lib/types/__tests__/loadableResource.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/loadableResource.spec.ts
@@ -50,16 +50,4 @@ describe(LoadableResource.fromUrn, () => {
     expect(queries![1]).toEqual({ type: 'supplied-id', id: '345' });
     expect(queries![2]).toEqual({ type: 'supplied-id', id: '456' });
   });
-
-  it('parses a camera type override for a URN', () => {
-    const urn =
-      'urn:vertex:stream-key:123?scene-view-state=234&load-camera-type=orthographic';
-    const { resource, subResource, queries } = LoadableResource.fromUrn(urn);
-    expect(resource).toEqual({ type: 'stream-key', id: '123' });
-    expect(subResource).toEqual({ type: 'scene-view-state', id: '234' });
-    expect(queries![0]).toEqual({
-      type: 'load-camera-type',
-      cameraType: 'orthographic',
-    });
-  });
 });

--- a/packages/viewer/src/lib/types/__tests__/loadableResource.spec.ts
+++ b/packages/viewer/src/lib/types/__tests__/loadableResource.spec.ts
@@ -50,4 +50,16 @@ describe(LoadableResource.fromUrn, () => {
     expect(queries![1]).toEqual({ type: 'supplied-id', id: '345' });
     expect(queries![2]).toEqual({ type: 'supplied-id', id: '456' });
   });
+
+  it('parses a camera type override for a URN', () => {
+    const urn =
+      'urn:vertex:stream-key:123?scene-view-state=234&camera-type=orthographic';
+    const { resource, subResource, queries } = LoadableResource.fromUrn(urn);
+    expect(resource).toEqual({ type: 'stream-key', id: '123' });
+    expect(subResource).toEqual({ type: 'scene-view-state', id: '234' });
+    expect(queries![0]).toEqual({
+      type: 'camera-type',
+      camera: 'orthographic',
+    });
+  });
 });

--- a/packages/viewer/src/lib/types/loadableResource.ts
+++ b/packages/viewer/src/lib/types/loadableResource.ts
@@ -1,6 +1,5 @@
 import { Uri } from '@vertexvis/utils';
 
-import { CameraType } from '../../interfaces';
 import { InvalidResourceUrnError } from '../errors';
 
 interface StreamKeyResource {
@@ -85,15 +84,7 @@ export interface SuppliedIdQueryValue {
   id: string;
 }
 
-export interface LoadCameraTypeQueryValue {
-  type: 'load-camera-type';
-  cameraType: CameraType;
-}
-
-export type QueryValue =
-  | SceneViewStateResource
-  | SuppliedIdQueryValue
-  | LoadCameraTypeQueryValue;
+export type QueryValue = SceneViewStateResource | SuppliedIdQueryValue;
 
 function fromQuery(query?: string): QueryValue[] {
   if (query != null) {
@@ -105,11 +96,6 @@ function fromQuery(query?: string): QueryValue[] {
           return { type: 'supplied-id', id: resourceId };
         case 'scene-view-state':
           return { type: 'scene-view-state', id: resourceId };
-        case 'load-camera-type':
-          return {
-            type: 'load-camera-type',
-            cameraType: resourceId as CameraType,
-          };
         default:
           throw new Error('Invalid URN. Unknown query value type');
       }

--- a/packages/viewer/src/lib/types/loadableResource.ts
+++ b/packages/viewer/src/lib/types/loadableResource.ts
@@ -85,15 +85,15 @@ export interface SuppliedIdQueryValue {
   id: string;
 }
 
-export interface CameraTypeQueryValue {
-  type: 'camera-type';
-  camera: CameraType;
+export interface LoadCameraTypeQueryValue {
+  type: 'load-camera-type';
+  cameraType: CameraType;
 }
 
 export type QueryValue =
   | SceneViewStateResource
   | SuppliedIdQueryValue
-  | CameraTypeQueryValue;
+  | LoadCameraTypeQueryValue;
 
 function fromQuery(query?: string): QueryValue[] {
   if (query != null) {
@@ -105,8 +105,11 @@ function fromQuery(query?: string): QueryValue[] {
           return { type: 'supplied-id', id: resourceId };
         case 'scene-view-state':
           return { type: 'scene-view-state', id: resourceId };
-        case 'camera-type':
-          return { type: 'camera-type', camera: resourceId as CameraType };
+        case 'load-camera-type':
+          return {
+            type: 'load-camera-type',
+            cameraType: resourceId as CameraType,
+          };
         default:
           throw new Error('Invalid URN. Unknown query value type');
       }

--- a/packages/viewer/src/lib/types/loadableResource.ts
+++ b/packages/viewer/src/lib/types/loadableResource.ts
@@ -1,5 +1,6 @@
 import { Uri } from '@vertexvis/utils';
 
+import { CameraType } from '../../interfaces';
 import { InvalidResourceUrnError } from '../errors';
 
 interface StreamKeyResource {
@@ -84,7 +85,15 @@ export interface SuppliedIdQueryValue {
   id: string;
 }
 
-export type QueryValue = SceneViewStateResource | SuppliedIdQueryValue;
+export interface CameraTypeQueryValue {
+  type: 'camera-type';
+  camera: CameraType;
+}
+
+export type QueryValue =
+  | SceneViewStateResource
+  | SuppliedIdQueryValue
+  | CameraTypeQueryValue;
 
 function fromQuery(query?: string): QueryValue[] {
   if (query != null) {
@@ -96,6 +105,8 @@ function fromQuery(query?: string): QueryValue[] {
           return { type: 'supplied-id', id: resourceId };
         case 'scene-view-state':
           return { type: 'scene-view-state', id: resourceId };
+        case 'camera-type':
+          return { type: 'camera-type', camera: resourceId as CameraType };
         default:
           throw new Error('Invalid URN. Unknown query value type');
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,10 +2219,10 @@
     eslint-plugin-simple-import-sort "^7.0.0"
     prettier "^2.5.1"
 
-"@vertexvis/frame-streaming-protos@^0.13.16":
-  version "0.13.16"
-  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.16.tgz#daeef727022647d72146c9c04c00e667c9a76e21"
-  integrity sha512-7PhFKSshsAo/On7k5ONBSMcPqfp+v7I+aeNm8qAgnDIk6UwVqwQyt/EiX3IH1R0JjlXiiRlYnFa6R+/+eoVg4w==
+"@vertexvis/frame-streaming-protos@^0.13.17":
+  version "0.13.17"
+  resolved "https://registry.yarnpkg.com/@vertexvis/frame-streaming-protos/-/frame-streaming-protos-0.13.17.tgz#dbff59465f3bb25233009613ec3dde866a742e14"
+  integrity sha512-nzSik+N1yAVDmNMFbplEmZq+QWJYxFk3/aROL4559ivAa8PN1KBqjnjmAqt4R3lPm8ipZ/svVw53Xo0a1QySGw==
 
 "@vertexvis/jest-config-vertexvis@^0.5.4":
   version "0.5.4"


### PR DESCRIPTION
## Summary
This PR adds support for optionally including a camera type override when starting a stream, applying a scene view, or resetting a scene. When the camera type override is included, the desired camera will be converted to the desired type before being applied to the scene.

## Test Plan
Verify a user can include a camera type override when starting a stream, applying a scene view, or resetting a scene 

## Release Notes
Ability to include a camera type override when starting a stream, applying a scene view, or resetting a scene

## Possible Regressions
Loading and resetting views

## Dependencies
Changes in FSS and SS
