### PR TITLE
[PLAT-8473] Add pan wheel listener to host rather than window

### DIFF
--- a/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
+++ b/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
@@ -307,7 +307,7 @@ export class VertexDocumentViewer implements BasicViewer {
     this.panInteractionHandler?.dispose();
 
     if (this.interactionMode === 'pan' && this.canvasEl != null && this.documentApi != null) {
-      this.panInteractionHandler = new PanInteractionHandler(this.canvasEl, this.documentApi);
+      this.panInteractionHandler = new PanInteractionHandler(this.canvasEl, this.hostEl, this.documentApi);
     }
   }
 

--- a/packages/doc-viewer/src/lib/interactions/__tests__/pan-interaction-handler.spec.ts
+++ b/packages/doc-viewer/src/lib/interactions/__tests__/pan-interaction-handler.spec.ts
@@ -67,11 +67,17 @@ describe('PanInteractionHandler', () => {
       configurable: true,
     });
 
-    new PanInteractionHandler(element, hostElement, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+    const handler = new PanInteractionHandler(
+      element,
+      hostElement,
+      new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }),
+    );
 
     expect(hostElement.addEventListener).toHaveBeenCalledWith('wheel', expect.any(Function));
     expect(mockAddEventListener).toHaveBeenCalledWith('pointerdown', expect.any(Function));
     expect(mockAddEventListener).toHaveBeenCalledWith('wheel', expect.any(Function));
+
+    handler.dispose();
   });
 
   it('should remove listeners when disposed', () => {
@@ -109,7 +115,7 @@ describe('PanInteractionHandler', () => {
   it('should pan the document when the element is dragged', () => {
     const element = document.createElement('div');
 
-    new PanInteractionHandler(
+    const handler = new PanInteractionHandler(
       element,
       document.createElement('div'),
       new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }),
@@ -120,12 +126,14 @@ describe('PanInteractionHandler', () => {
     window.dispatchEvent(new MouseEvent('pointerup', { clientX: 10, clientY: 10 }));
 
     expect(mockPanByDelta).toHaveBeenCalledWith(Point.create(5, 5));
+
+    handler.dispose();
   });
 
   it('should not pan the document when the element is dragged with a different button than the primary button', () => {
     const element = document.createElement('div');
 
-    new PanInteractionHandler(
+    const handler = new PanInteractionHandler(
       element,
       document.createElement('div'),
       new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }),
@@ -136,29 +144,43 @@ describe('PanInteractionHandler', () => {
     window.dispatchEvent(new MouseEvent('pointerup', { clientX: 10, clientY: 10 }));
 
     expect(mockPanByDelta).not.toHaveBeenCalled();
+
+    handler.dispose();
   });
 
   it('should pan the document when a wheel event occurs on the host element', () => {
     const element = document.createElement('div');
     const hostElement = document.createElement('div');
 
-    new PanInteractionHandler(element, hostElement, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+    const handler = new PanInteractionHandler(
+      element,
+      hostElement,
+      new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }),
+    );
 
     hostElement.dispatchEvent(new Event('wheel', { deltaX: 100, deltaY: 100 } as unknown as EventInit));
 
     expect(mockPanByDelta).toHaveBeenCalledWith(Point.create(-50, -50));
+
+    handler.dispose();
   });
 
   it('should continue to pan the document when a wheel event occurs after a pointerup', () => {
     const element = document.createElement('div');
     const hostElement = document.createElement('div');
 
-    new PanInteractionHandler(element, hostElement, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+    const handler = new PanInteractionHandler(
+      element,
+      hostElement,
+      new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }),
+    );
 
     element.dispatchEvent(new MouseEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 }));
     window.dispatchEvent(new MouseEvent('pointerup', { clientX: 10, clientY: 10 }));
     hostElement.dispatchEvent(new Event('wheel', { deltaX: 100, deltaY: 100 } as unknown as EventInit));
 
     expect(mockPanByDelta).toHaveBeenCalledWith(Point.create(-50, -50));
+
+    handler.dispose();
   });
 });

--- a/packages/doc-viewer/src/lib/interactions/__tests__/pan-interaction-handler.spec.ts
+++ b/packages/doc-viewer/src/lib/interactions/__tests__/pan-interaction-handler.spec.ts
@@ -53,6 +53,7 @@ describe('PanInteractionHandler', () => {
 
     const mockAddEventListener = jest.fn();
     const element = document.createElement('div');
+    const hostElement = document.createElement('div');
 
     Object.defineProperty(element, 'addEventListener', {
       value: mockAddEventListener,
@@ -60,9 +61,15 @@ describe('PanInteractionHandler', () => {
       configurable: true,
     });
 
-    new PanInteractionHandler(element, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+    Object.defineProperty(hostElement, 'addEventListener', {
+      value: mockAddEventListener,
+      writable: true,
+      configurable: true,
+    });
 
-    expect(window.addEventListener).toHaveBeenCalledWith('wheel', expect.any(Function));
+    new PanInteractionHandler(element, hostElement, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+
+    expect(hostElement.addEventListener).toHaveBeenCalledWith('wheel', expect.any(Function));
     expect(mockAddEventListener).toHaveBeenCalledWith('pointerdown', expect.any(Function));
     expect(mockAddEventListener).toHaveBeenCalledWith('wheel', expect.any(Function));
   });
@@ -72,6 +79,7 @@ describe('PanInteractionHandler', () => {
 
     const mockRemoveEventListener = jest.fn();
     const element = document.createElement('div');
+    const hostElement = document.createElement('div');
 
     Object.defineProperty(element, 'removeEventListener', {
       value: mockRemoveEventListener,
@@ -79,11 +87,21 @@ describe('PanInteractionHandler', () => {
       configurable: true,
     });
 
-    const handler = new PanInteractionHandler(element, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+    Object.defineProperty(hostElement, 'removeEventListener', {
+      value: mockRemoveEventListener,
+      writable: true,
+      configurable: true,
+    });
+
+    const handler = new PanInteractionHandler(
+      element,
+      hostElement,
+      new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }),
+    );
 
     handler.dispose();
 
-    expect(window.removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function));
+    expect(hostElement.removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function));
     expect(element.removeEventListener).toHaveBeenCalledWith('pointerdown', expect.any(Function));
     expect(element.removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function));
   });
@@ -91,7 +109,11 @@ describe('PanInteractionHandler', () => {
   it('should pan the document when the element is dragged', () => {
     const element = document.createElement('div');
 
-    new PanInteractionHandler(element, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+    new PanInteractionHandler(
+      element,
+      document.createElement('div'),
+      new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }),
+    );
 
     element.dispatchEvent(new MouseEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 }));
     window.dispatchEvent(new MouseEvent('pointermove', { clientX: 15, clientY: 15 }));
@@ -103,7 +125,11 @@ describe('PanInteractionHandler', () => {
   it('should not pan the document when the element is dragged with a different button than the primary button', () => {
     const element = document.createElement('div');
 
-    new PanInteractionHandler(element, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+    new PanInteractionHandler(
+      element,
+      document.createElement('div'),
+      new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }),
+    );
 
     element.dispatchEvent(new MouseEvent('pointerdown', { button: 1, clientX: 10, clientY: 10 }));
     window.dispatchEvent(new MouseEvent('pointermove', { clientX: 15, clientY: 15 }));
@@ -112,12 +138,26 @@ describe('PanInteractionHandler', () => {
     expect(mockPanByDelta).not.toHaveBeenCalled();
   });
 
-  it('should pan the document when a wheel event occurs', () => {
+  it('should pan the document when a wheel event occurs on the host element', () => {
     const element = document.createElement('div');
+    const hostElement = document.createElement('div');
 
-    new PanInteractionHandler(element, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+    new PanInteractionHandler(element, hostElement, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
 
-    window.dispatchEvent(new Event('wheel', { deltaX: 100, deltaY: 100 } as unknown as EventInit));
+    hostElement.dispatchEvent(new Event('wheel', { deltaX: 100, deltaY: 100 } as unknown as EventInit));
+
+    expect(mockPanByDelta).toHaveBeenCalledWith(Point.create(-50, -50));
+  });
+
+  it('should continue to pan the document when a wheel event occurs after a pointerup', () => {
+    const element = document.createElement('div');
+    const hostElement = document.createElement('div');
+
+    new PanInteractionHandler(element, hostElement, new MockDocumentApi({ zoomPercentage: 100, panOffset: Point.create(0, 0), viewport: Dimensions.create(100, 100) }));
+
+    element.dispatchEvent(new MouseEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 }));
+    window.dispatchEvent(new MouseEvent('pointerup', { clientX: 10, clientY: 10 }));
+    hostElement.dispatchEvent(new Event('wheel', { deltaX: 100, deltaY: 100 } as unknown as EventInit));
 
     expect(mockPanByDelta).toHaveBeenCalledWith(Point.create(-50, -50));
   });

--- a/packages/doc-viewer/src/lib/interactions/pan-interaction-handler.ts
+++ b/packages/doc-viewer/src/lib/interactions/pan-interaction-handler.ts
@@ -12,6 +12,7 @@ export class PanInteractionHandler implements Disposable {
 
   public constructor(
     private readonly element: HTMLElement,
+    private readonly hostElement: HTMLElement,
     private readonly api: DocumentApi,
   ) {
     this.handlePointerDown = this.handlePointerDown.bind(this);
@@ -21,12 +22,13 @@ export class PanInteractionHandler implements Disposable {
 
     this.element.addEventListener('pointerdown', this.handlePointerDown);
     this.element.addEventListener('wheel', this.handleWheel);
-    window.addEventListener('wheel', this.handleWheel);
+    this.hostElement.addEventListener('wheel', this.handleWheel);
   }
 
   public dispose(): void {
     this.element.removeEventListener('pointerdown', this.handlePointerDown);
     this.element.removeEventListener('wheel', this.handleWheel);
+    this.hostElement.removeEventListener('wheel', this.handleWheel);
 
     this.removeWindowListeners();
   }
@@ -87,6 +89,5 @@ export class PanInteractionHandler implements Disposable {
   private removeWindowListeners(): void {
     window.removeEventListener('pointermove', this.handlePointerMove);
     window.removeEventListener('pointerup', this.handlePointerUp);
-    window.removeEventListener('wheel', this.handleWheel);
   }
 }


### PR DESCRIPTION
## Summary

Updates the `<vertex-document-viewer>` to register a `wheel` event listener on the host element rather than the window. This prevents scenarios where the content was being panned when scrolling other elements within the window.

Additionally, this PR fixes a bug where the higher-level `wheel` listener was being unregistered when a `pointerup` occurred on the document itself, causing panning to stop working when the event occurred on markup elements.

## Test Plan

- Verify that scrolling content outside of the `<vertex-document-viewer>`'s viewport does not scroll the content of the `<vertex-document-viewer>`
- Verify that clicking within a `<vertex-document-viewer>` with markup added does not prevent panning that is initiated from over the top of a markup element

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
