### PR TITLE
[PLAT-5791] Update DomainPropertyEntry

### DIFF
--- a/packages/viewer/src/lib/scene-items/types.ts
+++ b/packages/viewer/src/lib/scene-items/types.ts
@@ -40,6 +40,7 @@ export type DomainPropertyValue =
 export interface DomainPropertyEntry {
   id: string;
   key?: DomainPropertyKey | null;
+  value?: DomainPropertyValue | null;
 }
 export interface SceneItemMetadataResponse {
   paging: PagingLinks;


### PR DESCRIPTION
## Summary
We were including a 'value' as part of a DomainPropertyEntry, but 'value' was not included in the official typing.

## Test Plan
Verify working with DomainPropertyEntry elements works as expected

## Release Notes
None

## Possible Regressions
Working with DomainPropertyEntry elements

## Dependencies
None