### PR TITLE
[PLAT-8617] Add debug logging support to the measurement controller

### DIFF
--- a/packages/viewer/src/lib/measurement/controller.ts
+++ b/packages/viewer/src/lib/measurement/controller.ts
@@ -20,6 +20,7 @@ import { MeasurementOutcome } from './outcomes';
  */
 export class MeasurementController {
   private outcome = Promise.resolve<MeasurementOutcome | undefined>(undefined);
+  private debugLogs = false;
 
   public constructor(
     private model: MeasurementModel,
@@ -39,6 +40,16 @@ export class MeasurementController {
   public addEntity(
     entity: MeasurementEntity
   ): Promise<MeasurementOutcome | undefined> {
+    if (this.debugLogs) {
+      const deserializedEntity = ModelEntity.deserializeBinary(
+        entity.modelEntity
+      );
+
+      this.log(
+        `Adding ModelEntity. [entityId={${deserializedEntity.getEntityId()}}, sceneItemId={${deserializedEntity.getSceneItemId()}}]`
+      );
+    }
+
     return this.performMeasurement(() => this.model.addEntity(entity));
   }
 
@@ -47,6 +58,8 @@ export class MeasurementController {
    * of measurement results.
    */
   public clearEntities(): Promise<MeasurementOutcome | undefined> {
+    this.log('Clearing all ModelEntities.');
+
     return this.performMeasurement(() => {
       this.model.clearEntities();
       this.model.clearOutcome();
@@ -65,6 +78,16 @@ export class MeasurementController {
   public removeEntity(
     entity: MeasurementEntity
   ): Promise<MeasurementOutcome | undefined> {
+    if (this.debugLogs) {
+      const deserializedEntity = ModelEntity.deserializeBinary(
+        entity.modelEntity
+      );
+
+      this.log(
+        `Removing ModelEntity. [entityId={${deserializedEntity.getEntityId()}}, sceneItemId={${deserializedEntity.getSceneItemId()}}]`
+      );
+    }
+
     return this.performMeasurement(() => this.model.removeEntity(entity));
   }
 
@@ -78,7 +101,21 @@ export class MeasurementController {
   public setEntities(
     entities: Set<MeasurementEntity>
   ): Promise<MeasurementOutcome | undefined> {
+    if (this.debugLogs) {
+      const deserializedEntities = Array.from(entities).map((e) =>
+        ModelEntity.deserializeBinary(e.modelEntity)
+      );
+
+      this.log(
+        `Setting ${deserializedEntities.length} ModelEntities. [entityIds=[${deserializedEntities.map((e) => e.getEntityId()).join(', ')}], sceneItemIds=[${deserializedEntities.map((e) => e.getSceneItemId()).join(', ')}]]`
+      );
+    }
+
     return this.performMeasurement(() => this.model.setEntities(entities));
+  }
+
+  public setDebugLogs(debugLogs: boolean): void {
+    this.debugLogs = debugLogs;
   }
 
   private performMeasurement(
@@ -150,5 +187,11 @@ export class MeasurementController {
       req.setUpdatesList([...clearEntities, ...highlightEntities]);
       this.client.updateModelEntities(req, meta, handler);
     });
+  }
+
+  private log(message?: string, ...optionalParams: unknown[]): void {
+    if (this.debugLogs) {
+      console.debug(message, optionalParams);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds debug logging to the measurement controller. Specifically, when `setDebugLogs(true)` is set, the following logs will appear:
- The `entityId` and `sceneItemId` of any `ModelEntity` added through `addEntity`
- The `entityId` and `sceneItemId` of any `ModelEntity` removed through `removeEntity`
- The `entityId` and `sceneItemId` of every `ModelEntity` set through `setEntities`
- The `entityId` and `sceneItemId` of every `ModelEntity` removed through `clearEntities`

## Test Plan

- Set debug logs to true for the `measurementController` of a `<vertex-viewer-measurement-precise>` element
- Verify logging appears in the console around the following:
  - Click around in the model to highlight entities through `addEntity`
  - Click in whitespace in the model to clear highlighting through `clearEntities`
  - Programmatically remove an entity through `removeEntity`
    - Example console command - `document.querySelector('vertex-viewer-measurement-precise').measurementController.removeEntity( document.querySelector('vertex-viewer-measurement-precise').measurementModel.getEntities()[0])`
  - Programmatically set entities through `setEntities`
    - Example console command after selecting a single surface (each line can be run separately as well) - `const entities = document.querySelector('vertex-viewer-measurement-precise').measurementModel.getEntities();
document.querySelector('vertex-viewer-measurement-precise').measurementController.clearEntities();
document.querySelector('vertex-viewer-measurement-precise').measurementController.setEntities(entities);`

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
