### PR TITLE
[PLAT-8122] Minor improvements to color util

### DIFF
--- a/packages/utils/src/__tests__/color.test.ts
+++ b/packages/utils/src/__tests__/color.test.ts
@@ -4,8 +4,10 @@ describe(Color.fromNumber, () => {
   it('converts a number to a color', () => {
     const black = Color.fromNumber(0x000000);
     const white = Color.fromNumber(0xffffff);
+    const color3 = Color.fromNumber(0x00ff00aa, true);
     expect(black).toEqual({ r: 0, g: 0, b: 0, a: 255 });
     expect(white).toEqual({ r: 255, g: 255, b: 255, a: 255 });
+    expect(color3).toEqual({ r: 0, g: 255, b: 0, a: 170 });
   });
 });
 
@@ -16,32 +18,46 @@ describe(Color.fromHexString, () => {
   });
 
   it('should parse 0x00ff00', () => {
-    const color = Color.fromHexString('0x00ff00');
-    expect(color).toEqual(Color.create(0, 255, 0));
+    const color = Color.fromHexString('0xff0000');
+    expect(color).toEqual(Color.create(255, 0, 0));
   });
 
   it('should parse 00ff00', () => {
-    const color = Color.fromHexString('00ff00');
-    expect(color).toEqual(Color.create(0, 255, 0));
+    const color = Color.fromHexString('0000ff');
+    expect(color).toEqual(Color.create(0, 0, 255));
+  });
+
+  it('should parse alpha too', () => {
+    const color = Color.fromHexString('#00ff00aa');
+    expect(color).toEqual(Color.create(0, 255, 0, 170));
   });
 });
 
 describe(Color.fromCss, () => {
   it('converts rgb(num, num, num)', () => {
-    const css = 'rgb(1, 2, 3)';
-    const color = Color.fromCss(css);
+    const color = Color.fromCss('rgb(1, 2, 3)');
     expect(color).toEqual({ r: 1, g: 2, b: 3, a: 255 });
   });
 
   it('converts rgba(num, num, num, num)', () => {
-    const css = 'rgba(1, 2, 3, 0.5)';
-    const color = Color.fromCss(css);
-    expect(color).toEqual({ r: 1, g: 2, b: 3, a: 127 });
+    const color = Color.fromCss('rgba(100, 200, 30, 0.5)');
+    expect(color).toEqual({ r: 100, g: 200, b: 30, a: 127 });
+    const color2 = Color.fromCss('rgba(45, 90, 120, 1)');
+    expect(color2).toEqual({ r: 45, g: 90, b: 120, a: 255 });
   });
 
-  it('converts #00ff00', () => {
+  it('converts rgb hex #00ff00', () => {
     const color = Color.fromCss('#00ff00');
     expect(color).toEqual(Color.create(0, 255, 0));
+    const color2 = Color.fromCss('#aabbcc');
+    expect(color2).toEqual({ r: 170, g: 187, b: 204, a: 255 });
+  });
+
+  it('converts rgba hex #00ff00ff', () => {
+    const color = Color.fromCss('#00ff00aa');
+    expect(color).toEqual(Color.create(0, 255, 0, 170));
+    const color2 = Color.fromCss('#aabbccdd');
+    expect(color2).toEqual({ r: 170, g: 187, b: 204, a: 221 });
   });
 });
 

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -1,52 +1,40 @@
-const rgbRegex = /rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/;
-const rgbaRegex = /rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(.+)\s*\)/;
-const hexRegex = /^(#|0x)?([A-Fa-f0-9]{6})$/;
+const hexRegex = /^(#|0x)?([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$/;
 
 /**
  * A `Color` represents an object containing values for red, green, blue and
  * alpha channels. Each value represents a number between 0 and 255.
  */
 export interface Color {
-  /**
-   * The color's red channel value, as a number from 0 to 255.
-   */
-  r: number;
-
-  /**
-   * The color's green channel value, as a number from 0 to 255.
-   */
-  g: number;
-
-  /**
-   * The color's blue channel value, as a number from 0 to 255.
-   */
-  b: number;
-
-  /**
-   * The color's alpha channel value, as a number from 0 to 255.
-   */
-  a: number;
+  r: number; // red channel value, from 0 to 255.
+  g: number; // green channel value, from 0 to 255.
+  b: number; // blue channel value, from 0 to 255.
+  a: number; // alpha channel value, from 0 to 255.
 }
 
 /**
  * Constructs a new color with the given red, green, blue and alpha values. If
  * alpha is undefined, defaults to 1.
  */
-export const create = (r: number, g: number, b: number, a = 255): Color => {
-  return { r, g, b, a };
-};
+export const create = (r: number, g: number, b: number, a = 255): Color => ({
+  r,
+  g,
+  b,
+  a,
+});
 
 /**
  * Converts a numeric color value containing red, green and blue values to a
  * `Color`. The alpha channel will default to fully opaque.
  */
-export const fromNumber = (num: number): Color => {
+export const fromNumber = (num: number, hasAlpha = false): Color => {
   // tslint:disable:no-bitwise
-  const normalized = num & 0xffffff;
+  const value = hasAlpha ? num : ((num & 0xffffff) << 8) | 0xff;
+
   return create(
-    (normalized >> 16) & 0xff,
-    (normalized >> 8) & 0xff,
-    normalized & 0xff
+    (value >> 24) & 0xff,
+    (value >> 16) & 0xff,
+    (value >> 8) & 0xff,
+    value & 0xff
   );
   // tslint:enable:no-bitwise
 };
@@ -59,35 +47,30 @@ export const fromNumber = (num: number): Color => {
 export const fromHexString = (str: string): Color | undefined => {
   const match = hexRegex.exec(str);
   if (match != null) {
-    return fromNumber(parseInt(match[2], 16));
+    const hex = match[2];
+    return fromNumber(parseInt(hex, 16), hex.length === 8);
   }
 };
 
 /**
  * Creates a `Color` from a CSS color value. This function currently only
  * supports `rgb(255, 255, 255)`, `rgba(255, 255, 255, 0.5)` or `"#FFFFFF"`.
- * Returns `undefined` if the color cannot be parsed.
+ * expects valid css color strings.
+ * @returns Color or `undefined` if the color cannot be parsed.
  */
 export const fromCss = (css: string): Color | undefined => {
-  const rgbMatch = rgbRegex.exec(css);
-  if (rgbMatch != null) {
+  if (css.startsWith('rgb')) {
+    const numbers = extractNumbersFromString(css);
+    if (numbers.length <= 3) {
+      return create(numbers[0], numbers[1], numbers[2]);
+    }
     return create(
-      parseInt(rgbMatch[1]),
-      parseInt(rgbMatch[2]),
-      parseInt(rgbMatch[3])
+      numbers[0],
+      numbers[1],
+      numbers[2],
+      Math.floor(Number(`${numbers[3]}.${numbers[4] ?? 0}`) * 255)
     );
   }
-
-  const rgbaMatch = rgbaRegex.exec(css);
-  if (rgbaMatch != null) {
-    return create(
-      parseInt(rgbaMatch[1]),
-      parseInt(rgbaMatch[2]),
-      parseInt(rgbaMatch[3]),
-      Math.floor(parseFloat(rgbaMatch[4]) * 255)
-    );
-  }
-
   if (hexRegex.test(css)) {
     return fromHexString(css);
   }
@@ -104,28 +87,31 @@ export const fromArray = (rgba: number[] | Uint8ClampedArray): Color => {
 /**
  * Returns `true` if the color's alpha channel is 0.
  */
-export const isInvisible = (color: Color): boolean => {
-  return color.a === 0;
-};
+export const isInvisible = (color: Color): boolean => color.a === 0;
 
 /**
  * Returns `true` if the alpha channel of this color is fully opaque (255).
  */
-export const isOpaque = (color: Color): boolean => {
-  return color.a === 255;
-};
+export const isOpaque = (color: Color): boolean => color.a === 255;
 
 /**
- * Converts a `Color` to a hex string. The returned string will be prefixed with
- * `#`.
+ * Converts a `Color` to a hex string - prefixed with `#`. ignores alpha value.
  */
-export const toHexString = (color: Omit<Color, 'a'>): string => {
-  return `#${componentToHex(color.r)}${componentToHex(color.g)}${componentToHex(
-    color.b
-  )}`;
-};
+export const toHexString = (color: Omit<Color, 'a'>): string =>
+  `#${componentToHex(color.r)}${componentToHex(color.g)}${componentToHex(color.b)}`;
 
+/**
+ * Takes rgb(a) component numeric value (0-255) and converts it to hexidecimal
+ */
 const componentToHex = (num: number): string => {
   const hex = num.toString(16);
   return hex.length === 1 ? '0' + hex : hex;
+};
+
+const extractNumbersFromString = (stringWithNumbers: string): number[] => {
+  const matches = stringWithNumbers.match(/\d+/g); // Matches all digits in the string
+  if (matches) {
+    return matches.map(Number); // Converts each match to a number
+  }
+  return []; // Return an empty array if no numbers are found
 };

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -98,12 +98,12 @@ export const isOpaque = (color: Color): boolean => color.a === 255;
  * Converts a `Color` to a hex string - prefixed with `#`. ignores alpha value.
  */
 export const toHexString = (color: Omit<Color, 'a'>): string =>
-  `#${componentToHex(color.r)}${componentToHex(color.g)}${componentToHex(color.b)}`;
+  `#${hexify(color.r)}${hexify(color.g)}${hexify(color.b)}`;
 
 /**
  * Takes rgb(a) component numeric value (0-255) and converts it to hexidecimal
  */
-const componentToHex = (num: number): string => {
+const hexify = (num: number): string => {
   const hex = num.toString(16);
   return hex.length === 1 ? '0' + hex : hex;
 };


### PR DESCRIPTION
## Summary

Make it so color util so can handle alpha channel for hex color stings and make a mildly more performant version of fromCss 

Wasn't directly related to React or Stencil upgrades, but was sort of result of initial experiments towards that work which is why is is tagged with that issue.

## Test Plan
Unit tests added and expanded

Test is vertex connect app, examples, or starter repo potentially

Could get good incidental coverage in manual and integration tests for 1.0 release testing

## Release Notes
Should be no breaking changes 
Now if using #rrggbbaa version of css hex colors has better chance of working

## Possible Regressions
Not a regression, but a note as I looked into this -  No gaurds against bad color numbers, for example. if user gave "rgb(453, -888, 515)" this is not a valid color, but chrome based browsers appear to just treat it as "rgb(255, 0, 255)" 

## Dependencies
n/a