### PR TITLE
[PLAT-5942] Network config validation

### DIFF
--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -19,7 +19,13 @@ import { Node } from '@vertexvis/scene-tree-protos/scenetree/protos/domain_pb';
 import { SceneTreeAPIClient } from '@vertexvis/scene-tree-protos/scenetree/protos/scene_tree_api_pb_service';
 import { Disposable } from '@vertexvis/utils';
 
-import { Config, parseConfig, PartialConfig } from '../../lib/config';
+import {
+  Config,
+  parseAndValidateConfig,
+  PartialConfig,
+  sanitizeConfig,
+  validateConfig,
+} from '../../lib/config';
 import { Environment } from '../../lib/environment';
 import { isSceneTreeTableCellElement } from '../scene-tree-table-cell/utils';
 import { SceneTreeError } from './errors';
@@ -972,7 +978,9 @@ export class SceneTree {
   }
 
   private getConfig(): Config {
-    return parseConfig(this.configEnv, this.config);
+    const parsedConfig = parseAndValidateConfig(this.configEnv, this.config);
+
+    return validateConfig(sanitizeConfig(parsedConfig));
   }
 
   private ensureLayoutDefined(): void {

--- a/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx
+++ b/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx
@@ -3,7 +3,7 @@ import { Component, h, Host, Prop, State, Watch } from '@stencil/core';
 import { SceneViewAPIClient } from '@vertexvis/scene-view-protos/sceneview/protos/scene_view_api_pb_service';
 import { Disposable } from '@vertexvis/utils';
 
-import { parseConfig, PartialConfig } from '../../lib/config';
+import { parseAndValidateConfig, PartialConfig } from '../../lib/config';
 import { Environment } from '../../lib/environment';
 import {
   MeasurementController,
@@ -143,7 +143,7 @@ export class ViewerMeasurementPrecise {
   }
 
   private setupController(): void {
-    const config = parseConfig(this.configEnv, this.config);
+    const config = parseAndValidateConfig(this.configEnv, this.config);
     const client = new SceneViewAPIClient(config.network.sceneViewHost);
     this.measurementController = new MeasurementController(
       this.measurementModel,

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -30,7 +30,11 @@ import {
   AnnotationController,
   AnnotationState,
 } from '../../lib/annotations/controller';
-import { Config, parseConfig, PartialConfig } from '../../lib/config';
+import {
+  Config,
+  parseAndValidateConfig,
+  PartialConfig,
+} from '../../lib/config';
 import { Cursor, CursorManager } from '../../lib/cursors';
 import { cssCursor } from '../../lib/dom';
 import { Environment } from '../../lib/environment';
@@ -878,7 +882,7 @@ export class Viewer {
 
       this.stream.update({
         streamAttributes: this.getStreamAttributes(),
-        config: parseConfig(this.configEnv, this.config),
+        config: parseAndValidateConfig(this.configEnv, this.config),
         dimensions: this.dimensions,
         frameBgColor: this.getBackgroundColor(),
       });
@@ -1570,7 +1574,7 @@ export class Viewer {
   }
 
   private updateResolvedConfig(): void {
-    this.resolvedConfig = parseConfig(this.configEnv, this.config);
+    this.resolvedConfig = parseAndValidateConfig(this.configEnv, this.config);
   }
 
   private getResolvedConfig(): Config {

--- a/packages/viewer/src/lib/__tests__/config.spec.ts
+++ b/packages/viewer/src/lib/__tests__/config.spec.ts
@@ -1,5 +1,115 @@
 import * as Config from '../config';
 
+describe(Config.parseAndValidateConfig, () => {
+  it('should trim whitespace', () => {
+    const expectedNetwork = {
+      apiHost: 'https://valid-api-host.vertex3d.com',
+      renderingHost: 'wss://valid-rendering-host.vertex3d.com',
+      sceneTreeHost: 'https://valid-scene-tree-host.vertex3d.com',
+      sceneViewHost: 'https://valid-scene-viewhost.vertex3d.com',
+    };
+    const json = JSON.stringify({
+      network: {
+        apiHost: `  ${expectedNetwork.apiHost}  `,
+        renderingHost: `  ${expectedNetwork.renderingHost}  `,
+        sceneTreeHost: `  ${expectedNetwork.sceneTreeHost}  `,
+        sceneViewHost: `  ${expectedNetwork.sceneViewHost}  `,
+      },
+    });
+    const config = Config.parseAndValidateConfig('platdev', json);
+    expect(config).toMatchObject({
+      network: expectedNetwork,
+    });
+  });
+
+  it('should throw errors if any host is invalid', () => {
+    const invalidApiHost = 'http://invalid-api-host.vertex3d.com';
+    const invalidRenderingHost = 'ws://invalid-rendering-host.vertex3d.com';
+    const invalidSceneTreeHost = 'invalid-scene-tree-host.vertex3d.com';
+    const invalidSceneViewHost = 'https:/invalid-scene-viewhost.vertex3d.com';
+
+    const invalidApiHostConfig = {
+      network: {
+        apiHost: invalidApiHost,
+      },
+    };
+    const invalidRenderingHostConfig = {
+      network: {
+        renderingHost: invalidRenderingHost,
+      },
+    };
+    const invalidSceneTreeHostConfig = {
+      network: {
+        sceneTreeHost: invalidSceneTreeHost,
+      },
+    };
+    const invalidSceneViewHostConfig = {
+      network: {
+        sceneViewHost: invalidSceneViewHost,
+      },
+    };
+
+    expect(() =>
+      Config.parseAndValidateConfig(
+        'platdev',
+        JSON.stringify(invalidApiHostConfig)
+      )
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid apiHost specified.'),
+      })
+    );
+    expect(() =>
+      Config.parseAndValidateConfig(
+        'platdev',
+        JSON.stringify(invalidRenderingHostConfig)
+      )
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid renderingHost specified.'),
+      })
+    );
+    expect(() =>
+      Config.parseAndValidateConfig(
+        'platdev',
+        JSON.stringify(invalidSceneTreeHostConfig)
+      )
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid sceneTreeHost specified.'),
+      })
+    );
+    expect(() =>
+      Config.parseAndValidateConfig(
+        'platdev',
+        JSON.stringify(invalidSceneViewHostConfig)
+      )
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid sceneViewHost specified.'),
+      })
+    );
+  });
+
+  it('should resolve a valid configuration', () => {
+    const expectedNetwork = {
+      apiHost: 'https://valid-api-host.vertex3d.com',
+      renderingHost: 'wss://valid-rendering-host.vertex3d.com',
+      sceneTreeHost: 'https://valid-scene-tree-host.vertex3d.com',
+      sceneViewHost: 'https://valid-scene-viewhost.vertex3d.com',
+    };
+
+    expect(
+      Config.parseAndValidateConfig(
+        'platdev',
+        JSON.stringify({ network: expectedNetwork })
+      )
+    ).toMatchObject({
+      network: expectedNetwork,
+    });
+  });
+});
+
 describe(Config.parseConfig, () => {
   it('should default to environment config', () => {
     const config = Config.parseConfig('platdev', {} as Config.Config);
@@ -31,6 +141,109 @@ describe(Config.parseConfig, () => {
         apiHost: 'host',
         renderingHost: 'wss://stream.platdev.vertexvis.io',
       },
+    });
+  });
+});
+
+describe(Config.sanitizeConfig, () => {
+  it('should trim whitespace from network URLs', () => {
+    const expectedNetwork = {
+      apiHost: 'api-host',
+      renderingHost: 'rendering-host',
+      sceneTreeHost: 'scene-tree-host',
+      sceneViewHost: 'scene-view-host',
+    };
+    const json = JSON.stringify({
+      network: {
+        apiHost: `  ${expectedNetwork.apiHost}  `,
+        renderingHost: `  ${expectedNetwork.renderingHost}  `,
+        sceneTreeHost: `  ${expectedNetwork.sceneTreeHost}  `,
+        sceneViewHost: `  ${expectedNetwork.sceneViewHost}  `,
+      },
+    });
+    const config = Config.parseConfig('platdev', json);
+    const sanitized = Config.sanitizeConfig(config);
+    expect(sanitized).toMatchObject({
+      network: expectedNetwork,
+    });
+  });
+});
+
+describe(Config.validateConfig, () => {
+  it('should throw an error for an invalid api host', () => {
+    const json = JSON.stringify({
+      network: {
+        apiHost: `http://invalid-host.vertex3d.com`,
+      },
+    });
+    const config = Config.parseConfig('platdev', json);
+
+    expect(() => Config.validateConfig(config)).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid apiHost specified.'),
+      })
+    );
+  });
+
+  it('should throw an error for an invalid rendering host', () => {
+    const json = JSON.stringify({
+      network: {
+        renderingHost: `https://invalid-host.vertex3d.com`,
+      },
+    });
+    const config = Config.parseConfig('platdev', json);
+
+    expect(() => Config.validateConfig(config)).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid renderingHost specified.'),
+      })
+    );
+  });
+
+  it('should throw an error for an invalid scene tree host', () => {
+    const json = JSON.stringify({
+      network: {
+        sceneTreeHost: `invalid-host.vertex3d.com`,
+      },
+    });
+    const config = Config.parseConfig('platdev', json);
+
+    expect(() => Config.validateConfig(config)).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid sceneTreeHost specified.'),
+      })
+    );
+  });
+
+  it('should throw an error for an invalid scene view host', () => {
+    const json = JSON.stringify({
+      network: {
+        sceneViewHost: `https:/invalid-host.vertex3d.com`,
+      },
+    });
+    const config = Config.parseConfig('platdev', json);
+
+    expect(() => Config.validateConfig(config)).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid sceneViewHost specified.'),
+      })
+    );
+  });
+
+  it('should not throw for valid host values', () => {
+    const expectedNetwork = {
+      apiHost: 'https://valid-api-host.vertex3d.com',
+      renderingHost: 'wss://valid-rendering-host.vertex3d.com',
+      sceneTreeHost: 'https://valid-scene-tree-host.vertex3d.com',
+      sceneViewHost: 'https://valid-scene-viewhost.vertex3d.com',
+    };
+    const json = JSON.stringify({
+      network: expectedNetwork,
+    });
+    const config = Config.parseConfig('platdev', json);
+
+    expect(Config.validateConfig(config)).toMatchObject({
+      network: expectedNetwork,
     });
   });
 });

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -20,7 +20,7 @@ import {
 import deepEqual from 'fast-deep-equal';
 
 import { Color3, StreamAttributes } from '../../interfaces';
-import { Config, parseConfig } from '../config';
+import { Config, parseAndValidateConfig } from '../config';
 import {
   CustomError,
   SceneRenderError,
@@ -120,7 +120,7 @@ export class ViewerStream extends StreamApi {
     this.streamAttributes = {};
     this.enableTemporalRefinement = opts.enableTemporalRefinement ?? true;
     this.frameBgColor = Color.create(255, 255, 255);
-    this.config = parseConfig('platprod');
+    this.config = parseAndValidateConfig('platprod');
 
     this.options = {
       tokenRefreshOffsetInSeconds: opts.tokenRefreshOffsetInSeconds ?? 30,
@@ -149,7 +149,7 @@ export class ViewerStream extends StreamApi {
     urn: string,
     clientId: string | undefined,
     deviceId: string | undefined,
-    config: Config = parseConfig('platprod'),
+    config: Config = parseAndValidateConfig('platprod'),
     cameraType?: FrameCameraType
   ): Promise<void> {
     this.clientId = clientId;


### PR DESCRIPTION
## Summary

Introduces some basic validation/sanitation of the `network` properties provided in a configuration object. With this in place, the SDK will now automatically trim whitespace on either end of the URLs provided, and will validate that each URL begins with the appropriate scheme (`https` or `wss`), throwing a descriptive error in the case that these requirements are not met.

## Test Plan

- Verify that out of the box configurations continue to work as expected (`config-env`)
- Verify that providing custom network hosts continues to work as expected
- Verify that providing network hosts with additional whitespace now loads the resource as expected (`sceneTreeHost: 'https://scene-trees.platprod.vertexvis.io '` should now resolve and load a tree for instance)
- Verify that providing invalid network hosts throws a descriptive error (`sceneTreeHost: 'http://scene-trees.platprod.vertexvis.io'` should throw indicating that the `https://` scheme is required)

## Release Notes

N/A

## Possible Regressions

Configuration defaults

## Dependencies

N/A
