### PR TITLE
[PLAT-2469] Group stream attribute changes

### DIFF
--- a/packages/viewer/src/components/viewer/viewer.spec.tsx
+++ b/packages/viewer/src/components/viewer/viewer.spec.tsx
@@ -439,16 +439,22 @@ describe('vertex-viewer', () => {
       const update = jest.spyOn(stream, 'update');
       await loadViewerStreamKey(key1, { stream, ws, viewer });
 
-      viewer.depthBuffers = 'final';
+      jest.useFakeTimers();
+      viewer.depthBuffers = 'all';
+      jest.advanceTimersByTime(50);
+      jest.useRealTimers();
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({
           streamAttributes: expect.objectContaining({
-            depthBuffers: 'final',
+            depthBuffers: 'all',
           }),
         })
       );
 
+      jest.useFakeTimers();
       viewer.phantom = { opacity: 1 };
+      jest.advanceTimersByTime(50);
+      jest.useRealTimers();
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({
           streamAttributes: expect.objectContaining({
@@ -457,7 +463,10 @@ describe('vertex-viewer', () => {
         })
       );
 
+      jest.useFakeTimers();
       viewer.featureLines = { width: 1 };
+      jest.advanceTimersByTime(50);
+      jest.useRealTimers();
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({
           streamAttributes: expect.objectContaining({
@@ -466,7 +475,10 @@ describe('vertex-viewer', () => {
         })
       );
 
+      jest.useFakeTimers();
       viewer.featureHighlighting = { highlightColor: 0xff0000 };
+      jest.advanceTimersByTime(50);
+      jest.useRealTimers();
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({
           streamAttributes: expect.objectContaining({
@@ -475,7 +487,10 @@ describe('vertex-viewer', () => {
         })
       );
 
+      jest.useFakeTimers();
       viewer.featureMaps = 'final';
+      jest.advanceTimersByTime(50);
+      jest.useRealTimers();
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({
           streamAttributes: expect.objectContaining({
@@ -484,9 +499,12 @@ describe('vertex-viewer', () => {
         })
       );
 
+      jest.useFakeTimers();
       viewer.crossSectioning = {};
       viewer.crossSectioning.endCapEnabled = true;
       viewer.crossSectioning.endCapColor = '#112233';
+      jest.advanceTimersByTime(50);
+      jest.useRealTimers();
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({
           streamAttributes: expect.objectContaining({

--- a/packages/viewer/src/components/viewer/viewer.tsx
+++ b/packages/viewer/src/components/viewer/viewer.tsx
@@ -535,6 +535,7 @@ export class Viewer implements BasicViewer {
   private isVisible = false;
 
   private resizeTimer?: NodeJS.Timeout;
+  private streamAttributesUpdateTimer?: NodeJS.Timeout;
   private frameRenderVersion = 0;
 
   private interactionHandlers: InteractionHandler[] = [];
@@ -977,19 +978,32 @@ export class Viewer implements BasicViewer {
   /**
    * @ignore
    */
-  @Watch('experimentalRenderingOptions')
+  @Watch('crossSectioning')
   @Watch('depthBuffers')
+  @Watch('experimentalRenderingOptions')
   @Watch('featureHighlighting')
   @Watch('featureLines')
   @Watch('featureMaps')
   @Watch('noDefaultLights')
   @Watch('phantom')
   @Watch('sceneComparison')
-  @Watch('crossSectioning')
   @Watch('selectionHighlighting')
   protected handleStreamAttributesChanged(): void {
-    this.updateStreamAttributes();
+    this.handleUpdateStreamAttributesWithTimer();
   }
+
+  // Group stream attribute changes happening in quick succession to
+  // ensure the correct attributes are applied to the stream
+  private handleUpdateStreamAttributesWithTimer = (): void => {
+    const streamAttributesUpdateThrottleInMilliseconds = 50;
+
+    if (this.streamAttributesUpdateTimer == null) {
+      this.streamAttributesUpdateTimer = setTimeout(() => {
+        this.streamAttributesUpdateTimer = undefined;
+        this.updateStreamAttributes();
+      }, streamAttributesUpdateThrottleInMilliseconds);
+    }
+  };
 
   /**
    * @ignore


### PR DESCRIPTION
## Summary
This PR groups stream attribute changes happening in quick succession (within 50 milliseconds of each other) in order to ensure that the correct attributes are applied to the stream. Previously, if multiple attributes changed at once, sometimes one or more of the new attribute values were not applied because they were overwritten by a change set that included a different updated value, but not that one.

## Test Plan
Verify stream attributes can be changed and are updated on the stream as expected

## Release Notes
Group stream attribute changes

## Possible Regressions
Stream attribute changes

## Dependencies
None