### PR TITLE
[PLAT-8195] Emit event when scene tree search has finished

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -2331,9 +2331,15 @@ declare namespace LocalJSX {
      */
     disabled?: boolean;
     /**
-     * An event that is emitted when a user has inputted or cleared the search term. The event may be delayed according to the current `debounce` value.
+     * An event that is emitted when a user has changed or cleared the search term. The event may be delayed according to the current `debounce` value.
      */
     onSearch?: (event: VertexSceneTreeSearchCustomEvent<string>) => void;
+    /**
+     * An event that is emitted when a search has completed.
+     */
+    onSearchCompleted?: (
+      event: VertexSceneTreeSearchCustomEvent<string>
+    ) => void;
     /**
      * Placeholder text if `value` is empty.
      */

--- a/packages/viewer/src/components/scene-tree-search/readme.md
+++ b/packages/viewer/src/components/scene-tree-search/readme.md
@@ -29,9 +29,10 @@ functionality will need to be wired programmatically to
 
 ## Events
 
-| Event    | Description                                                                                                                                       | Type                  |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `search` | An event that is emitted when a user has inputted or cleared the search term. The event may be delayed according to the current `debounce` value. | `CustomEvent<string>` |
+| Event             | Description                                                                                                                                      | Type                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| `search`          | An event that is emitted when a user has changed or cleared the search term. The event may be delayed according to the current `debounce` value. | `CustomEvent<string>` |
+| `searchCompleted` | An event that is emitted when a search has completed.                                                                                            | `CustomEvent<string>` |
 
 
 ## Methods

--- a/packages/viewer/src/components/scene-tree-search/scene-tree-search.tsx
+++ b/packages/viewer/src/components/scene-tree-search/scene-tree-search.tsx
@@ -64,11 +64,17 @@ export class SceneTreeSearch {
   public value = '';
 
   /**
-   * An event that is emitted when a user has inputted or cleared the search
+   * An event that is emitted when a user has changed or cleared the search
    * term. The event may be delayed according to the current `debounce` value.
    */
   @Event({ bubbles: true })
   public search!: EventEmitter<string>;
+
+  /**
+   * An event that is emitted when a search has completed.
+   */
+  @Event({ bubbles: true })
+  public searchCompleted!: EventEmitter<string>;
 
   @State()
   private focused = false;
@@ -234,6 +240,12 @@ export class SceneTreeSearch {
 
     this.onStateChangeDisposable = this.controller?.onStateChange.on(
       (state) => {
+        // If a search was previously being performed, but has now finished,
+        // emit the event that the search has completed.
+        if (this.isSearching && !state.isSearching) {
+          this.searchCompleted.emit(this.value);
+        }
+
         this.isSearching = state.isSearching;
       }
     );


### PR DESCRIPTION
## Summary
This PR adds an event emitter that emits an event when a search has completed in the scene tree.

## Test Plan
Verify the event is emitted when a search has complete in the scene tree

## Release Notes
Emit event when scene tree search has finished

## Possible Regressions
None

## Dependencies
None