### PR TITLE
[PLAT-6168] Showing Partial Results Banner on Filter responses

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -51,7 +51,7 @@
     "@vertexvis/frame-streaming-protos": "^0.13.17",
     "@vertexvis/geometry": "0.23.5",
     "@vertexvis/html-templates": "0.23.5",
-    "@vertexvis/scene-tree-protos": "^0.1.21",
+    "@vertexvis/scene-tree-protos": "^0.1.26",
     "@vertexvis/scene-view-protos": "^0.7.0",
     "@vertexvis/stream-api": "0.23.5",
     "@vertexvis/utils": "0.23.5",

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -312,6 +312,16 @@ export namespace Components {
      */
     viewerSelector?: string;
   }
+  interface VertexSceneTreeNotificationBanner {
+    /**
+     * The label of the action button.
+     */
+    actionLabel?: string;
+    /**
+     * The message to display in the banner.
+     */
+    message?: string;
+  }
   interface VertexSceneTreeSearch {
     /**
      * Clears the current search term and clears any debounced filters.
@@ -1718,6 +1728,11 @@ export interface VertexSceneTreeCustomEvent<T> extends CustomEvent<T> {
   detail: T;
   target: HTMLVertexSceneTreeElement;
 }
+export interface VertexSceneTreeNotificationBannerCustomEvent<T>
+  extends CustomEvent<T> {
+  detail: T;
+  target: HTMLVertexSceneTreeNotificationBannerElement;
+}
 export interface VertexSceneTreeSearchCustomEvent<T> extends CustomEvent<T> {
   detail: T;
   target: HTMLVertexSceneTreeSearchElement;
@@ -1797,6 +1812,13 @@ declare global {
   var HTMLVertexSceneTreeElement: {
     prototype: HTMLVertexSceneTreeElement;
     new (): HTMLVertexSceneTreeElement;
+  };
+  interface HTMLVertexSceneTreeNotificationBannerElement
+    extends Components.VertexSceneTreeNotificationBanner,
+      HTMLStencilElement {}
+  var HTMLVertexSceneTreeNotificationBannerElement: {
+    prototype: HTMLVertexSceneTreeNotificationBannerElement;
+    new (): HTMLVertexSceneTreeNotificationBannerElement;
   };
   interface HTMLVertexSceneTreeSearchElement
     extends Components.VertexSceneTreeSearch,
@@ -2080,6 +2102,7 @@ declare global {
   };
   interface HTMLElementTagNameMap {
     'vertex-scene-tree': HTMLVertexSceneTreeElement;
+    'vertex-scene-tree-notification-banner': HTMLVertexSceneTreeNotificationBannerElement;
     'vertex-scene-tree-search': HTMLVertexSceneTreeSearchElement;
     'vertex-scene-tree-table-cell': HTMLVertexSceneTreeTableCellElement;
     'vertex-scene-tree-table-column': HTMLVertexSceneTreeTableColumnElement;
@@ -2199,6 +2222,22 @@ declare namespace LocalJSX {
      * A CSS selector that points to a `<vertex-viewer>` element. Either this property or `viewer` must be set.
      */
     viewerSelector?: string;
+  }
+  interface VertexSceneTreeNotificationBanner {
+    /**
+     * The label of the action button.
+     */
+    actionLabel?: string;
+    /**
+     * The message to display in the banner.
+     */
+    message?: string;
+    /**
+     * An event that is emitted when the action button is clicked.
+     */
+    onAction?: (
+      event: VertexSceneTreeNotificationBannerCustomEvent<void>
+    ) => void;
   }
   interface VertexSceneTreeSearch {
     /**
@@ -3691,6 +3730,7 @@ declare namespace LocalJSX {
   }
   interface IntrinsicElements {
     'vertex-scene-tree': VertexSceneTree;
+    'vertex-scene-tree-notification-banner': VertexSceneTreeNotificationBanner;
     'vertex-scene-tree-search': VertexSceneTreeSearch;
     'vertex-scene-tree-table-cell': VertexSceneTreeTableCell;
     'vertex-scene-tree-table-column': VertexSceneTreeTableColumn;
@@ -3739,6 +3779,8 @@ declare module '@stencil/core' {
     interface IntrinsicElements {
       'vertex-scene-tree': LocalJSX.VertexSceneTree &
         JSXBase.HTMLAttributes<HTMLVertexSceneTreeElement>;
+      'vertex-scene-tree-notification-banner': LocalJSX.VertexSceneTreeNotificationBanner &
+        JSXBase.HTMLAttributes<HTMLVertexSceneTreeNotificationBannerElement>;
       'vertex-scene-tree-search': LocalJSX.VertexSceneTreeSearch &
         JSXBase.HTMLAttributes<HTMLVertexSceneTreeSearchElement>;
       'vertex-scene-tree-table-cell': LocalJSX.VertexSceneTreeTableCell &

--- a/packages/viewer/src/components/scene-tree-notification-banner/readme.md
+++ b/packages/viewer/src/components/scene-tree-notification-banner/readme.md
@@ -1,0 +1,43 @@
+# vertex-scene-tree-notification-banner
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property      | Attribute      | Description                           | Type                  | Default     |
+| ------------- | -------------- | ------------------------------------- | --------------------- | ----------- |
+| `actionLabel` | `action-label` | The label of the action button.       | `string \| undefined` | `undefined` |
+| `message`     | `message`      | The message to display in the banner. | `string \| undefined` | `undefined` |
+
+
+## Events
+
+| Event    | Description                                                 | Type                |
+| -------- | ----------------------------------------------------------- | ------------------- |
+| `action` | An event that is emitted when the action button is clicked. | `CustomEvent<void>` |
+
+
+## Dependencies
+
+### Used by
+
+ - [vertex-scene-tree](../scene-tree)
+
+### Depends on
+
+- [vertex-viewer-icon](../viewer-icon)
+
+### Graph
+```mermaid
+graph TD;
+  vertex-scene-tree-notification-banner --> vertex-viewer-icon
+  vertex-scene-tree --> vertex-scene-tree-notification-banner
+  style vertex-scene-tree-notification-banner fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/viewer/src/components/scene-tree-notification-banner/scene-tree-notification-banner.css
+++ b/packages/viewer/src/components/scene-tree-notification-banner/scene-tree-notification-banner.css
@@ -1,0 +1,42 @@
+.notification-banner {
+    background-color: var(--blue-200);
+    padding: 0px 16px;
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.875rem;
+    line-height: 0.5;
+    color: var(--neutral-600);
+  }
+  
+  .notification-banner-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  
+  .notification-banner-info .icon {
+    color: var(--blue-600);
+  }
+  
+  .notification-banner-actions {
+    display: flex;
+    align-items: center;
+  }
+  
+  .notification-banner-button {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: var(--blue-600);
+    font-size: 0.875rem;
+    display: flex;
+    align-items: center;
+  }
+  
+  .notification-banner-button:hover {
+    color: var(--blue-800);
+  }
+  
+  

--- a/packages/viewer/src/components/scene-tree-notification-banner/scene-tree-notification-banner.spec.tsx
+++ b/packages/viewer/src/components/scene-tree-notification-banner/scene-tree-notification-banner.spec.tsx
@@ -1,0 +1,53 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+
+import { SceneTreeNotificationBanner } from './scene-tree-notification-banner';
+
+describe('<vertex-scene-tree-notification-banner>', () => {
+  it('renders a message', async () => {
+    const message = 'My Message';
+    const { banner } = await newComponentSpec({
+      html: `<vertex-scene-tree-notification-banner message="${message}"></vertex-scene-tree-notification-banner>`,
+    });
+
+    expect(banner.shadowRoot?.querySelector('div')).not.toBeNull();
+    expect(banner.shadowRoot?.querySelector('p')?.textContent).toBe(message);
+  });
+
+  it('emits an action event when the action button is clicked', async () => {
+    const onActionMock = jest.fn();
+    const { banner } = await newComponentSpec({
+      html: `<vertex-scene-tree-notification-banner action-label="My Action"></vertex-scene-tree-notification-banner>`,
+    });
+
+    banner.addEventListener('action', onActionMock);
+    const actionButton = banner.shadowRoot?.querySelector(
+      '.notification-banner-button'
+    );
+    actionButton?.dispatchEvent(new MouseEvent('click'));
+
+    expect(onActionMock).toHaveBeenCalled();
+  });
+
+  it('does not render an action button if no action label is provided', async () => {
+    const { banner } = await newComponentSpec({
+      html: `<vertex-scene-tree-notification-banner></vertex-scene-tree-notification-banner>`,
+    });
+
+    expect(
+      banner.shadowRoot?.querySelector('.notification-banner-button')
+    ).toBeNull();
+  });
+});
+
+async function newComponentSpec(data: { html: string }): Promise<{
+  page: SpecPage;
+  banner: HTMLVertexSceneTreeNotificationBannerElement;
+}> {
+  const page = await newSpecPage({
+    components: [SceneTreeNotificationBanner],
+    html: data.html,
+  });
+  const banner = page.root as HTMLVertexSceneTreeNotificationBannerElement;
+
+  return { page, banner };
+}

--- a/packages/viewer/src/components/scene-tree-notification-banner/scene-tree-notification-banner.tsx
+++ b/packages/viewer/src/components/scene-tree-notification-banner/scene-tree-notification-banner.tsx
@@ -1,0 +1,52 @@
+import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
+
+/**
+ * A notification banner that displays a message and an action button.
+ */
+@Component({
+  tag: 'vertex-scene-tree-notification-banner',
+  styleUrl: 'scene-tree-notification-banner.css',
+  shadow: true,
+})
+export class SceneTreeNotificationBanner {
+  /**
+   * The message to display in the banner.
+   */
+  @Prop()
+  public message?: string;
+
+  /**
+   * The label of the action button.
+   */
+  @Prop()
+  public actionLabel?: string;
+
+  /**
+   * An event that is emitted when the action button is clicked.
+   */
+  @Event()
+  public action!: EventEmitter<void>;
+
+  public render(): h.JSX.IntrinsicElements {
+    return (
+      <Host>
+        <div class="notification-banner">
+          <div class="notification-banner-info">
+            <vertex-viewer-icon class="icon" name="info" size="sm" />
+            <p>{this.message}</p>
+          </div>
+          {this.actionLabel != null && (
+            <div class="notification-banner-actions">
+              <button
+                class="notification-banner-button"
+                onClick={() => this.action.emit()}
+              >
+                {this.actionLabel}
+              </button>
+            </div>
+          )}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/viewer/src/components/scene-tree/readme.md
+++ b/packages/viewer/src/components/scene-tree/readme.md
@@ -866,6 +866,7 @@ Type: `Promise<void>`
 
 - [vertex-scene-tree-toolbar](../scene-tree-toolbar)
 - [vertex-scene-tree-search](../scene-tree-search)
+- [vertex-scene-tree-notification-banner](../scene-tree-notification-banner)
 - [vertex-viewer-spinner](../viewer-spinner)
 - [vertex-scene-tree-table-layout](../scene-tree-table-layout)
 
@@ -874,10 +875,12 @@ Type: `Promise<void>`
 graph TD;
   vertex-scene-tree --> vertex-scene-tree-toolbar
   vertex-scene-tree --> vertex-scene-tree-search
+  vertex-scene-tree --> vertex-scene-tree-notification-banner
   vertex-scene-tree --> vertex-viewer-spinner
   vertex-scene-tree --> vertex-scene-tree-table-layout
   vertex-scene-tree-search --> vertex-viewer-spinner
   vertex-scene-tree-search --> vertex-viewer-icon
+  vertex-scene-tree-notification-banner --> vertex-viewer-icon
   style vertex-scene-tree fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -249,6 +249,12 @@ export class SceneTree {
   private errorDetails: SceneTreeErrorDetails | undefined;
 
   @State()
+  private hasPartialFilterResults = false;
+
+  @State()
+  private refreshingResults = false;
+
+  @State()
   private attemptingRetry = false;
 
   @Element()
@@ -735,6 +741,20 @@ export class SceneTree {
           </slot>
         </div>
 
+        <slot name="partial-filter-results-banner">
+          {this.hasPartialFilterResults && (
+            <vertex-scene-tree-notification-banner
+              message={
+                this.refreshingResults
+                  ? 'Refreshing results...'
+                  : 'Partial results returned. Refresh for more.'
+              }
+              actionLabel="Refresh"
+              onAction={() => this.controller?.refreshFilter()}
+            />
+          )}
+        </slot>
+
         {this.errorDetails != null && this.renderError(this.errorDetails)}
 
         {this.errorDetails == null && (
@@ -880,6 +900,8 @@ export class SceneTree {
     this.showEmptyResults = !!state.shouldShowEmptyResults;
     this.rows = state.rows;
     this.totalRows = state.totalRows;
+    this.hasPartialFilterResults = !!state.isPartialFilterResponse;
+    this.refreshingResults = !!state.isSearching;
 
     if (state.connection.type === 'failure') {
       this.errorDetails = state.connection.details;

--- a/packages/viewer/src/components/viewer-icon/readme.md
+++ b/packages/viewer/src/components/viewer-icon/readme.md
@@ -46,16 +46,17 @@ component.
 
 ## Properties
 
-| Property | Attribute | Description                                                                                                                                                                                                                                                          | Type                                                                                                                                                                                                         | Default     |
-| -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| `name`   | `name`    | The name of the icon to render.                                                                                                                                                                                                                                      | `"chevron-down" \| "chevron-right" \| "close-circle" \| "comment-filled" \| "comment-show" \| "eye-half" \| "eye-half-dotted" \| "eye-open" \| "fit-all" \| "locate" \| "pin-fill" \| "search" \| undefined` | `undefined` |
-| `size`   | `size`    | The size of the icon. Can be `'sm' \| 'md' \| 'lg' \| undefined`. Predefined sizes are set to:   * `sm`: 16px  * `md`: 24px  * `lg`: 32px  A custom size can be supplied by setting this field to `undefined` and setting `font-size` through CSS. Defaults to `md`. | `"lg" \| "md" \| "sm" \| undefined`                                                                                                                                                                          | `'md'`      |
+| Property | Attribute | Description                                                                                                                                                                                                                                                          | Type                                                                                                                                                                                                                   | Default     |
+| -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `name`   | `name`    | The name of the icon to render.                                                                                                                                                                                                                                      | `"chevron-down" \| "chevron-right" \| "close-circle" \| "comment-filled" \| "comment-show" \| "eye-half" \| "eye-half-dotted" \| "eye-open" \| "fit-all" \| "info" \| "locate" \| "pin-fill" \| "search" \| undefined` | `undefined` |
+| `size`   | `size`    | The size of the icon. Can be `'sm' \| 'md' \| 'lg' \| undefined`. Predefined sizes are set to:   * `sm`: 16px  * `md`: 24px  * `lg`: 32px  A custom size can be supplied by setting this field to `undefined` and setting `font-size` through CSS. Defaults to `md`. | `"lg" \| "md" \| "sm" \| undefined`                                                                                                                                                                                    | `'md'`      |
 
 
 ## Dependencies
 
 ### Used by
 
+ - [vertex-scene-tree-notification-banner](../scene-tree-notification-banner)
  - [vertex-scene-tree-search](../scene-tree-search)
  - [vertex-scene-tree-table-cell](../scene-tree-table-cell)
  - [vertex-viewer-annotation-callout](../viewer-annotation-callout)
@@ -65,6 +66,7 @@ component.
 ### Graph
 ```mermaid
 graph TD;
+  vertex-scene-tree-notification-banner --> vertex-viewer-icon
   vertex-scene-tree-search --> vertex-viewer-icon
   vertex-scene-tree-table-cell --> vertex-viewer-icon
   vertex-viewer-annotation-callout --> vertex-viewer-icon

--- a/packages/viewer/src/components/viewer-icon/viewer-icon.tsx
+++ b/packages/viewer/src/components/viewer-icon/viewer-icon.tsx
@@ -10,6 +10,7 @@ export type ViewerIconName =
   | 'close-circle'
   | 'comment-filled'
   | 'comment-show'
+  | 'info'
   | 'eye-half'
   | 'eye-half-dotted'
   | 'eye-open'
@@ -73,6 +74,10 @@ export class ViewerIcon {
       case 'comment-show':
         return this.renderSvgIcon(
           <path d="M11.5,8h-7a.5.5,0,0,0,0,1h7a.5.5,0,0,0,0-1Zm0-3h-7a.5.5,0,0,0,0,1h7a.5.5,0,0,0,0-1Zm2-3H2.5A1.5,1.5,0,0,0,1,3.5v7A1.5,1.5,0,0,0,2.5,12H8.29l2.86,2.85a.47.47,0,0,0,.54.11A.5.5,0,0,0,12,14.5V12h1.5A1.5,1.5,0,0,0,15,10.5v-7A1.5,1.5,0,0,0,13.5,2Zm.5,8.5a.5.5,0,0,1-.5.5h-2a.51.51,0,0,0-.5.5v1.79L8.85,11.15A.47.47,0,0,0,8.5,11h-6a.5.5,0,0,1-.5-.5v-7A.5.5,0,0,1,2.5,3h11a.5.5,0,0,1,.5.5Z" />
+        );
+      case 'info':
+        return this.renderSvgIcon(
+          <path d="M8,15A7,7,0,1,0,1,8,7,7,0,0,0,8,15ZM3.73,3.77A6,6,0,1,1,2,8,6,6,0,0,1,3.73,3.77ZM8,12a.5.5,0,0,0,.5-.5v-5a.5.5,0,0,0-1,0v5A.5.5,0,0,0,8,12ZM8,5a.51.51,0,1,0-.35-.15A.47.47,0,0,0,8,5Z" />
         );
       case 'eye-half':
         return this.renderSvgIcon(

--- a/packages/viewer/src/testing/sceneTree.ts
+++ b/packages/viewer/src/testing/sceneTree.ts
@@ -1,6 +1,7 @@
 import { OffsetCursor } from '@vertexvis/scene-tree-protos/core/protos/paging_pb';
 import { Uuid } from '@vertexvis/scene-tree-protos/core/protos/uuid_pb';
 import {
+  IndexingStatus,
   ListChange,
   Node,
   TreeChangeType,
@@ -83,9 +84,17 @@ export function createGetTreeResponse(
   return res;
 }
 
-export function createFilterTreeResponse(resultCount: number): FilterResponse {
+export function createFilterTreeResponse(
+  resultCount: number,
+  partialResults = false
+): FilterResponse {
   const res = new FilterResponse();
   res.setNumberOfResults(resultCount);
+  res.setIndexingStatus(
+    partialResults
+      ? IndexingStatus.INDEXING_STATUS_INDEXING
+      : IndexingStatus.INDEXING_STATUS_READY
+  );
 
   return res;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,10 +2243,10 @@
   resolved "https://registry.yarnpkg.com/@vertexvis/rollup-plugin-web-workers/-/rollup-plugin-web-workers-0.1.0.tgz#53c0981df8127125e3fd3c67ddc0169693efec58"
   integrity sha512-5pJbF5/nMdqybxpZW2yBIQ9lF3P61ziaC3APTfHXU9APhnVfp+3jdW5PkrWGc45zFn1wCkuwEFhD+ORv3LEePw==
 
-"@vertexvis/scene-tree-protos@^0.1.21":
-  version "0.1.25"
-  resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.25.tgz#e41223ed3a5aef9609c7e42c2687649c968c0fd1"
-  integrity sha512-MjeVWG41f6p4en9dtYdV852POeDMMoyqhdTIYJMuUBJvXlW9YjINWXHB+Vd5uNZ1xumU6Rahx1KqTxcOYkPxhw==
+"@vertexvis/scene-tree-protos@^0.1.26":
+  version "0.1.26"
+  resolved "https://registry.yarnpkg.com/@vertexvis/scene-tree-protos/-/scene-tree-protos-0.1.26.tgz#57f8b1af89aadbaf2ab1cef8767155ab5278ebb2"
+  integrity sha512-tEO0jj4UnZK+I+Xc9OkUePnPL/TSTawtMsG9/E2QOaWMTJZ5wxla5DzKBmtoR2CycStcWwc1A2Qjkfw4ga2rlA==
 
 "@vertexvis/scene-view-protos@^0.7.0":
   version "0.7.0"


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes conditionally show a partial results banner when the scene that is being viewed is currently indexing. This only shows up on a filter request that occurs during the time of indexing. The user is notified with an option to refresh the results. 

The banner goes away once a response comes back on a request that occurs after the indexing is complete. 


## Test Plan
<!-- How to test changes. -->

https://github.com/user-attachments/assets/72185507-ebc6-4d70-be68-1980b77fe5a4





## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
