### PR TITLE
[PLAT-8473] Document markup adjustments

### DIFF
--- a/packages/doc-viewer/src/components/document-viewer/document-viewer.spec.ts
+++ b/packages/doc-viewer/src/components/document-viewer/document-viewer.spec.ts
@@ -1,8 +1,18 @@
+jest.mock('../../lib/dom', () => {
+  const original = jest.requireActual('../../lib/dom');
+
+  return {
+    ...original,
+    getAllVertexElementChildren: jest.fn(() => []),
+  };
+});
+
 import { newSpecPage } from '@stencil/core/testing';
 import { Async } from '@vertexvis/utils';
 
 import { mockGetDocument, mockGetPage, mockGetViewport, mockPageRender } from '../../__mocks__/pdfjs-mock';
 import { triggerResizeObserver } from '../../__setup__/resize-observer';
+import { getAllVertexElementChildren } from '../../lib/dom';
 import { VertexDocumentViewer } from './document-viewer';
 
 describe('vertex-document-viewer', () => {
@@ -95,6 +105,22 @@ describe('vertex-document-viewer', () => {
 
       const viewer = root as HTMLVertexDocumentViewerElement;
       await expect(viewer.loadPage(1)).rejects.toThrow('No document has been loaded. Ensure that the `src` property is set and the resource is accessible.');
+    });
+  });
+
+  describe('injectViewerApi', () => {
+    it('injects the viewer API into vertex custom element children', async () => {
+      const testElement = { nodeName: 'VERTEX-VIEWER-MARKUP', viewer: undefined };
+      (getAllVertexElementChildren as jest.Mock).mockReturnValue([testElement]);
+
+      const page = await newSpecPage({
+        components: [VertexDocumentViewer],
+        html: `<vertex-document-viewer></vertex-document-viewer>`,
+      });
+
+      await page.waitForChanges();
+
+      expect(testElement.viewer).toBeDefined();
     });
   });
 });

--- a/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
+++ b/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
@@ -9,7 +9,7 @@ import { DocumentApi, DocumentApiState } from '../../lib/document/api';
 import { DocumentLayersController } from '../../lib/document/layers/controller';
 import { DocumentProvider } from '../../lib/document/provider';
 import { DocumentRenderer } from '../../lib/document/renderer';
-import { getElementBoundingClientRect } from '../../lib/dom';
+import { getAllVertexElementChildren, getElementBoundingClientRect } from '../../lib/dom';
 import { PanInteractionHandler } from '../../lib/interactions/pan-interaction-handler';
 import { PdfJsProvider } from '../../lib/pdf/pdfjs-provider';
 
@@ -105,6 +105,7 @@ export class VertexDocumentViewer implements BasicViewer {
 
   private dimensions: Dimensions.Dimensions = Dimensions.create(0, 0);
   private resizeObserver?: ResizeObserver;
+  private mutationObserver?: MutationObserver;
   private resizeTimer?: number;
 
   private documentRenderer?: DocumentRenderer;
@@ -123,6 +124,8 @@ export class VertexDocumentViewer implements BasicViewer {
     this.handlePageDrawn = this.handlePageDrawn.bind(this);
 
     this.resizeObserver = new ResizeObserver(this.handleElementResize);
+
+    this.registerSlotChangeListeners();
   }
 
   protected componentShouldUpdate(newValue: unknown, oldValue: unknown, propName: string): boolean {
@@ -136,6 +139,8 @@ export class VertexDocumentViewer implements BasicViewer {
 
     this.updateComponentDimensions();
     this.handleSrcChange();
+
+    this.injectViewerApi();
   }
 
   protected disconnectedCallback(): void {
@@ -342,5 +347,20 @@ export class VertexDocumentViewer implements BasicViewer {
     }
 
     handler.initialize(this.canvasEl);
+  }
+
+  private registerSlotChangeListeners(): void {
+    this.mutationObserver = new MutationObserver(_ => this.injectViewerApi());
+    this.mutationObserver.observe(this.hostEl, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  private injectViewerApi(): void {
+    getAllVertexElementChildren(this.hostEl).forEach(node => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node as any).viewer = this.hostEl;
+    });
   }
 }

--- a/packages/doc-viewer/src/lib/dom.ts
+++ b/packages/doc-viewer/src/lib/dom.ts
@@ -1,3 +1,13 @@
 export function getElementBoundingClientRect(element: HTMLElement): ClientRect {
   return element.getBoundingClientRect();
 }
+
+export function getAllVertexElementChildren(element: Element): Element[] {
+  return getAllChildren(element)
+    .filter(node => node.nodeName.startsWith('VERTEX-'))
+    .reduce((elements, element) => [...elements, element, ...getAllChildren(element)], [] as Element[]);
+}
+
+function getAllChildren(element: Element): Element[] {
+  return Array.from(element.querySelectorAll('*'));
+}

--- a/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.tsx
+++ b/packages/viewer/src/components/viewer-markup-arrow/viewer-markup-arrow.tsx
@@ -217,6 +217,7 @@ export class ViewerMarkupArrow {
     this.updateViewport();
     this.handleViewerChanged(this.viewer);
     this.handleScaleChange();
+    this.handleScalingConfigurationChange();
     this.updatePointsFromProps();
   }
 

--- a/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
+++ b/packages/viewer/src/components/viewer-markup-circle/viewer-markup-circle.tsx
@@ -175,6 +175,7 @@ export class ViewerMarkupCircle {
     this.updateViewport();
     this.handleViewerChanged(this.viewer);
     this.handleScaleChange();
+    this.handleScalingConfigurationChange();
     this.updateBoundsFromProps();
   }
 

--- a/packages/viewer/src/components/viewer-markup-freeform/viewer-markup-freeform.tsx
+++ b/packages/viewer/src/components/viewer-markup-freeform/viewer-markup-freeform.tsx
@@ -202,6 +202,7 @@ export class ViewerMarkupFreeform {
     this.updateViewport();
     this.handleViewerChanged(this.viewer);
     this.handleScaleChange();
+    this.handleScalingConfigurationChange();
     this.updatePointsFromProps();
   }
 

--- a/packages/viewer/src/lib/markup/interactions.ts
+++ b/packages/viewer/src/lib/markup/interactions.ts
@@ -50,6 +50,10 @@ export abstract class MarkupInteractionHandler implements BasicInteractionHandle
     };
   }
 
+  public getScalingOptions(): MarkupInteractionHandlerScalingOptions {
+    return this.scalingOptions;
+  }
+
   protected acceptInteraction(): void {
     window.addEventListener('pointermove', this.handlePointerMove);
     window.addEventListener('pointerup', this.handlePointerUp);


### PR DESCRIPTION
## Summary

Makes a couple small adjustments to the SDK behavior with markup in a document viewer. Specifically this PR:
- Adds an `injectViewerApi` helper similar to the `<vertex-viewer>`'s implementation to support auto-injecting this viewer into child elements (specifically `<vertex-viewer-markup>`)
- Updates the `<vertex-viewer-markup-*>` elements to call `this.handleScalingConfigurationChange` when the component loads. This fixes an issue where the interaction handler was not properly getting the values when initially constructed and markup was not rendering correctly

## Test Plan

- Verify the above items work as expected
  - Placing a `<vertex-viewer-markup>` under a `<vertex-document-viewer>` should auto-inject the viewer into the component
  - Drafting markup using a `<vertex-viewer-markup-tool>` and setting `scale`, `offset`, and `originatingViewport` should properly position markup at scale

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
