### PR TITLE
[PLAT-8475] Publish doc-viewer and doc-viewer-react

### DIFF
--- a/packages/doc-viewer-react/package.json
+++ b/packages/doc-viewer-react/package.json
@@ -18,7 +18,10 @@
   "files": [
     "dist/*"
   ],
-  "private": "true",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "scripts": {
     "clean": "rm -fr ./dist && mkdir ./dist",
     "prebuild": "yarn clean",

--- a/packages/doc-viewer/package.json
+++ b/packages/doc-viewer/package.json
@@ -51,7 +51,10 @@
     "loader/",
     "LICENSE"
   ],
-  "private": "true",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "scripts": {
     "prebuild": "mkdir -p assets && cp ../../node_modules/pdfjs-dist/build/pdf.worker.min.mjs ./assets",
     "build": "stencil build",


### PR DESCRIPTION
## Summary

Updates the package.json of `@vertexvis/doc-viewer` and `@vertexvis/doc-viewer-react` to publish these packages to the public registry. This PR does not update `@vertexvis/doc-viewer-vue`, as this was unintentionally already published 🙃.

## Test Plan

- Verify `@vertexvis/doc-viewer` and `@vetexvis/doc-viewer-react` are available on the public NPM registry

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
