### PR TITLE
[PLAT-8122] remove obsolete deps on uuid & is-plain-object

### DIFF
--- a/packages/stream-api/src/__tests__/webSocketClient.spec.ts
+++ b/packages/stream-api/src/__tests__/webSocketClient.spec.ts
@@ -1,3 +1,14 @@
+// jsDom v20 does not have randomUUID(). remove after upgrade to jest-environment-jsdom 30+
+jest.mock('@vertexvis/utils', () => {
+  const utils = jest.requireActual('@vertexvis/utils');
+  return {
+    ...utils,
+    UUID: { create: jest.fn(() => 'mock-websocket-id') },
+  };
+});
+
+import { UUID } from '@vertexvis/utils';
+
 import { ConnectionDescriptor } from '../connection';
 import { WebSocketClientImpl } from '../webSocketClient';
 
@@ -16,6 +27,10 @@ describe('WebSocketClientImpl', () => {
     };
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   afterAll(() => {
     (global as any).WebSocket = globalWebSocket;
   });
@@ -32,6 +47,7 @@ describe('WebSocketClientImpl', () => {
       await wsImpl.connect(descriptor);
       await wsImpl.connect(descriptor);
 
+      expect(UUID.create).toHaveBeenCalledTimes(2);
       expect(mockClose).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -46,13 +46,10 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "fast-deep-equal": "^3.1.3",
-    "is-plain-object": "^3.0.0",
-    "uuid": "^8.3.2"
+    "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/uuid": "^8.3.4",
     "@vertexvis/eslint-config-vertexvis-typescript": "^0.5.0",
     "@vertexvis/jest-config-vertexvis": "^0.5.4",
     "@vertexwebsdk/build": "0.24.5",

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -1,7 +1,5 @@
 import fastDeepEqual from 'fast-deep-equal';
-import isSimpleObject from 'is-plain-object';
 
-/* eslint-disable padding-line-between-statements */
 /**
  * Returns a new object where any enumerable property from `other` are
  * recursively applied to `a`. Once a property is set, it will not be
@@ -42,7 +40,6 @@ export function defaults(
     return other.reduce((result, next) => defaults(result, next), a);
   }
 }
-/* eslint-enable padding-line-between-statements */
 
 /**
  * Returns `true` if this is a plain object, which is defined by a type created
@@ -64,7 +61,11 @@ export function defaults(
  * ```
  */
 export function isPlainObject(obj: unknown): boolean {
-  return isSimpleObject(obj);
+  if (obj == null || typeof obj !== 'object') {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(obj);
+  return prototype != null && prototype.constructor === Object;
 }
 
 /**

--- a/packages/utils/src/uuid.ts
+++ b/packages/utils/src/uuid.ts
@@ -1,5 +1,3 @@
-import { v4 as uuid } from 'uuid';
-
 export type UUID = string;
 
 export interface UUIDMsbLsb {
@@ -8,7 +6,7 @@ export interface UUIDMsbLsb {
 }
 
 export function create(): UUID {
-  return uuid();
+  return globalThis.crypto.randomUUID(); // synonomys with uuid.v4()
 }
 
 export function fromMsbLsb(msb: bigint | string, lsb: bigint | string): UUID {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4939,11 +4939,6 @@ is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-plain-object@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
-  integrity sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
-
 is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
@@ -8910,7 +8905,7 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@8.3.2, uuid@^8.3.2:
+uuid@8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
## Summary
Cleanup of obsolete dependencies

## Test Plan
Automated unit tests should cover this pretty well, but will also get incidental coverage in manual and integration testing for 1.0 release

## Release Notes
Some packages that got type info from @types/uuid could just use `: string` if you just need to get the job done and don't care about strict enforcement, or use `${string}-${string}-${string}-${string}-${string}` if you want a bit more

## Possible Regressions
Shouldn't be

## Dependencies
Build off of #763 
