### PR TITLE
[PLAT-5195] Fix re-render warnings & other console noise seen on test runs

### DIFF
--- a/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
+++ b/packages/viewer/src/components/scene-tree-table-layout/scene-tree-table-layout.tsx
@@ -226,6 +226,7 @@ export class SceneTreeTableLayout {
   public componentWillLoad(): void {
     this.updateColumnElements();
     this.createPools();
+    this.initializeColumnLayout();
 
     this.headerResizeObserver = new ResizeObserver(() => {
       this.stateMap.headerHeight = undefined;
@@ -243,13 +244,6 @@ export class SceneTreeTableLayout {
   }
 
   public async componentDidLoad(): Promise<void> {
-    this.computeInitialColumnWidths();
-    this.computeColumnGridLayout();
-    this.ensureDividerTemplateDefined();
-    this.computeCellHeight();
-    this.computeHeaderHeight();
-    this.rebindHeaderData();
-
     this.tableElement?.addEventListener('scroll', this.handleScrollChanged, {
       passive: true,
     });
@@ -259,6 +253,11 @@ export class SceneTreeTableLayout {
     }
 
     this.resizeObserver?.observe(this.hostEl);
+
+    // These measurements require rendered DOM, but mutating tracked values
+    // directly in componentDidLoad triggers Stencil dev warnings.
+    await Promise.resolve();
+    await this.initializeMeasuredLayout();
   }
 
   public async componentWillRender(): Promise<void> {
@@ -390,6 +389,18 @@ export class SceneTreeTableLayout {
       this.viewportEndIndex = endIndex;
       this.stateMap.viewportRows = rows;
     }
+  }
+
+  private initializeColumnLayout(): void {
+    this.computeInitialColumnWidths();
+    this.computeColumnGridLayout();
+    this.ensureDividerTemplateDefined();
+    this.rebindHeaderData();
+  }
+
+  private async initializeMeasuredLayout(): Promise<void> {
+    await this.computeCellHeight();
+    this.computeHeaderHeight();
   }
 
   private async computeAndUpdateViewportRows(): Promise<void> {

--- a/packages/viewer/src/components/scene-tree/scene-tree.tsx
+++ b/packages/viewer/src/components/scene-tree/scene-tree.tsx
@@ -725,6 +725,7 @@ export class SceneTree {
     );
 
     this.connectToViewer();
+    this.updateMissingViewerError();
   }
 
   /**
@@ -744,13 +745,6 @@ export class SceneTree {
     this.stateMap.componentLoaded = true;
 
     this.controller?.setMetadataKeys(this.metadataKeys);
-
-    if (this.viewer == null) {
-      this.errorDetails = new SceneTreeErrorDetails(
-        'MISSING_VIEWER',
-        SceneTreeErrorCode.MISSING_VIEWER
-      );
-    }
   }
 
   public componentWillRender(): void {
@@ -896,6 +890,8 @@ export class SceneTree {
     }
 
     if (this.viewer != null) {
+      this.clearMissingViewerError();
+
       const handleSceneReady = async (): Promise<void> => {
         const layoutEl = this.getLayoutElement();
 
@@ -912,6 +908,24 @@ export class SceneTree {
       };
     } else {
       this.attemptingRetry = false;
+      if (this.stateMap.componentLoaded) {
+        this.updateMissingViewerError();
+      }
+    }
+  }
+
+  private updateMissingViewerError(): void {
+    if (this.viewer == null) {
+      this.errorDetails = new SceneTreeErrorDetails(
+        'MISSING_VIEWER',
+        SceneTreeErrorCode.MISSING_VIEWER
+      );
+    }
+  }
+
+  private clearMissingViewerError(): void {
+    if (this.errorDetails?.code === SceneTreeErrorCode.MISSING_VIEWER) {
+      this.errorDetails = undefined;
     }
   }
 

--- a/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.spec.ts
+++ b/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('../viewer/viewer');
 
+import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 
 import {
@@ -34,11 +35,8 @@ describe('<vertex-viewer-default-toolbar>', () => {
     it('performs fit all with animation when fit all button is clicked', async () => {
       const page = await newSpecPage({
         components: [ViewerDefaultToolbar],
-        html: `<vertex-viewer-default-toolbar></vertex-viewer-default-toolbar>`,
+        template: () => h('vertex-viewer-default-toolbar', { viewer }),
       });
-
-      page.rootInstance.viewer = viewer;
-      await page.waitForChanges();
 
       const btn = page.root?.shadowRoot?.querySelector(
         '[data-testid="fit-all-btn"]'
@@ -58,11 +56,12 @@ describe('<vertex-viewer-default-toolbar>', () => {
     it('performs fit all without animation if disabled', async () => {
       const page = await newSpecPage({
         components: [ViewerDefaultToolbar],
-        html: `<vertex-viewer-default-toolbar animations-disabled></vertex-viewer-default-toolbar>`,
+        template: () =>
+          h('vertex-viewer-default-toolbar', {
+            animationsDisabled: true,
+            viewer,
+          }),
       });
-
-      page.rootInstance.viewer = viewer;
-      await page.waitForChanges();
 
       const btn = page.root?.shadowRoot?.querySelector(
         '[data-testid="fit-all-btn"]'

--- a/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
+++ b/packages/viewer/src/components/viewer-pin-group/viewer-pin-group.tsx
@@ -62,7 +62,7 @@ export class ViewerPinGroup {
   /**
    * The controller that drives behavior for pin operations
    */
-  @Prop()
+  @Prop({ mutable: true })
   public pinController?: PinController;
 
   /**
@@ -92,12 +92,14 @@ export class ViewerPinGroup {
 
   private resizeObserver?: ResizeObserver;
 
-  protected componentDidLoad(): void {
-    this.setLabelObserver();
-
+  protected componentWillLoad(): void {
     if (this.pinController == null) {
       this.pinController = new PinController(this.pinModel);
     }
+  }
+
+  protected componentDidLoad(): void {
+    this.setLabelObserver();
 
     if (this.selected) {
       this.labelEl?.setFocus();

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -58,7 +58,7 @@ export class VertexPinLabel {
   /**
    * The controller that drives behavior for pin operations
    */
-  @Prop()
+  @Prop({ mutable: true })
   public pinController?: PinController;
 
   /**
@@ -160,6 +160,10 @@ export class VertexPinLabel {
   protected componentWillLoad(): void {
     this.value = this.pin?.label.text ?? '';
     this.computeScreenPosition();
+
+    if (this.pinController == null) {
+      this.pinController = new PinController(new PinModel());
+    }
   }
 
   protected componentDidLoad(): void {
@@ -177,9 +181,6 @@ export class VertexPinLabel {
       this.contentResizeObserver.observe(this.contentEl);
     }
 
-    if (this.pinController == null) {
-      this.pinController = new PinController(new PinModel());
-    }
   }
 
   protected disconnectedCallback(): void {

--- a/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
+++ b/packages/viewer/src/components/viewer-pin-label/viewer-pin-label.tsx
@@ -180,7 +180,6 @@ export class VertexPinLabel {
     if (this.contentEl != null) {
       this.contentResizeObserver.observe(this.contentEl);
     }
-
   }
 
   protected disconnectedCallback(): void {

--- a/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
+++ b/packages/viewer/src/components/viewer-transform-widget/viewer-transform-widget.tsx
@@ -262,9 +262,6 @@ export class ViewerTransformWidget {
   @State()
   protected isEndingTransform = false;
 
-  @State()
-  protected inputShouldFocus = false;
-
   @Element()
   private hostEl!: HTMLElement;
 
@@ -293,6 +290,7 @@ export class ViewerTransformWidget {
   private canvasRef?: HTMLCanvasElement;
   private inputWrapperRef?: HTMLDivElement;
   private inputRef?: HTMLInputElement;
+  private inputShouldFocus = false;
 
   private hoveredChangeDisposable?: Disposable;
 
@@ -541,8 +539,8 @@ export class ViewerTransformWidget {
             ref={(el) => {
               if (el != null) {
                 this.inputResizeObserver?.observe(el);
-              } else if (this.inputRef != null) {
-                this.inputResizeObserver?.unobserve(this.inputRef);
+              } else if (this.inputWrapperRef != null) {
+                this.inputResizeObserver?.unobserve(this.inputWrapperRef);
               }
               this.inputWrapperRef = el;
             }}

--- a/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.spec.tsx
+++ b/packages/viewer/src/components/viewer-view-cube/viewer-view-cube.spec.tsx
@@ -181,16 +181,18 @@ describe('vertex-viewer-view-cube interactions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
+    Object.assign(viewer, {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    });
     resetAwaiter(sceneMock);
   });
 
   it('performs standard view when side clicked', async () => {
     const page = await newSpecPage({
       components: [ViewerViewCube],
-      template: () => <vertex-viewer-view-cube />,
+      template: () => <vertex-viewer-view-cube viewer={viewer} />,
     });
-
-    page.rootInstance.viewer = viewer;
 
     const frontEl = page.root?.shadowRoot?.querySelector(
       '.cube-side-face-front'
@@ -218,10 +220,10 @@ describe('vertex-viewer-view-cube interactions', () => {
   it('performs a standard view without a fit all when side clicked with viewAll set to false', async () => {
     const page = await newSpecPage({
       components: [ViewerViewCube],
-      template: () => <vertex-viewer-view-cube viewAll={false} />,
+      template: () => (
+        <vertex-viewer-view-cube viewer={viewer} viewAll={false} />
+      ),
     });
-
-    page.rootInstance.viewer = viewer;
 
     const frontEl = page.root?.shadowRoot?.querySelector(
       '.cube-side-face-front'
@@ -253,10 +255,8 @@ describe('vertex-viewer-view-cube interactions', () => {
 
     const page = await newSpecPage({
       components: [ViewerViewCube],
-      template: () => <vertex-viewer-view-cube />,
+      template: () => <vertex-viewer-view-cube viewer={viewer} />,
     });
-
-    page.rootInstance.viewer = viewer;
 
     const frontEl = page.root?.shadowRoot?.querySelector(
       '.cube-side-face-front'
@@ -284,10 +284,10 @@ describe('vertex-viewer-view-cube interactions', () => {
   it('does not animation if animation duration is 0', async () => {
     const page = await newSpecPage({
       components: [ViewerViewCube],
-      template: () => <vertex-viewer-view-cube animationDuration={0} />,
+      template: () => (
+        <vertex-viewer-view-cube viewer={viewer} animationDuration={0} />
+      ),
     });
-
-    page.rootInstance.viewer = viewer;
 
     const frontEl = page.root?.shadowRoot?.querySelector(
       '.cube-side-face-front'
@@ -302,10 +302,10 @@ describe('vertex-viewer-view-cube interactions', () => {
   it('does not perform standard view if disabled', async () => {
     const page = await newSpecPage({
       components: [ViewerViewCube],
-      template: () => <vertex-viewer-view-cube standardViewsOff />,
+      template: () => (
+        <vertex-viewer-view-cube viewer={viewer} standardViewsOff />
+      ),
     });
-
-    page.rootInstance.viewer = viewer;
 
     const frontEl = page.root?.shadowRoot?.querySelector(
       '.cube-side-face-front'


### PR DESCRIPTION
## Summary
Re-render warnings are potential runtime issue, so addressing those as part of exploring solutions for scroll wheel bug causing frames out of order, and while at it getting a little more cleanup of console complaints seen on test suite runs. 

## Test Plan
Beyond automatted tests doing some exploratory testing on touched components. 

## Release Notes
Preventative maintenance on component lifecycle

## Possible Regressions
Nothing known

## Dependencies
Doing similar work in https://github.com/Vertexvis/vertex-web-ui/pull/258
