### PR TITLE
[PLAT-7223] Close WebSocket on vertex-viewer disconnectedCallback

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -337,6 +337,43 @@ describe('vertex-viewer', () => {
     });
   });
 
+  describe('disconnect behavior', () => {
+    it('should pause the stream and close the websocket when disconnected', async () => {
+      const { stream, ws } = makeViewerStream();
+      const viewer = await newViewerSpec({
+        template: () => <vertex-viewer clientId={clientId} stream={stream} />,
+      });
+
+      const close = jest.spyOn(ws, 'close');
+      const pause = jest.spyOn(stream, 'pause');
+      await loadViewerStreamKey(key1, { stream, ws, viewer });
+      viewer.remove();
+
+      expect(close).toHaveBeenCalled();
+      expect(pause).toHaveBeenCalled();
+    });
+  });
+
+  describe('reconnect behavior', () => {
+    it('should reconnect to a paused stream', async () => {
+      const { stream, ws } = makeViewerStream();
+      const viewer = await newViewerSpec({
+        template: () => <vertex-viewer clientId={clientId} stream={stream} />,
+      });
+
+      const pause = jest.spyOn(stream, 'pause');
+      const resume = jest.spyOn(stream, 'resume');
+      const viewerParent = viewer.parentElement;
+      await loadViewerStreamKey(key1, { stream, ws, viewer });
+      viewer.remove();
+
+      viewerParent?.appendChild(viewer);
+
+      expect(pause).toHaveBeenCalled();
+      expect(resume).toHaveBeenCalled();
+    });
+  });
+
   describe('stream attributes', () => {
     it('updates stream when a stream attribute changes', async () => {
       const { stream, ws } = makeViewerStream();

--- a/packages/viewer/src/lib/stream/stream.ts
+++ b/packages/viewer/src/lib/stream/stream.ts
@@ -109,6 +109,7 @@ export class ViewerStream extends StreamApi {
   private deviceId: string | undefined;
 
   private state: ViewerStreamState = { type: 'disconnected' };
+  private pausedState?: Connected;
   public readonly stateChanged = new EventDispatcher<ViewerStreamState>();
 
   private options: Required<Omit<FrameStreamOptions, 'loggingEnabled'>>;
@@ -128,6 +129,10 @@ export class ViewerStream extends StreamApi {
       loadTimeoutInSeconds: opts.loadTimeoutInSeconds ?? 15,
       enableTemporalRefinement: opts.enableTemporalRefinement ?? true,
     };
+  }
+
+  public isPaused(): boolean {
+    return this.pausedState != null;
   }
 
   public getState(): ViewerStreamState {
@@ -201,6 +206,28 @@ export class ViewerStream extends StreamApi {
       if (this.state.type === 'connected') {
         this.closeAndReconnect(this.state);
       }
+    }
+  }
+
+  public pause(): void {
+    if (this.state.type === 'connected') {
+      this.pausedState = this.state;
+
+      console.debug(
+        `Stream paused [stream-id=${this.pausedState.streamId}, scene-id=${this.pausedState.sceneId}, scene-view-id=${this.pausedState.sceneViewId}]`
+      );
+
+      this.disconnect();
+    }
+  }
+
+  public resume(): void {
+    if (this.pausedState != null) {
+      console.debug(
+        `Stream resumed [stream-id=${this.pausedState.streamId}, scene-id=${this.pausedState.sceneId}, scene-view-id=${this.pausedState.sceneViewId}]`
+      );
+
+      this.connectToExistingStream(this.pausedState);
     }
   }
 


### PR DESCRIPTION
## Summary

Introduces a `pause` and `resume` method to the `ViewerStream` maintained by the `<vertex-viewer>` element that are used when the element is disconnected or connected to the DOM. When disconnected, the `pause` method will close the open WebSocket and keep track of the state to allow the `resume` method to reconnect to the existing Stream when/if the element is re-connected. This fixes an issue where repeatedly disconnecting and reconnecting the element from the DOM could result in a number of open WebSocket connections.

## Test Plan

- Verify that the viewer properly closes WebSocket connections when disconnected from the DOM
- Verify that the viewer properly resumes a Stream when reconnected to the DOM
  - This used to be available for "free" since we kept the WebSocket open, but now is an intentional reconnect action

1. Create a viewer and obtain a reference to the viewer and its parentElement
2. Call `viewer.remove()` - (see that the WebSocket disconnects)
3. Call `viewerParent.appendChild(viewer)` - (see that the WebSocket reconnects)
4. Verify the Stream state remains the same after the reconnect

## Release Notes

N/A

## Possible Regressions

Maintaining of Stream state when the viewer is moved or removed/added within the DOM
- Prior to this change, the above four steps to test would keep a single WebSocket connection each time the actions were performed. This is now a more intentional disconnect + reconnect, with potential to lose state if something doesn't go as expected

## Dependencies

N/A
