### PR TITLE
[PLAT-8423] Fix arrow markup clipping

### DIFF
--- a/packages/doc-viewer-react/package.json
+++ b/packages/doc-viewer-react/package.json
@@ -18,7 +18,10 @@
   "files": [
     "dist/*"
   ],
-  "private": "true",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "scripts": {
     "clean": "rm -fr ./dist && mkdir ./dist",
     "prebuild": "yarn clean",

--- a/packages/doc-viewer/package.json
+++ b/packages/doc-viewer/package.json
@@ -51,7 +51,10 @@
     "loader/",
     "LICENSE"
   ],
-  "private": "true",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "scripts": {
     "prebuild": "mkdir -p assets && cp ../../node_modules/pdfjs-dist/build/pdf.worker.min.mjs ./assets",
     "build": "stencil build",

--- a/packages/doc-viewer/package.json
+++ b/packages/doc-viewer/package.json
@@ -43,6 +43,9 @@
     "./assets/pdf.worker.min.mjs": {
       "import": "./assets/pdf.worker.min.mjs",
       "default": "./assets/pdf.worker.min.mjs"
+    },
+    "./dist/doc-viewer/doc-viewer.css": {
+      "default": "./dist/doc-viewer/doc-viewer.css"
     }
   },
   "files": [

--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -1119,7 +1119,7 @@ export namespace Components {
      *
      * When provided, all computed coordinates will be scaled by this amount.
      */
-    scale?: number;
+    scale: number;
     /**
      * Indicates if new markup should be automatically selected.
      */
@@ -1186,7 +1186,7 @@ export namespace Components {
      *
      * When provided, all computed coordinates will be scaled by this amount.
      */
-    scale?: number;
+    scale: number;
     /**
      * The position of the starting anchor. Can either be an instance of a `Point` or a JSON string representation in the format of `[x, y]` or `{"x": 0, "y": 0}`.
      *
@@ -1251,7 +1251,7 @@ export namespace Components {
      *
      * When provided, all computed coordinates will be scaled by this amount.
      */
-    scale?: number;
+    scale: number;
     /**
      * The viewer to connect to markups.
      *
@@ -1312,7 +1312,7 @@ export namespace Components {
      *
      * When provided, all computed coordinates will be scaled by this amount.
      */
-    scale?: number;
+    scale: number;
     /**
      * The viewer to connect to markups.
      *
@@ -1370,7 +1370,7 @@ export namespace Components {
      *
      * When provided, all computed coordinates will be scaled by this amount.
      */
-    scale?: number;
+    scale: number;
     /**
      * The style of the starting anchor. This defaults to none.
      */

--- a/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.tsx
+++ b/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.tsx
@@ -369,7 +369,7 @@ export class ViewerMarkupArrow {
           <Host>
             <svg class="svg" onTouchStart={this.handleTouchStart}>
               <defs>
-                <SvgShadow id="arrow-shadow" />
+                <SvgShadow id="arrow-shadow" scale={this.scale} />
               </defs>
               <g
                 transform={`translate(${offsetX} ${offsetY})`}

--- a/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
+++ b/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
@@ -265,7 +265,7 @@ export class ViewerMarkupCircle {
         <Host>
           <svg class="svg" onTouchStart={this.handleTouchStart}>
             <defs>
-              <SvgShadow id="circle-shadow" />
+              <SvgShadow id="circle-shadow" scale={this.scale} />
             </defs>
             <g
               transform={`translate(${offsetX} ${offsetY})`}

--- a/packages/viewer/src/components/viewer-markup-freeform/viewer-markup-freeform.tsx
+++ b/packages/viewer/src/components/viewer-markup-freeform/viewer-markup-freeform.tsx
@@ -289,7 +289,7 @@ export class ViewerMarkupFreeform {
         <Host>
           <svg class="svg" onTouchStart={this.handleTouchStart}>
             <defs>
-              <SvgShadow id="freeform-markup-shadow" />
+              <SvgShadow id="freeform-markup-shadow" scale={this.scale} />
             </defs>
             <g
               transform={`translate(${offsetX} ${offsetY})`}

--- a/packages/viewer/src/components/viewer-markup/viewer-markup-components.tsx
+++ b/packages/viewer/src/components/viewer-markup/viewer-markup-components.tsx
@@ -42,11 +42,33 @@ export const RelativeAnchor: FunctionalComponent<RelativeAnchorProps> = (
 
 export interface SvgShadowProps {
   id: string;
+  scale?: number;
 }
 
-export const SvgShadow: FunctionalComponent<SvgShadowProps> = ({ id }) => {
+export const SvgShadow: FunctionalComponent<SvgShadowProps> = ({
+  id,
+  scale,
+}) => {
+  // Scale default values for a `<filter>` element by the provided scale.
+  // This prevents the filter area from being too small when scale is greater than 1,
+  // and uses the default values for a scale less than 1 to prevent the same issue.
+  // See https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/filter
+  // for more details on the default values used here.
+  const effectiveScale = scale ?? 1;
+  const xOffset = Math.max(10, 10 * effectiveScale);
+  const yOffset = Math.max(10, 10 * effectiveScale);
+  const width = Math.max(120, 110 * effectiveScale + xOffset);
+  const height = Math.max(120, 110 * effectiveScale + yOffset);
+
   return (
-    <filter id={id}>
+    <filter
+      id={id}
+      filterUnits="userSpaceOnUse"
+      x={`${-xOffset}%`}
+      y={`${-yOffset}%`}
+      width={`${width}%`}
+      height={`${height}%`}
+    >
       <feGaussianBlur in="SourceAlpha" stdDeviation="2" />
       <feOffset dx="0" dy="1" result="offsetblur" />
       <feFlood flood-color="#000000" flood-opacity="0.25" />

--- a/packages/viewer/src/components/viewer-markup/viewer-markup.spec.tsx
+++ b/packages/viewer/src/components/viewer-markup/viewer-markup.spec.tsx
@@ -394,6 +394,99 @@ describe('vertex-viewer-markup', () => {
     });
   });
 
+  describe('scaling markup', () => {
+    it('scales markup shadows up in size when scaled up', async () => {
+      const page = await newSpecPage({
+        components: [
+          ViewerMarkup,
+          ViewerMarkupArrow,
+          ViewerMarkupCircle,
+          ViewerMarkupFreeform,
+        ],
+        html: `<vertex-viewer-markup>
+          <vertex-viewer-markup-arrow start="[-0.25, 0]" end="[0, 0]"></vertex-viewer-markup-arrow>
+          <vertex-viewer-markup-circle bounds="[0,0,0.5,0.5]"></vertex-viewer-markup-circle>
+          <vertex-viewer-markup-freeform points="[[0,0],[0.5,0.5]]"></vertex-viewer-markup-freeform>
+        </vertex-viewer-markup>`,
+      });
+
+      const el = page.root as HTMLVertexViewerMarkupElement;
+      const arrow = el.querySelector(
+        'vertex-viewer-markup-arrow'
+      ) as HTMLVertexViewerMarkupArrowElement;
+      const circle = el.querySelector(
+        'vertex-viewer-markup-circle'
+      ) as HTMLVertexViewerMarkupCircleElement;
+      const freeform = el.querySelector(
+        'vertex-viewer-markup-freeform'
+      ) as HTMLVertexViewerMarkupFreeformElement;
+
+      el.scale = 2;
+      await page.waitForChanges();
+
+      [arrow, circle, freeform].forEach((el) => {
+        console.log(el.tagName);
+        expect(el.shadowRoot?.querySelector('filter')?.getAttribute('x')).toBe(
+          '-20%'
+        );
+        expect(el.shadowRoot?.querySelector('filter')?.getAttribute('y')).toBe(
+          '-20%'
+        );
+        expect(
+          el.shadowRoot?.querySelector('filter')?.getAttribute('width')
+        ).toBe('240%');
+        expect(
+          el.shadowRoot?.querySelector('filter')?.getAttribute('height')
+        ).toBe('240%');
+      });
+    });
+
+    it('keeps markup shadows at the default size when scaled down', async () => {
+      const page = await newSpecPage({
+        components: [
+          ViewerMarkup,
+          ViewerMarkupArrow,
+          ViewerMarkupCircle,
+          ViewerMarkupFreeform,
+        ],
+        html: `<vertex-viewer-markup>
+          <vertex-viewer-markup-arrow start="[-0.25, 0]" end="[0, 0]"></vertex-viewer-markup-arrow>
+          <vertex-viewer-markup-circle bounds="[0,0,0.5,0.5]"></vertex-viewer-markup-circle>
+          <vertex-viewer-markup-freeform points="[[0,0],[0.5,0.5]]"></vertex-viewer-markup-freeform>
+        </vertex-viewer-markup>`,
+      });
+
+      const el = page.root as HTMLVertexViewerMarkupElement;
+      const arrow = el.querySelector(
+        'vertex-viewer-markup-arrow'
+      ) as HTMLVertexViewerMarkupArrowElement;
+      const circle = el.querySelector(
+        'vertex-viewer-markup-circle'
+      ) as HTMLVertexViewerMarkupCircleElement;
+      const freeform = el.querySelector(
+        'vertex-viewer-markup-freeform'
+      ) as HTMLVertexViewerMarkupFreeformElement;
+
+      el.scale = 0.5;
+      await page.waitForChanges();
+
+      [arrow, circle, freeform].forEach((el) => {
+        expect(el.shadowRoot?.querySelector('filter')?.getAttribute('x')).toBe(
+          '-10%'
+        );
+        expect(el.shadowRoot?.querySelector('filter')?.getAttribute('y')).toBe(
+          '-10%'
+        );
+        expect(
+          el.shadowRoot?.querySelector('filter')?.getAttribute('width')
+        ).toBe('120%');
+        expect(
+          el.shadowRoot?.querySelector('filter')?.getAttribute('height')
+        ).toBe('120%');
+      });
+    });
+  });
+
   describe('query markup', () => {
     it('returns markup with id', async () => {
       const page = await newSpecPage({


### PR DESCRIPTION
## Summary

After the changes in #757, `<vertex-viewer-markup-arrow>` elements could experience clipping of the left and right sides of the arrowhead. This was particularly noticeable if the `--viewer-markup-arrow-head-stroke-width` value was set higher than `4px`. This PR re-introduces the `filterUnits="userSpaceOnUse"` parameter we were previously using, but now accounts for the `scale` of the element as well to ensure we scale the default `x`, `y`, `width`, and `height` values up if the scale could cause the markup to appear outside the initially computed bounds via `transform`. In the case of a `scale` less than one, we maintain the default bounds, as the transform will not cause the markup to be clipped.

This PR also includes a small adjustment to the `exports` config of the `@vertexvis/doc-viewer` package to export the `doc-viewer.css` file.

## Test Plan

- Verify that an arrow with the default arrowhead drawn parallel to the X or Y axis on-screen does not have the left and right sides of the arrowhead clipped
- Verify that scaling markup up and down does not cause unexpected clipping

## Release Notes

N/A

## Possible Regressions

Markup clipping when `scale` is provided

## Dependencies

N/A
