### PR TITLE
[PLAT-5521] Support reloading scene from viewer element

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -666,6 +666,10 @@ export namespace Components {
       keyInteraction: KeyInteraction<TapEventDetails>
     ) => Promise<void>;
     /**
+     * Disconnects the websocket and clears the internal state associated with the scene before reconnecting to the same scene.
+     */
+    reload: () => Promise<void>;
+    /**
      * An optional value that will debounce frame updates when resizing this viewer element.
      */
     resizeDebounce: number;

--- a/packages/viewer/src/components/viewer/readme.md
+++ b/packages/viewer/src/components/viewer/readme.md
@@ -158,6 +158,17 @@ Type: `Promise<void>`
 
 
 
+### `reload() => Promise<void>`
+
+Disconnects the websocket and clears the internal state associated with
+the scene before reconnecting to the same scene.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `scene() => Promise<Scene>`
 
 Returns an object that is used to perform operations on the `Scene` that's

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -933,6 +933,18 @@ export class Viewer {
   }
 
   /**
+   * Disconnects the websocket and clears the internal state associated with
+   * the scene before reconnecting to the same scene.
+   */
+  @Method()
+  public async reload(): Promise<void> {
+    if (this.src != null) {
+      await this.unload();
+      await this.load(this.src, { cameraType: this.cameraType });
+    }
+  }
+
+  /**
    * Returns an object that is used to perform operations on the `Scene` that's
    * currently being viewed. These operations include updating items,
    * positioning the camera and performing hit tests.
@@ -1440,7 +1452,7 @@ export class Viewer {
   }
 
   /**
-   * This function is currently not in use, but will required
+   * This function is currently not in use, but will be required
    * when we want to automatically configure the background color of
    * JPEG images.
    */

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -47,6 +47,7 @@ export {
   EntityType,
   FrameCameraBase,
   LoadableResource,
+  Orientation,
   Frame as ReceivedFrame,
   FrameImage as ReceivedFrameImage,
   FrameScene as ReceivedFrameScene,

--- a/packages/viewer/src/lib/types/orientation.ts
+++ b/packages/viewer/src/lib/types/orientation.ts
@@ -5,7 +5,7 @@ import { Matrix4, Vector3 } from '@vertexvis/geometry';
  */
 export class Orientation {
   /**
-   * A default orientation where up points up is represented as `[0, 1, 0]` and
+   * A default orientation where the up vector points up is represented as `[0, 1, 0]` and
    * forward is represented as `[0, 0, -1]`.
    */
   public static DEFAULT = new Orientation(Vector3.up(), Vector3.back());


### PR DESCRIPTION
## Summary
This PR adds the ability to reload the scene from the viewer element. The method disconnects the stream and then immediately reconnects the same scene.

Further, this PR also exports the 'Orientation' type.

## Test Plan
Verify a viewer element can reload its scene

## Release Notes
Ability to reload the scene from the viewer element

## Possible Regressions
None

## Dependencies
None