### PR TITLE
[PLAT-8725] Bulk replace data-test-id with data-testid

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
+++ b/packages/viewer/src/components/scene-tree-table-cell/scene-tree-table-cell.tsx
@@ -242,7 +242,7 @@ export class SceneTreeTableCell {
           {showSpaceForExpansionIcon && (
             <button
               class="expand-btn no-shrink"
-              data-test-id={'expand-' + this.node?.name}
+              data-testid={'expand-' + this.node?.name}
               onPointerUp={this.createActionPointerUpHandler(
                 this.toggleExpansion
               )}
@@ -260,7 +260,7 @@ export class SceneTreeTableCell {
           {showSpaceForEndItemIcon && (
             <button
               class="end-item-btn no-shrink"
-              data-test-id={'end-item-' + this.node?.name}
+              data-testid={'end-item-' + this.node?.name}
             >
               {endItemIcon && (
                 <vertex-viewer-icon
@@ -282,7 +282,7 @@ export class SceneTreeTableCell {
           {this.isolateButton && (
             <button
               class="isolate-btn no-shrink"
-              data-test-id={'isolate-btn-' + this.node?.name}
+              data-testid={'isolate-btn-' + this.node?.name}
               onPointerUp={this.createActionPointerUpHandler(this.isolate)}
             >
               {isolateIcon && (
@@ -293,7 +293,7 @@ export class SceneTreeTableCell {
           {this.visibilityToggle && (
             <button
               class="visibility-btn no-shrink"
-              data-test-id={'visibility-btn-' + this.node?.name}
+              data-testid={'visibility-btn-' + this.node?.name}
               onPointerUp={this.createActionPointerUpHandler(
                 this.toggleVisibility
               )}

--- a/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.spec.ts
+++ b/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.spec.ts
@@ -26,7 +26,7 @@ describe('<vertex-viewer-default-toolbar>', () => {
       });
 
       const btn = page.root?.shadowRoot?.querySelector(
-        '[data-test-id="fit-all-btn"]'
+        '[data-testid="fit-all-btn"]'
       );
       expect(btn).toBeDefined();
     });
@@ -41,7 +41,7 @@ describe('<vertex-viewer-default-toolbar>', () => {
       await page.waitForChanges();
 
       const btn = page.root?.shadowRoot?.querySelector(
-        '[data-test-id="fit-all-btn"]'
+        '[data-testid="fit-all-btn"]'
       );
       btn?.dispatchEvent(new MouseEvent('click'));
 
@@ -65,7 +65,7 @@ describe('<vertex-viewer-default-toolbar>', () => {
       await page.waitForChanges();
 
       const btn = page.root?.shadowRoot?.querySelector(
-        '[data-test-id="fit-all-btn"]'
+        '[data-testid="fit-all-btn"]'
       );
       btn?.dispatchEvent(new MouseEvent('click'));
 

--- a/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.tsx
+++ b/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.tsx
@@ -55,7 +55,7 @@ export class ViewerDefaultToolbar {
         >
           <vertex-viewer-button
             class="group-item btn"
-            data-test-id="fit-all-btn"
+            data-testid="fit-all-btn"
             onClick={() => this.viewAll()}
           >
             <vertex-viewer-icon class="icon" name="fit-all" size="md" />


### PR DESCRIPTION
## Summary
Given data-testid is the settled standard selector for modern testing tools. Cleaning up some old patterns 

## Test Plan
Fixing a selector for automated tests, so as long as automated tests are happy that should do, I think

## Release Notes
Nothing of note. 

## Possible Regressions
Suspect none, however implementors with their own tests based on these data-test-id selectors would need to adjust as well

## Dependencies
Vertex will have PRs in other repositories , including integration test repos, to correspond with these cleanups