### PR TITLE
[PLAT-8227] PDF paging support

### DIFF
--- a/packages/doc-viewer/index.html
+++ b/packages/doc-viewer/index.html
@@ -29,12 +29,125 @@
         width: 100%;
         height: 100%;
       }
+
+      svg {
+        fill: currentColor;
+      }
+
+      .toolbar {
+        display: flex;
+        gap: 1rem;
+        position: absolute;
+        bottom: 10px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 10;
+        background-color: #eeeeee;
+        padding: 0.25rem;
+        border-radius: 0.5rem;
+      }
+
+      .toolbar-button {
+        background-color: transparent;
+        border: none;
+        cursor: pointer;
+        font-size: 1rem;
+        padding: 0.5rem;
+        border-radius: 0.25rem;
+        color: #777777;
+      }
+
+      .toolbar-button.enabled {
+        color: #4db8db;
+      }
+
+      .controls {
+        display: flex;
+        gap: 1rem;
+        position: fixed;
+        bottom: 10px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 10;
+      }
     </style>
+
+    <script type="module">
+      async function main() {
+        await window.customElements.whenDefined('vertex-document-viewer');
+
+        const documentViewer = document.querySelector('vertex-document-viewer');
+        const modeButton = document.getElementById('interaction-mode-toggle');
+        const zoomInButton = document.getElementById('zoom-in-button');
+        const zoomOutButton = document.getElementById('zoom-out-button');
+        const loadNextPageButton = document.getElementById('load-next-page');
+        const loadPreviousPageButton = document.getElementById('load-previous-page');
+
+        modeButton.addEventListener('click', () => {
+          const updatedInteractionMode = documentViewer.interactionMode === 'pan' ? 'none' : 'pan';
+          documentViewer.interactionMode = updatedInteractionMode;
+
+          if (updatedInteractionMode === 'pan') {
+            modeButton.classList.add('enabled');
+          } else {
+            modeButton.classList.remove('enabled');
+          }
+        });
+
+        zoomInButton.addEventListener('click', () => {
+          documentViewer.zoomTo(documentViewer.documentState.zoomPercentage + 10);
+        });
+
+        zoomOutButton.addEventListener('click', () => {
+          documentViewer.zoomTo(documentViewer.documentState.zoomPercentage - 10);
+        });
+
+        loadNextPageButton.addEventListener('click', async () => {
+          await documentViewer.loadPage(documentViewer.documentState.loadedPageNumber + 1);
+        });
+        loadPreviousPageButton.addEventListener('click', async () => {
+          await documentViewer.loadPage(documentViewer.documentState.loadedPageNumber - 1);
+        });
+      }
+
+
+      window.addEventListener('DOMContentLoaded', main);
+    </script>
   </head>
   <body>
     <div class="app">
       <vertex-document-viewer src="{ PDF_URL }">
       </vertex-document-viewer> 
+
+      <div class="toolbar">
+        <button id="interaction-mode-toggle" class="enabled toolbar-button" title="Toggle Panning">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20">
+            <polygon points="15 8 13 6 13 7.5 8.5 7.5 8.5 3 10 3 8 1 6 3 7.5 3 7.5 7.5 3 7.5 3 6 1 8 3 10 3 8.5 7.5 8.5 7.5 13 6 13 8 15 10 13 8.5 13 8.5 8.5 13 8.5 13 10 15 8" />
+          </svg>
+        </button>
+        <button id="zoom-out-button" class="toolbar-button" title="Zoom Out">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 22" width="20" height="20">
+            <path transform="translate(4 8)" d="M8.2988873 0L0.71542132 0C0.31478536 0 0 0.44 0 1C0 1.5599999 0.31478536 2 0.71542132 2L8.2845783 2C8.685215 2 9 1.5599999 9 1C9 0.44 8.685215 0 8.2845783 0L8.2988873 0Z"/>
+            <path d="M21.764622 20.665239L15.126962 14.02284C16.413694 12.48394 17.135521 10.599572 17.135521 8.5738754C17.135521 3.8472519 13.291013 0 8.5677605 0C3.8445079 0 0 3.8315489 0 8.5581732C0 13.284797 3.8445079 17.132048 8.5677605 17.132048C10.57632 17.132048 12.490727 16.409708 14.028531 15.122056L20.666191 21.764454C20.823111 21.921484 21.027103 22 21.215406 22C21.403709 22 21.623396 21.921484 21.764622 21.764454C22.078459 21.450392 22.078459 20.963598 21.764622 20.649536L21.764622 20.665239ZM13.400856 13.630264C12.098431 14.870807 10.372325 15.561742 8.5677605 15.561742C4.7075605 15.561742 1.5691869 12.421127 1.5691869 8.5581732C1.5691869 4.6952176 4.7075605 1.5546038 8.5677605 1.5546038C12.42796 1.5546038 15.566334 4.6952176 15.566334 8.5581732C15.566334 10.489651 14.797432 12.295504 13.385164 13.630264L13.400856 13.630264Z"/>
+          </svg>
+        </button>
+        <button id="zoom-in-button" class="toolbar-button" title="Zoom In">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 21" width="20" height="20">
+            <path transform="translate(4 4)" d="M8.2857141 3.7857144L5.2142859 3.7857144L5.2142859 0.71428573C5.2142859 0.31428573 4.9000001 0 4.5 0C4.0999999 0 3.7857144 0.31428573 3.7857144 0.71428573L3.7857144 3.7857144L0.71428573 3.7857144C0.31428573 3.7857144 0 4.0999999 0 4.5C0 4.9000001 0.31428573 5.2142859 0.71428573 5.2142859L3.7857144 5.2142859L3.7857144 8.2857141C3.7857144 8.6857147 4.0999999 9 4.5 9C4.9000001 9 5.2142859 8.6857147 5.2142859 8.2857141L5.2142859 5.2142859L8.2857141 5.2142859C8.6857147 5.2142859 9 4.9000001 9 4.5C9 4.0999999 8.6857147 3.7857144 8.2857141 3.7857144Z"/>
+            <path d="M20.7903 19.72591L14.45435 13.385439C15.682596 11.916489 16.371613 10.117773 16.371613 8.1841545C16.371613 3.6723769 12.701855 0 8.1932955 0C3.684736 0 0 3.6573875 0 8.1691647C0 12.680943 3.6697576 16.353319 8.1783171 16.353319C10.095578 16.353319 11.922967 15.663812 13.39087 14.43469L19.726818 20.77516C19.876604 20.925053 20.071327 21 20.25107 21C20.430813 21 20.640514 20.925053 20.77532 20.77516C21.074894 20.475374 21.074894 20.010706 20.77532 19.71092L20.7903 19.72591ZM12.791726 13.010707C11.548502 14.19486 9.900856 14.85439 8.1783171 14.85439C4.4935808 14.85439 1.4978602 11.856531 1.4978602 8.1691647C1.4978602 4.4817986 4.5085592 1.48394 8.1932955 1.48394C11.878032 1.48394 14.873752 4.4817986 14.873752 8.1691647C14.873752 10.012848 14.1398 11.736617 12.791726 13.010707Z"/>
+          </svg>
+        </button>
+        <button id="load-previous-page" class="toolbar-button" title="Previous Page">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20">
+            <path d="M9.71,4a.51.51,0,0,0-.54.08l-4,3.5a.51.51,0,0,0,0,.76l4,3.5A.5.5,0,0,0,10,11.5v-7A.51.51,0,0,0,9.71,4Z" />
+          </svg>
+        </button>
+        <button id="load-next-page" class="toolbar-button" title="Next Page">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20">
+            <path d="M10.83,7.62l-4-3.5A.5.5,0,0,0,6,4.5v7a.5.5,0,0,0,.83.38l4-3.5a.51.51,0,0,0,0-.76Z" />
+          </svg>
+        </button>
+      </div>
    </div>
   </body>
 </html>

--- a/packages/doc-viewer/src/__mocks__/pdfjs-mock.ts
+++ b/packages/doc-viewer/src/__mocks__/pdfjs-mock.ts
@@ -20,7 +20,7 @@ export const mockGetDocument = jest.fn((): any => ({
 }));
 
 export const mockPdfDocument = {
-  numPages: 1,
+  numPages: 10,
   getPage: mockGetPage,
   getOptionalContentConfig: jest.fn(),
   destroy: mockDestroy,

--- a/packages/doc-viewer/src/components.d.ts
+++ b/packages/doc-viewer/src/components.d.ts
@@ -25,6 +25,11 @@ export namespace Components {
          */
         "interactionMode": InteractionMode;
         /**
+          * Loads a specific page of the currently loaded document.  Note that any offset applied by panning the document will be reset when loading a new page.
+          * @param pageNumber The page number to load.
+         */
+        "loadPage": (pageNumber: number) => Promise<void>;
+        /**
           * Pans the currently loaded document by the specified delta.  This method will be bounded to the visible portion of the document to ensure at least a portion of the document is always visible, and the `canvas` does not appear blank.
           * @param delta The delta to pan the document by.
          */

--- a/packages/doc-viewer/src/components/document-viewer/document-viewer.spec.ts
+++ b/packages/doc-viewer/src/components/document-viewer/document-viewer.spec.ts
@@ -10,25 +10,6 @@ describe('vertex-document-viewer', () => {
     jest.clearAllMocks();
   });
 
-  it('renders', async () => {
-    const { root } = await newSpecPage({
-      components: [VertexDocumentViewer],
-      html: '<vertex-document-viewer></vertex-document-viewer>',
-    });
-
-    expect(root).toEqualHtml(`
-      <vertex-document-viewer>
-        <mock:shadow-root>
-          <div class="viewer-container">
-            <div class="canvas-container">
-              <canvas></canvas>
-            </div>
-          </div>
-        </mock:shadow-root>
-      </vertex-document-viewer>
-    `);
-  });
-
   it('retrieves the document specified by the src property and loads the first page', async () => {
     const mockSrc = 'https://vertex3d.com';
 
@@ -88,5 +69,32 @@ describe('vertex-document-viewer', () => {
         }),
       }),
     );
+  });
+
+  describe('loadPage', () => {
+    it('loads a page by number', async () => {
+      const mockSrc = 'https';
+
+      const { root } = await newSpecPage({
+        components: [VertexDocumentViewer],
+        html: `<vertex-document-viewer src="${mockSrc}"></vertex-document-viewer>`,
+      });
+
+      const viewer = root as HTMLVertexDocumentViewerElement;
+      await viewer.loadPage(5);
+
+      expect(mockGetPage).toHaveBeenCalledWith(5);
+      expect(mockPageRender).toHaveBeenCalled();
+    });
+
+    it('throws an error if no document has been loaded and the API is not defined', async () => {
+      const { root } = await newSpecPage({
+        components: [VertexDocumentViewer],
+        html: '<vertex-document-viewer></vertex-document-viewer>',
+      });
+
+      const viewer = root as HTMLVertexDocumentViewerElement;
+      await expect(viewer.loadPage(1)).rejects.toThrow('No document has been loaded. Ensure that the `src` property is set and the resource is accessible.');
+    });
   });
 });

--- a/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
+++ b/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
@@ -101,7 +101,7 @@ export class VertexDocumentViewer {
    */
   @Method()
   public async panByDelta(delta: Point.Point): Promise<void> {
-    await this.documentApi?.panByDelta(delta);
+    await this.getDocumentApi().panByDelta(delta);
   }
 
   /**
@@ -114,7 +114,22 @@ export class VertexDocumentViewer {
    */
   @Method()
   public async zoomTo(percentage: number): Promise<void> {
-    await this.documentApi?.zoomTo(percentage);
+    await this.getDocumentApi().zoomTo(percentage);
+  }
+
+  /**
+   * Loads a specific page of the currently loaded document.
+   *
+   * Note that any offset applied by panning the document will be reset when loading
+   * a new page.
+   *
+   * @param pageNumber The page number to load.
+   */
+  @Method()
+  public async loadPage(pageNumber: number): Promise<void> {
+    const documentApi = this.getDocumentApi();
+
+    await documentApi.loadPage(pageNumber);
   }
 
   @Watch('src')
@@ -151,9 +166,19 @@ export class VertexDocumentViewer {
           >
             <canvas ref={el => (this.canvasEl = el)} />
           </div>
+
+          <slot></slot>
         </div>
       </Host>
     );
+  }
+
+  private getDocumentApi(): DocumentApi {
+    if (this.documentApi == null) {
+      throw new Error('No document has been loaded. Ensure that the `src` property is set and the resource is accessible.');
+    }
+
+    return this.documentApi;
   }
 
   private clearCurrentDocument(): void {

--- a/packages/doc-viewer/src/components/document-viewer/readme.md
+++ b/packages/doc-viewer/src/components/document-viewer/readme.md
@@ -18,6 +18,25 @@
 
 ## Methods
 
+### `loadPage(pageNumber: number) => Promise<void>`
+
+Loads a specific page of the currently loaded document.
+
+Note that any offset applied by panning the document will be reset when loading
+a new page.
+
+#### Parameters
+
+| Name         | Type     | Description              |
+| ------------ | -------- | ------------------------ |
+| `pageNumber` | `number` | The page number to load. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `panByDelta(delta: Point.Point) => Promise<void>`
 
 Pans the currently loaded document by the specified delta.

--- a/packages/doc-viewer/src/lib/document/api.ts
+++ b/packages/doc-viewer/src/lib/document/api.ts
@@ -10,6 +10,7 @@ export interface DocumentApiState {
   readonly contentDimensions?: Dimensions.Dimensions;
   readonly panOffset: Point.Point;
   readonly loadedPageNumber?: number;
+  readonly totalPageCount?: number;
 }
 
 /**

--- a/packages/doc-viewer/src/lib/pdf/__tests__/pdfjs-api.spec.ts
+++ b/packages/doc-viewer/src/lib/pdf/__tests__/pdfjs-api.spec.ts
@@ -57,6 +57,20 @@ describe('PdfJsApi', () => {
         }),
       );
     });
+
+    it('throws an error if the page number is less than 1', async () => {
+      const api = new PdfJsApi();
+      await api.load('https');
+
+      await expect(api.loadPage(0)).rejects.toThrow('Unable to load page 0. The provided page number must be greater than 0.');
+    });
+
+    it('throws an error if the page number is greater than the total number of pages in the document', async () => {
+      const api = new PdfJsApi();
+      await api.load('https');
+
+      await expect(api.loadPage(100)).rejects.toThrow('Unable to load page 100. The document only has 10 page(s).');
+    });
   });
 
   describe('dispose', () => {

--- a/packages/doc-viewer/src/lib/pdf/pdfjs-api.ts
+++ b/packages/doc-viewer/src/lib/pdf/pdfjs-api.ts
@@ -28,17 +28,25 @@ export class PdfJsApi extends DocumentApi<PdfJsApiState> {
     if (resource.resource.type === 'url') {
       const document = await pdfjs.getDocument(resource.resource.url).promise;
 
-      this.updateState({ document });
+      this.updateState({ document, totalPageCount: document.numPages });
     } else {
       throw new Error('Invalid resource URI provided. Expected a URL to retrieve a PDF.');
     }
   }
 
   public async loadPage(pageNumber: number): Promise<void> {
+    const totalPageCount = this.state.totalPageCount ?? 1;
+
+    if (pageNumber <= 0) {
+      throw new Error(`Unable to load page ${pageNumber}. The provided page number must be greater than 0.`);
+    } else if (pageNumber > totalPageCount) {
+      throw new Error(`Unable to load page ${pageNumber}. The document only has ${totalPageCount} page(s).`);
+    }
+
     const page = await this.state.document?.getPage(pageNumber);
     const baseViewport = page?.getViewport({ scale: 1 });
     const contentDimensions = baseViewport != null ? Dimensions.create(baseViewport.width, baseViewport.height) : undefined;
 
-    this.updateState({ loadedPageNumber: pageNumber, contentDimensions });
+    this.updateState({ loadedPageNumber: pageNumber, contentDimensions, panOffset: Point.create(0, 0) });
   }
 }

--- a/packages/doc-viewer/src/lib/pdf/pdfjs-renderer.ts
+++ b/packages/doc-viewer/src/lib/pdf/pdfjs-renderer.ts
@@ -53,9 +53,17 @@ export class PdfJsRenderer extends DocumentRenderer {
       const scaleY = dimensions.height / baseViewport.height;
       const baseScale = Math.max(0.1, Math.min(scaleX, scaleY));
 
+      // If the zoom percentage or viewport dimensions result in a situation where the content
+      // has been scaled down to a point where the horizontal dimension is smaller than the viewport,
+      // adjust the current panOffset by the difference between the viewport width and the scaled width.
+      // This ensures that the content is always centered in the viewport horizontally.
+      const effectiveScale = baseScale * (zoomPercentage / 100);
+      const scaledWidth = baseViewport.width * effectiveScale;
+      const centerOffsetX = Math.max(0, (dimensions.width - scaledWidth) / 2);
+
       const scaled = page.getViewport({
-        scale: baseScale * (zoomPercentage / 100),
-        offsetX: panOffset.x,
+        scale: effectiveScale,
+        offsetX: panOffset.x + centerOffsetX,
         offsetY: panOffset.y,
       });
 
@@ -63,7 +71,6 @@ export class PdfJsRenderer extends DocumentRenderer {
         canvas: this.canvas,
         viewport: scaled,
         intent: 'display',
-        background: '#ffffff',
         optionalContentConfigPromise: document.getOptionalContentConfig(),
       }).promise;
 

--- a/packages/viewer/src/components/viewer-walk-mode-tool/viewer-walk-mode-tool.spec.tsx
+++ b/packages/viewer/src/components/viewer-walk-mode-tool/viewer-walk-mode-tool.spec.tsx
@@ -62,7 +62,7 @@ describe('vertex-viewer-walk-mode-tool', () => {
     const tool = viewer.querySelector(
       'vertex-viewer-walk-mode-tool'
     ) as HTMLVertexViewerWalkModeToolElement;
-    const teleportTool = tool.shadowRoot?.querySelector(
+    const teleportTool = tool.querySelector(
       'vertex-viewer-teleport-tool'
     ) as HTMLVertexViewerTeleportToolElement;
 
@@ -86,7 +86,7 @@ describe('vertex-viewer-walk-mode-tool', () => {
     const tool = viewer.querySelector(
       'vertex-viewer-walk-mode-tool'
     ) as HTMLVertexViewerWalkModeToolElement;
-    const teleportTool = tool.shadowRoot?.querySelector(
+    const teleportTool = tool.querySelector(
       'vertex-viewer-teleport-tool'
     ) as HTMLVertexViewerTeleportToolElement;
 
@@ -110,7 +110,7 @@ describe('vertex-viewer-walk-mode-tool', () => {
     const tool = viewer.querySelector(
       'vertex-viewer-walk-mode-tool'
     ) as HTMLVertexViewerWalkModeToolElement;
-    const teleportTool = tool.shadowRoot?.querySelector(
+    const teleportTool = tool.querySelector(
       'vertex-viewer-teleport-tool'
     ) as HTMLVertexViewerTeleportToolElement;
 

--- a/packages/viewer/src/components/viewer-walk-mode-tool/viewer-walk-mode-tool.tsx
+++ b/packages/viewer/src/components/viewer-walk-mode-tool/viewer-walk-mode-tool.tsx
@@ -233,15 +233,12 @@ export class ViewerWalkModeTool {
       if (slottedTeleportTool != null) {
         this.stateMap.teleportTool = slottedTeleportTool;
       } else {
-        const slot: HTMLSlotElement | undefined =
-          this.hostEl?.shadowRoot?.querySelector(
-            'slot[name="teleport-tool"]'
-          ) ?? undefined;
-
         this.stateMap.teleportTool = document.createElement(
           'vertex-viewer-teleport-tool'
         );
-        slot?.appendChild(this.stateMap.teleportTool);
+        this.stateMap.teleportTool.slot = 'teleport-tool';
+
+        this.hostEl?.appendChild(this.stateMap.teleportTool);
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds support for paging a PDF document. As part of this work, the logic for where the PDF is actually drawn on the canvas has also been updated to keep it centered horizontally (similar to browser PDF viewers). The `index.html` for the doc-viewer package has also been updated with a toolbar for controlling the interaction mode, zoom level, and current page.

Additionally, as part of this work, I've fixed a bug with the `<viewer-walk-mode-tool>` element I noticed after trying to run all the examples after #741. The `onSlotchange` behavior appears to have regressed - I'm assuming this is related to underlying browser implementation, but ultimately adding the teleport tool as a direct child of the `<slot>` element was not properly adding the element, causing the `ensureTeleportToolConfigured` method to always append a new child. This would trigger the `onSlotchange` callback, and since it could not find the element, it would attempt to add it again, repeating this cycle indefinitely. I spent a bit of time trying to get a test to capture this, but ultimately left it as-is with slightly modified tests, as the behavior in the JSDOM simulated environment was not consistent with browser behavior.

## Test Plan

- Verify that the `<vertex-document-viewer>` element can page forward and backward
- Verify that the `<vertex-walk-mode-tool>` does not cause infinite re-renders when loaded without a slotted tool element

## Release Notes

N/A

## Possible Regressions

`<vertex-walk-mode-tool>` default behavior

## Dependencies

N/A
