### PR TITLE
[PLAT-8696] Fix pin label initialization 

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -1760,6 +1760,7 @@ export namespace Components {
         "submit": () => Promise<void>;
         /**
           * The current text value of the component. Value is updated on user interaction.
+          * @default ''
          */
         "value": string;
     }
@@ -4312,6 +4313,7 @@ declare namespace LocalJSX {
         "pinController"?: PinController;
         /**
           * The current text value of the component. Value is updated on user interaction.
+          * @default ''
          */
         "value"?: string;
     }

--- a/packages/viewer/src/components/viewer-pin-label/readme.md
+++ b/packages/viewer/src/components/viewer-pin-label/readme.md
@@ -12,7 +12,7 @@
 | `elementBounds` | --        | The dimensions of the canvas for the pins                                      | `DOMRect \| undefined`       | `undefined` |
 | `pin`           | --        | The pin to draw for the group                                                  | `TextPin \| undefined`       | `undefined` |
 | `pinController` | --        | The controller that drives behavior for pin operations                         | `PinController \| undefined` | `undefined` |
-| `value`         | `value`   | The current text value of the component. Value is updated on user interaction. | `string`                     | `undefined` |
+| `value`         | `value`   | The current text value of the component. Value is updated on user interaction. | `string`                     | `''`        |
 
 
 ## Events

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -53,7 +53,7 @@ export class VertexPinLabel {
    * interaction.
    */
   @Prop({ mutable: true })
-  public value: string;
+  public value = '';
 
   /**
    * The controller that drives behavior for pin operations
@@ -105,10 +105,6 @@ export class VertexPinLabel {
   private resizeObserver?: ResizeObserver;
   private contentResizeObserver?: ResizeObserver;
 
-  public constructor() {
-    this.value = this.getPinText();
-  }
-
   /**
    * Gives focus to the component's internal text input.
    */
@@ -152,7 +148,7 @@ export class VertexPinLabel {
 
   @Watch('pin')
   protected watchPinChange(): void {
-    this.value = this.getPinText();
+    this.value = this.pin?.label.text ?? '';
     this.computeScreenPosition();
   }
 
@@ -162,6 +158,7 @@ export class VertexPinLabel {
   }
 
   protected componentWillLoad(): void {
+    this.value = this.pin?.label.text ?? '';
     this.computeScreenPosition();
   }
 
@@ -297,16 +294,6 @@ export class VertexPinLabel {
     return `calc(${this.elementBounds?.height.toString() || 0}px - ${
       this.computedScreenPosition?.y.toString() || 0
     }px)`;
-  }
-
-  private getPinText(): string {
-    if (this.pin?.label.text != null) {
-      this.value = this.pin.label.text;
-    } else {
-      this.value = '';
-    }
-
-    return this.value;
   }
 
   private computeScreenPosition(): void {


### PR DESCRIPTION
## Summary

Fixes an issue where the `value` of a `vertex-viewer-pin-label` element was not being initialized as expected. This caused text pins to always initialize with an empty string for a value until a user interacted with the pin.

## Test Plan

- Verify creating a `vertex-viewer-pin-label` element with a `value` provided initially shows the value as expected

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
