### PR TITLE
[PLAT-8807] Default PDF background color

### DIFF
--- a/packages/doc-viewer/src/__mocks__/pdfjs-mock.ts
+++ b/packages/doc-viewer/src/__mocks__/pdfjs-mock.ts
@@ -6,7 +6,8 @@ export class MockOptionalContentConfig extends Map {
 
 export const mockGetViewport = jest.fn(() => ({ width: 100, height: 100 }));
 
-export const mockPageRender = jest.fn(() => ({ promise: Promise.resolve() }));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const mockPageRender = jest.fn((args: any) => ({ promise: Promise.resolve() }));
 
 export const mockGetPage = jest.fn(() => ({
   getTextContent: jest.fn(() => ({

--- a/packages/doc-viewer/src/components/document-viewer/document-viewer.css
+++ b/packages/doc-viewer/src/components/document-viewer/document-viewer.css
@@ -8,6 +8,13 @@
 
   user-select: none;
   -webkit-user-select: none;
+
+  /**
+   * @prop --viewer-background:
+   * A CSS color value used as the background painted behind the loaded PDF,
+   * visible in the negative space around the page. Defaults to #cccccc.
+   */
+  --viewer-background: #cccccc;
 }
 
 .viewer-container {
@@ -23,4 +30,8 @@
   width: 100%;
   height: 100%;
   position: relative;
+}
+
+#document-viewer-canvas {
+  background-color: var(--viewer-background);
 }

--- a/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
+++ b/packages/doc-viewer/src/components/document-viewer/document-viewer.tsx
@@ -257,7 +257,7 @@ export class VertexDocumentViewer implements BasicViewer {
               'enable-pointer-events ': window.PointerEvent != null,
             })}
           >
-            <canvas role="presentation" ref={el => (this.canvasEl = el)} />
+            <canvas id="document-viewer-canvas" role="presentation" ref={el => (this.canvasEl = el)} />
           </div>
 
           <slot></slot>

--- a/packages/doc-viewer/src/components/document-viewer/readme.md
+++ b/packages/doc-viewer/src/components/document-viewer/readme.md
@@ -108,6 +108,13 @@ Type: `Promise<void>`
 
 
 
+## CSS Custom Properties
+
+| Name                  | Description                                                                                                                                 |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--viewer-background` | A CSS color value used as the background painted behind the loaded PDF, visible in the negative space around the page. Defaults to #cccccc. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/doc-viewer/src/lib/dom.ts
+++ b/packages/doc-viewer/src/lib/dom.ts
@@ -2,6 +2,10 @@ export function getElementBoundingClientRect(element: HTMLElement): ClientRect {
   return element.getBoundingClientRect();
 }
 
+export function createElement(tagName: string): HTMLElement {
+  return document.createElement(tagName);
+}
+
 export function getAllVertexElementChildren(element: Element): Element[] {
   return getAllChildren(element)
     .filter(node => node.nodeName.startsWith('VERTEX-'))

--- a/packages/doc-viewer/src/lib/dom.ts
+++ b/packages/doc-viewer/src/lib/dom.ts
@@ -2,8 +2,8 @@ export function getElementBoundingClientRect(element: HTMLElement): ClientRect {
   return element.getBoundingClientRect();
 }
 
-export function createElement(tagName: string): HTMLElement {
-  return document.createElement(tagName);
+export function createElement<T extends HTMLElement>(tagName: string): T {
+  return document.createElement(tagName) as T;
 }
 
 export function getAllVertexElementChildren(element: Element): Element[] {

--- a/packages/doc-viewer/src/lib/pdf/__tests__/pdfjs-renderer.spec.ts
+++ b/packages/doc-viewer/src/lib/pdf/__tests__/pdfjs-renderer.spec.ts
@@ -2,6 +2,10 @@ const mockOnStateChangeDispose = jest.fn();
 const mockOnStateChange = jest.fn((_handler: (state: PdfJsApiState) => Promise<void>) => ({
   dispose: mockOnStateChangeDispose,
 }));
+const mockCreateElement = jest.fn();
+jest.mock('../../dom', () => ({
+  createElement: mockCreateElement,
+}));
 jest.mock('../pdfjs-api', () => ({
   PdfJsApi: jest.fn().mockImplementation(() => ({
     onStateChanged: mockOnStateChange,
@@ -32,20 +36,21 @@ describe('PdfJsRenderer', () => {
 
   describe('renderPage', () => {
     it('renders the page', async () => {
+      const mockContext = { fillStyle: '#000000', fillRect: jest.fn() };
+
+      mockCreateElement.mockImplementation(() => ({ getContext: jest.fn().mockReturnValue(mockContext) }));
+
       new PdfJsRenderer(new PdfJsApi(), new HTMLCanvasElement());
       const handler = mockOnStateChange.mock.calls[0][0];
 
       await handler({ document: mockPdfDocument, loadedPageNumber: 1, zoomPercentage: 100, panOffset: Point.create(0, 0) });
 
-      expect(mockPageRender).toHaveBeenCalledWith(
-        expect.objectContaining({
-          canvas: expect.any(HTMLCanvasElement),
-          viewport: expect.objectContaining({
-            width: 100,
-            height: 100,
-          }),
-        }),
-      );
+      const firstCall = mockPageRender.mock.calls[0][0];
+
+      // Expect the fill style to have been updated to `#ffffff` to give the page a white background.
+      expect(firstCall.canvas.getContext('2d')?.fillStyle).toBe('#ffffff');
+      expect(firstCall.viewport.width).toBe(100);
+      expect(firstCall.viewport.height).toBe(100);
     });
 
     it('scales the page to fit within the viewport', async () => {

--- a/packages/doc-viewer/src/lib/pdf/__tests__/pdfjs-renderer.spec.ts
+++ b/packages/doc-viewer/src/lib/pdf/__tests__/pdfjs-renderer.spec.ts
@@ -48,9 +48,9 @@ describe('PdfJsRenderer', () => {
       const firstCall = mockPageRender.mock.calls[0][0];
 
       // Expect the fill style to have been updated to `#ffffff` to give the page a white background.
-      expect(firstCall.canvas.getContext('2d')?.fillStyle).toBe('#ffffff');
-      expect(firstCall.viewport.width).toBe(100);
-      expect(firstCall.viewport.height).toBe(100);
+      expect(firstCall?.canvas.getContext('2d')?.fillStyle).toBe('#ffffff');
+      expect(firstCall?.viewport.width).toBe(100);
+      expect(firstCall?.viewport.height).toBe(100);
     });
 
     it('scales the page to fit within the viewport', async () => {

--- a/packages/doc-viewer/src/lib/pdf/pdfjs-renderer.ts
+++ b/packages/doc-viewer/src/lib/pdf/pdfjs-renderer.ts
@@ -22,7 +22,7 @@ export class PdfJsRenderer extends DocumentRenderer {
 
     // Render pages using an offscreen canvas to avoid flickering that can occur for
     // PDFs with annotations.
-    this.offscreenCanvas = createElement('canvas');
+    this.offscreenCanvas = createElement<HTMLCanvasElement>('canvas');
 
     this.handleStateChanged = this.handleStateChanged.bind(this);
 

--- a/packages/doc-viewer/src/lib/pdf/pdfjs-renderer.ts
+++ b/packages/doc-viewer/src/lib/pdf/pdfjs-renderer.ts
@@ -3,6 +3,7 @@ import { Disposable } from '@vertexvis/utils';
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
 
 import { DocumentRenderer } from '../document/renderer';
+import { createElement } from '../dom';
 import { PdfJsApi, PdfJsApiState } from './pdfjs-api';
 
 interface PdfJsRendererState {
@@ -21,7 +22,7 @@ export class PdfJsRenderer extends DocumentRenderer {
 
     // Render pages using an offscreen canvas to avoid flickering that can occur for
     // PDFs with annotations.
-    this.offscreenCanvas = document.createElement('canvas');
+    this.offscreenCanvas = createElement('canvas');
 
     this.handleStateChanged = this.handleStateChanged.bind(this);
 

--- a/packages/doc-viewer/src/lib/pdf/pdfjs-renderer.ts
+++ b/packages/doc-viewer/src/lib/pdf/pdfjs-renderer.ts
@@ -76,10 +76,20 @@ export class PdfJsRenderer extends DocumentRenderer {
       this.offscreenCanvas.width = this.canvas.width;
       this.offscreenCanvas.height = this.canvas.height;
 
+      const offscreenCanvasCtx = this.offscreenCanvas.getContext('2d');
+
+      // Fill the offscreen canvas with a white background prior to rendering the page to give the content
+      // of the PDF a white background, but maintain the canvas it gets drawn to when copying to the main canvas.
+      if (offscreenCanvasCtx != null) {
+        offscreenCanvasCtx.fillStyle = '#ffffff';
+        offscreenCanvasCtx.fillRect(panOffset.x + centerOffsetX, panOffset.y, scaled.width, scaled.height);
+      }
+
       await page.render({
         canvas: this.offscreenCanvas,
         viewport: scaled,
         intent: 'display',
+        background: 'transparent',
         optionalContentConfigPromise: optionalContentConfig != null ? Promise.resolve(optionalContentConfig) : undefined,
       }).promise;
 


### PR DESCRIPTION
## Summary

Adds a default background color of `#cccccc` for PDFs such that the primary content of the PDF displays with a letterbox effect. Screenshot for example:

<img width="1300" height="945" alt="Screenshot 2026-07-01 at 5 53 22 PM" src="https://github.com/user-attachments/assets/c51f3a0c-85dd-49a6-a187-e2460477ce90" />


## Test Plan

- Verify that by default the PDF viewer displays with the `#cccccc` background where PDF content is not present
- Verify that this letterboxing is not visible if zoomed in such that the PDF content displays within the entire viewport
- Verify that passing a different value for `--viewer-background` to the `<vertex-document-viewer>` element updates the letterboxing color

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
