### PR TITLE
[PLAT-7150] Only emit selectionToggled event when selection is toggled

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
@@ -363,6 +363,7 @@ export class SceneTreeTableCell {
       // Blur the `hostEl` after a `preventDefault` to clear focus that
       // is left on the element after `pointerdown` event.
       event.preventDefault();
+      event.stopPropagation();
       blurElement(this.hostEl);
 
       action(event);


### PR DESCRIPTION
## Summary
This PR prevents the selectionToggled event from emitting when a user expands a row, collapses a row, flies to a row, or changes a row's visibility. 

## Test Plan
Verify the selectionToggled event is not emited when a user expands a row, collapses a row, flies to a row, or changes a row's visibility

## Release Notes
Prevents the selectionToggled event from emitting when a user expands a row, collapses a row, flies to a row, or changes a row's visibility

## Possible Regressions
None

## Dependencies
None