### PR TITLE
[PLAT-7164] Improve ancestor selection

### DIFF
--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -480,6 +480,9 @@ export class SceneTree {
         if (nextNode != null) {
           await this.selectItem(nextNode, options);
           this.lastSelectedItemId = id;
+        } else {
+          await selectItem(viewer, id, options);
+          this.lastSelectedItemId = id;
         }
       } else if (options.range && this.lastSelectedItemId != null) {
         const currentRowIndex = await this.controller?.expandParentNodes(id);


### PR DESCRIPTION
## Summary
This PR improves ancestor selection behavior. Specifically, now when a user has clicked a part enough times to select the entire tree, when they click the part again, the selection will be cleared and only the part will be selected. The process of selecting the part's ancestors can then be repeated if desired. 

## Test Plan
1. Click an item in the scene tree until the entire tree is selected
2. Click the item again. Note that the selection is cleared and only the part is selected now

## Release Notes
Improved ancestor selection

## Possible Regressions
Selection

## Dependencies
None