### PR TITLE
[PLAT-8321] Clear cross-section when unloading model view

### DIFF
--- a/packages/viewer/src/lib/model-views/controller.ts
+++ b/packages/viewer/src/lib/model-views/controller.ts
@@ -94,6 +94,16 @@ export class ModelViewController {
    * the scene view.
    */
   public async unload(): Promise<void> {
-    this.stream.updateModelView({}, true);
+    await this.stream.updateModelView({}, true);
+
+    // Clear any cross-section added from the model view
+    await this.stream.updateCrossSectioning(
+      {
+        crossSectioning: {
+          sectionPlanes: [],
+        },
+      },
+      true
+    );
   }
 }


### PR DESCRIPTION
## Summary
This PR ensures that the active cross-section planes are cleared when unloading a model view.

## Test Plan
Verify the active cross-section planes are cleared when unloading a model view

## Release Notes
Clear cross-section when unloading model view

## Possible Regressions
None

## Dependencies
None