### PR TITLE
[PLAT-5771] Clear scene tree search

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -337,7 +337,7 @@ export namespace Components {
      */
     placeholder?: string;
     /**
-     * Gives focus to the the component's internal text input.
+     * Gives focus to the component's internal text input.
      */
     setFocus: () => Promise<void>;
     /**

--- a/packages/viewer/src/components/scene-tree-search/readme.md
+++ b/packages/viewer/src/components/scene-tree-search/readme.md
@@ -48,7 +48,7 @@ Type: `Promise<void>`
 
 ### `setFocus() => Promise<void>`
 
-Gives focus to the the component's internal text input.
+Gives focus to the component's internal text input.
 
 #### Returns
 

--- a/packages/viewer/src/components/scene-tree-search/scene-tree-search.tsx
+++ b/packages/viewer/src/components/scene-tree-search/scene-tree-search.tsx
@@ -82,7 +82,7 @@ export class SceneTreeSearch {
   private searchDisposable?: Disposable;
 
   /**
-   * Gives focus to the the component's internal text input.
+   * Gives focus to the component's internal text input.
    */
   @Method()
   public async setFocus(): Promise<void> {
@@ -120,9 +120,10 @@ export class SceneTreeSearch {
    * Clears the current search term and clears any debounced filters.
    */
   @Method()
-  public async clear(): Promise<void> {
+  public clear(): void {
     this.value = '';
     this.searchDisposable?.dispose();
+    this.emitCurrentValue();
   }
 
   /**


### PR DESCRIPTION
## Summary
We were not correctly emitting the updated value when clearing the scene tree search.

## Test Plan
Verify the 'clear()' method works as expected on a scene tree search element.

## Release Notes
None

## Possible Regressions
Clearing a scene tree search

## Dependencies
None