### PR TITLE
[PLAT-8381] Add document ID prop

### DIFF
--- a/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
+++ b/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
@@ -28,6 +28,16 @@ export class VertexDocumentViewer {
   @Prop() public src?: string;
 
   /**
+   * The ID of the loaded `Document`. This ID is required to enable persistence of
+   * annotations.
+   *
+   * Note that this is different than a `File` ID within the Vertex Platform, and must
+   * be created separately using the `/documents` endpoints.
+   * See https://docs.vertex3d.com/ for more details.
+   */
+  @Prop({ reflect: true }) public documentId?: string;
+
+  /**
    * The provider used to create the document API and renderer.
    */
   @Prop({ mutable: true }) public provider: DocumentProvider = new PdfJsProvider();


### PR DESCRIPTION
## Summary

Title says it all - just adding a `documentId` prop to support creation of `DocumentReference`s.

## Test Plan

- Verify the `documentId` property is accessible on the element

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
