### PR TITLE
[PLAT-7985] Unload model view

### DIFF
--- a/packages/viewer/src/lib/model-views/controller.ts
+++ b/packages/viewer/src/lib/model-views/controller.ts
@@ -95,15 +95,5 @@ export class ModelViewController {
    */
   public async unload(): Promise<void> {
     await this.stream.updateModelView({}, true);
-
-    // Clear any cross-section added from the model view
-    await this.stream.updateCrossSectioning(
-      {
-        crossSectioning: {
-          sectionPlanes: [],
-        },
-      },
-      true
-    );
   }
 }


### PR DESCRIPTION
## Summary
This PR reverts https://github.com/Vertexvis/vertex-web-sdk/pull/743, as we now handle clearing the cross-section when unloading a model view on the backend.

## Test Plan
Verify the active cross-section planes are cleared when unloading a model view

## Release Notes
None

## Possible Regressions
Clearing model views

## Dependencies
None