### PR TITLE
[PLAT-8373] Include doc-viewer loader + assets

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -32,6 +32,8 @@ jobs:
           path: |
             packages/*/dist
             packages/viewer/loader
+            packages/doc-viewer/loader
+            packages/doc-viewer/assets
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,6 +33,8 @@ jobs:
           path: |
             packages/*/dist
             packages/viewer/loader
+            packages/doc-viewer/loader
+            packages/doc-viewer/assets
 
   detect-publish-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,6 +31,8 @@ jobs:
           path: |
             packages/*/dist
             packages/viewer/loader
+            packages/doc-viewer/loader
+            packages/doc-viewer/assets
   publish-testing:
     runs-on: ubuntu-latest
     needs: [build]


### PR DESCRIPTION
## Summary

Updates our actions flow to include the `doc-viewer/loader` and `doc-viewer/assets` directories. These are referenced in the `files` section of the package.json, but were not correctly being uploaded as assets during the actions build, resulting in the files missing when consumers attempted to use them.

## Test Plan

- Verify the `loader` and `assets` directories are present in the published package

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
