### PR TITLE
[PLAT-6842] Enable experimental import injection flag

### DIFF
--- a/packages/viewer/stencil.config.ts
+++ b/packages/viewer/stencil.config.ts
@@ -57,6 +57,7 @@ export const config: Config = {
   extras: {
     dynamicImportShim: true,
     shadowDomShim: true,
+    experimentalImportInjection: true,
   },
 };
 


### PR DESCRIPTION
## Summary

This PR enables the `experimentalImportInjection` flag in our StencilJS configuration. This flag creates dynamic imports for all of the lazy-loaded components, such that they can be properly included with certain bundling tools, such as Vite. See https://stenciljs.com/docs/config-extras#experimentalimportinjection for more information on the flag (also note that we're using `experimentalImportInjection` instead of `enableImportInjection` due to the version of Stencil we're using).

One additional detail included with the `experimentalImportInjection` flag is that it has potential side-effects for the size of our bundles, so as part of this work, some analysis of those changes was done using [rollup-plugin-analyzer](https://www.npmjs.com/package/rollup-plugin-analyzer), and the top-level summaries are listed below.

Bundle sizes for `@vertexvis/viewer`

```
--------------------------------|---------------------------------
Rollup File Analysis (before)   | Rollup File Analysis (after)
--------------------------------|---------------------------------
bundle size:    8.183 MB        | bundle size:    8.062 MB
original size:  8.582 MB        | original size:  8.411 MB
code reduction: 4.65 %          | code reduction: 4.15 %
module count:   429             | module count:   431

```


Bundle sizes for `@vertexvis/viewer-react`

```
--------------------------------|---------------------------------
Rollup File Analysis (before)   | Rollup File Analysis (after)
--------------------------------|---------------------------------
bundle size:    12.969 KB       | bundle size:    12.969 KB
original size:  16.979 KB       | original size:  16.979 KB
code reduction: 23.62 %         | code reduction: 23.62 %
module count:   6               | module count:   6

```


Bundle sizes for `@vertexvis/viewer-vue`

```
--------------------------------|---------------------------------
Rollup File Analysis (before)   | Rollup File Analysis (after)
--------------------------------|---------------------------------
bundle size:    96.851 KB       | bundle size:    96.851 KB
original size:  308.464 KB      | original size:  308.464 KB
code reduction: 68.6 %          | code reduction: 68.6 %
module count:   8               | module count:   8

```

Based on the above findings analyzing the bundles, this approach appears to very slightly reduce the size of the `@vertexvis/viewer` bundle, but leaves both our React and Vue bindings untouched size-wise (these full analyses will be attached to the ticket as well). Additionally, running our Connect build with the `@vertexvis/viewer-react` bundle had no notable changes to the size of the bundle, so this seems like a solid path forward for resolving Vite incompatibilities.

## Test Plan

- Verify the `@vertexvis/viewer`, `@vertexvis/viewer-vue`, and `@vertexvis/viewer-react` packages continue to work as expected with the canary release for this PR
- Verify the `@vertexvis/viewer`, `@vertexvis/viewer-vue`, and `@vertexvis/viewer-react` packages maintain the same or smaller bundle sizes (through the unpacked size on NPM, something like bundlephobia, or other analysis tools)
- Verify that the `@vertexvis/viewer-vue` package can properly be used in VueJS apps built using Vite

## Release Notes

N/A

## Possible Regressions

Bundle sizes, lazy-loading of components

## Dependencies

N/A
