### PR TITLE
[PLAT-8847] Improve init for watched handlers in measurement components

### DIFF
--- a/packages/viewer/src/components/viewer-measurement-details/viewer-measurement-details.spec.tsx
+++ b/packages/viewer/src/components/viewer-measurement-details/viewer-measurement-details.spec.tsx
@@ -78,6 +78,46 @@ describe('vertex-viewer-measurement-details', () => {
     ).toContain('formatted distance');
   });
 
+  it('creates a default measurement model', async () => {
+    const page = await newSpecPage({
+      components: [ViewerMeasurementDetails],
+      template: () => <vertex-viewer-measurement-details />,
+    });
+
+    const comp = page.root as HTMLVertexViewerMeasurementDetailsElement;
+    expect(comp.measurementModel).toBeInstanceOf(MeasurementModel);
+  });
+
+  it('renders with initial distance units', async () => {
+    const model = new MeasurementModel();
+    model.setOutcome({
+      isApproximate: true,
+      results: [
+        {
+          type: 'minimum-distance',
+          point1: Vector3.create(0, 0, 0),
+          point2: Vector3.create(0, 0, 25.4),
+          distance: 25.4,
+        },
+      ],
+    });
+
+    const page = await newSpecPage({
+      components: [ViewerMeasurementDetails],
+      template: () => (
+        <vertex-viewer-measurement-details
+          distanceUnits="inches"
+          measurementModel={model}
+        />
+      ),
+    });
+
+    expect(
+      page.root?.shadowRoot?.querySelector('div.measurement-details-entry')
+        ?.innerHTML
+    ).toContain('~1.00 in');
+  });
+
   it('displays planar angle', async () => {
     const angle = Angle.toRadians(90);
     const { model, page } = await newMeasurementDetailsSpec();

--- a/packages/viewer/src/components/viewer-measurement-details/viewer-measurement-details.tsx
+++ b/packages/viewer/src/components/viewer-measurement-details/viewer-measurement-details.tsx
@@ -36,7 +36,7 @@ export class ViewerMeasurementDetails {
    * which can then be used to update the display.
    */
   @Prop()
-  public measurementModel?: MeasurementModel;
+  public measurementModel?: MeasurementModel = new MeasurementModel();
 
   /**
    * The manager that the component will use to present measurement overlays.
@@ -118,10 +118,7 @@ export class ViewerMeasurementDetails {
    * @internal
    */
   protected connectedCallback(): void {
-    this.onOutcomeChangedHandler = this.measurementModel?.onOutcomeChanged(
-      this.handleOutcomeChange
-    );
-    this.updateStateFromModel();
+    this.handleMeasurementModelChanged();
   }
 
   /**
@@ -134,7 +131,7 @@ export class ViewerMeasurementDetails {
   /**
    * @internal
    */
-  @Watch('distanceUnits')
+  @Watch('distanceUnits', { immediate: true })
   protected handleDistanceUnitsChanged(): void {
     this.distanceMeasurementUnits = new DistanceUnits(this.distanceUnits);
     this.areaMeasurementUnits = new AreaUnits(this.distanceUnits);
@@ -143,7 +140,7 @@ export class ViewerMeasurementDetails {
   /**
    * @internal
    */
-  @Watch('angleUnits')
+  @Watch('angleUnits', { immediate: true })
   protected handleAngleUnitsChanged(): void {
     this.angleMeasurementUnits = new AngleUnits(this.angleUnits);
   }
@@ -151,7 +148,7 @@ export class ViewerMeasurementDetails {
   /**
    * @internal
    */
-  @Watch('measurementModel')
+  @Watch('measurementModel', { immediate: true })
   protected handleMeasurementModelChanged(): void {
     this.onOutcomeChangedHandler?.dispose();
     this.onOutcomeChangedHandler = this.measurementModel?.onOutcomeChanged(

--- a/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
+++ b/packages/viewer/src/components/viewer-measurement-distance/viewer-measurement-distance.tsx
@@ -468,7 +468,7 @@ export class ViewerMeasurementDistance {
   /**
    * @ignore
    */
-  @Watch('units')
+  @Watch('units', { immediate: true })
   protected handleUnitsChanged(): void {
     this.measurementUnits = new DistanceUnits(this.units);
   }

--- a/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx
+++ b/packages/viewer/src/components/viewer-measurement-precise/viewer-measurement-precise.tsx
@@ -116,7 +116,7 @@ export class ViewerMeasurementPrecise {
   /**
    * @ignore
    */
-  @Watch('measurementModel')
+  @Watch('measurementModel', { immediate: true })
   protected handleMeasurementModelChanged(): void {
     this.setupController();
   }


### PR DESCRIPTION
## Summary
Address lifecycle change. Measurement components were not reflecting units provided on component mount


## Test Plan
Have a reproduction of the issue in a fork of nextjs-starter, and can see it in connect-app implementation

## Release Notes
BugFix: measurement unit should display as configured, not always in 'mm' - no required changes

## Possible Regressions
No known

## Dependencies
n/a