### PR TITLE
[PLAT-6607] Prevent duplicate cursors

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -498,7 +498,8 @@ export namespace Components {
      */
     addCursor: (
       cursor: Cursor,
-      priority?: number | undefined
+      priority?: number | undefined,
+      preventDuplicate?: boolean | undefined
     ) => Promise<Disposable>;
     /**
      * The annotation controller for accessing annotations associated with the scene view.

--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
@@ -354,10 +354,10 @@ export class ViewerMeasurementDistance {
     await this.getStencilBuffer();
     this.updateViewport();
 
-    this.handleViewerChanged(this.viewer);
-    this.handleModeChanged();
+    await this.handleViewerChanged(this.viewer);
+    await this.handleModeChanged();
 
-    this.computePropsAndState();
+    await this.computePropsAndState();
 
     this.model.onIndicatorChanged((pt) => {
       this.indicatorPt = pt;
@@ -375,8 +375,8 @@ export class ViewerMeasurementDistance {
   /**
    * @ignore
    */
-  protected componentWillUpdate(): void {
-    this.computePropsAndState();
+  protected async componentWillUpdate(): Promise<void> {
+    await this.computePropsAndState();
   }
 
   /**
@@ -440,18 +440,18 @@ export class ViewerMeasurementDistance {
    * @ignore
    */
   @Watch('viewer')
-  protected handleViewerChanged(
+  protected async handleViewerChanged(
     newViewer?: HTMLVertexViewerElement,
     oldViewer?: HTMLVertexViewerElement
-  ): void {
+  ): Promise<void> {
     if (oldViewer != null) {
       oldViewer.removeEventListener('frameDrawn', this.handleFrameDrawn);
-      this.removeInteractionListeners(oldViewer);
+      await this.removeInteractionListeners(oldViewer);
     }
 
     if (newViewer != null) {
       newViewer.addEventListener('frameDrawn', this.handleFrameDrawn);
-      this.addInteractionListeners(newViewer);
+      await this.addInteractionListeners(newViewer);
     }
   }
 
@@ -475,7 +475,7 @@ export class ViewerMeasurementDistance {
    * @ignore
    */
   @Watch('mode')
-  protected handleModeChanged(): void {
+  protected async handleModeChanged(): Promise<void> {
     this.warnIfDepthBuffersDisabled();
 
     // If we're not in edit or replace mode, ensure that the measurement
@@ -485,8 +485,8 @@ export class ViewerMeasurementDistance {
     }
 
     if (this.viewer != null) {
-      this.removeInteractionListeners(this.viewer);
-      this.addInteractionListeners(this.viewer);
+      await this.removeInteractionListeners(this.viewer);
+      await this.addInteractionListeners(this.viewer);
     }
   }
 
@@ -514,9 +514,9 @@ export class ViewerMeasurementDistance {
     this.updateInteractionModel();
   }
 
-  private computePropsAndState(): void {
+  private async computePropsAndState(): Promise<void> {
     this.updateCamera();
-    this.updateDepthBuffer();
+    await this.updateDepthBuffer();
     this.updateMeasurementPropsFromModel();
     this.updateOverlays();
   }
@@ -539,7 +539,11 @@ export class ViewerMeasurementDistance {
     this.stateMap.hoverCursor?.dispose();
 
     if (!this.isUserInteractingWithModel) {
-      this.stateMap.hoverCursor = await this.viewer?.addCursor(cursor);
+      this.stateMap.hoverCursor = await this.viewer?.addCursor(
+        cursor,
+        undefined,
+        true
+      );
     }
   }
 

--- a/packages/viewer/src/components/viewer/readme.md
+++ b/packages/viewer/src/components/viewer/readme.md
@@ -56,7 +56,7 @@
 
 ## Methods
 
-### `addCursor(cursor: Cursor, priority?: number | undefined) => Promise<Disposable>`
+### `addCursor(cursor: Cursor, priority?: number | undefined, preventDuplicate?: boolean | undefined) => Promise<Disposable>`
 
 Adds a cursor to the viewer, and displays it if the cursor has the highest
 priority.

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -751,9 +751,10 @@ export class Viewer {
   @Method()
   public async addCursor(
     cursor: Cursor,
-    priority?: number
+    priority?: number,
+    preventDuplicate?: boolean
   ): Promise<Disposable> {
-    return this.stateMap.cursorManager.add(cursor, priority);
+    return this.stateMap.cursorManager.add(cursor, priority, preventDuplicate);
   }
 
   @Method()

--- a/packages/viewer/src/lib/__tests__/cursors.spec.ts
+++ b/packages/viewer/src/lib/__tests__/cursors.spec.ts
@@ -1,10 +1,52 @@
-import { CursorManager } from '../cursors';
+import { CursorManager, measurementCursor } from '../cursors';
 
 describe(CursorManager, () => {
   it('can add a cursor', () => {
     const cursors = new CursorManager();
+
+    const listener = jest.fn();
+    cursors.onChanged.on(listener);
+
     cursors.add('crosshair');
+
     expect(cursors.getActiveCursor()).toBeDefined();
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('adds a duplicate cursor when preventDuplicate is false', () => {
+    const cursors = new CursorManager();
+
+    const listener = jest.fn();
+    cursors.onChanged.on(listener);
+
+    cursors.add(measurementCursor);
+
+    expect(cursors.getActiveCursor()).toBeDefined();
+    expect(listener).toHaveBeenCalled();
+
+    listener.mockClear();
+
+    cursors.add(measurementCursor, undefined, false);
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('does not add a duplicate cursor when preventDuplicate is true', () => {
+    const cursors = new CursorManager();
+
+    const listener = jest.fn();
+    cursors.onChanged.on(listener);
+
+    cursors.add(measurementCursor);
+
+    expect(cursors.getActiveCursor()).toBeDefined();
+    expect(listener).toHaveBeenCalled();
+
+    listener.mockClear();
+
+    cursors.add(measurementCursor, undefined, true);
+
+    expect(listener).not.toHaveBeenCalled();
   });
 
   it('can remove a cursor', () => {

--- a/packages/viewer/src/lib/cursors.ts
+++ b/packages/viewer/src/lib/cursors.ts
@@ -115,9 +115,9 @@ export class CursorManager {
     preventDuplicate = false
   ): Disposable {
     if (preventDuplicate) {
-      const hasDuplicate = this.getExistingDuplicateCursor(cursor);
-      if (hasDuplicate != null) {
-        return hasDuplicate;
+      const duplicateCursor = this.getExistingDuplicateCursor(cursor);
+      if (duplicateCursor != null) {
+        return duplicateCursor;
       }
     }
 

--- a/packages/viewer/src/lib/cursors.ts
+++ b/packages/viewer/src/lib/cursors.ts
@@ -111,8 +111,16 @@ export class CursorManager {
    */
   public add(
     cursor: Cursor,
-    priority = CursorManager.NORMAL_PRIORITY
+    priority = CursorManager.NORMAL_PRIORITY,
+    preventDuplicate = false
   ): Disposable {
+    if (preventDuplicate) {
+      const hasDuplicate = this.getExistingDuplicateCursor(cursor);
+      if (hasDuplicate != null) {
+        return hasDuplicate;
+      }
+    }
+
     const id = ++this.nextId;
     const instance = { id, cursor, priority, dispose: () => this.remove(id) };
     this.cursors.push(instance);
@@ -130,6 +138,26 @@ export class CursorManager {
     if (index >= 0) {
       this.cursors.splice(index, 1);
       this.onChanged.emit();
+    }
+  }
+
+  /**
+   * Checks to see if an existing cursor matches the provided cursor.
+   * The matching cursor is returned if found.
+   *
+   * @param cursorToCheck The cursor to check for duplicates against.
+   */
+  private getExistingDuplicateCursor(
+    cursorToCheck: Cursor
+  ): CursorInstance | undefined {
+    const cursorMatches = this.cursors.filter(
+      (cursor) => cursor.cursor === cursorToCheck
+    );
+
+    if (cursorMatches.length > 0) {
+      return cursorMatches[0];
+    } else {
+      return undefined;
     }
   }
 


### PR DESCRIPTION
## Summary
Users could hit a race condition when using point-to-point measurement where multiple, identical measurement cursors would be added to the viewer's cursor manager. Once in this state, when the custom cursor was to be removed, only one of the measurement cursors was removed from the cursor manager and since a measurement cursor was still present in the cursor manager, the measurement cursor persisted.

Therefore, this PR adds an optional parameter to the 'add cursor' method to prevent adding a duplicate cursor. 

## Test Plan
<!-- How to test changes. -->

## Release Notes
Ability to prevent duplicate custom cursors

## Possible Regressions
Custom cursors

## Dependencies
None
