### PR TITLE
[PLAT-5195] zoom accumulator + requestAnimationFrame

### DIFF
--- a/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
@@ -270,8 +270,10 @@ describe(ZoomInteraction, () => {
         mouseWheelInteractionEndDebounce: timeoutDelay,
       };
     };
-    function delay(): Promise<void> {
-      return new Promise((resolve) => setTimeout(resolve, timeoutDelay + 10));
+    function delay(extraDelayMs = 0): Promise<void> {
+      return new Promise((resolve) =>
+        setTimeout(resolve, timeoutDelay + extraDelayMs + 10),
+      );
     }
 
     it('only begins interaction once within interaction timeout', async () => {
@@ -286,7 +288,7 @@ describe(ZoomInteraction, () => {
     it('ends interaction after interaction timeout', async () => {
       const interaction = new ZoomInteraction(interactionConfigProvider);
       interaction.zoom(1, api);
-      await delay();
+      await delay(48); // zoom has extra delay of approx 3 frames at 60fp
       expect(api.endInteraction).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
@@ -40,6 +40,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   private lastMoveEvent?: BaseEvent;
   private interactionTimer?: number;
   private keyboardControls = false;
+  private pendingWheelZoom: { point: Point.Point; delta: number } | null = null;
 
   protected disableIndividualInteractions = false;
 
@@ -86,6 +87,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     this.element?.removeEventListener('mousedown', this.handleDoubleClick);
     this.element?.removeEventListener('wheel', this.handleMouseWheel);
     this.element = undefined;
+    this.pendingWheelZoom = null;
   }
 
   public onPrimaryInteractionTypeChange(listener: Listener<void>): Disposable {
@@ -316,36 +318,24 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
         -this.wheelDeltaToPixels(event.deltaY, event.deltaMode) / 10;
       const rect = this.element.getBoundingClientRect();
       const point = getMouseClientPosition(event, rect);
-      const scrollSize = Math.abs(event.deltaY);
 
-      if (scrollSize < 12) {
-        // For small wheel movements, send a single zoom event.
-        void this.zoomInteraction.zoomToPoint(
-          point,
-          delta,
-          this.interactionApi,
-        );
+      // Accumulate wheel input and process on next frame for smooth zooming
+      if (this.pendingWheelZoom) {
+        this.pendingWheelZoom.delta += delta;
       } else {
-        const divisions = Math.min(10, Math.ceil(scrollSize / 12));
-        const zoomDelta = delta / divisions;
-        // For larger wheel movements, divide the delta into multiple zoom events with increasing delay
-        // which approximates a smooth zoom deceleration curve for the end user.
-        for (let i = 1; i <= divisions; i++) {
-          const delayMs = i * 5;
-          window.setTimeout(() => {
-            if (this.interactionApi != null) {
-              this.zoomInteraction.zoomToPoint(
-                point,
-                zoomDelta,
-                this.interactionApi,
-                delayMs,
-              );
-            }
-          }, delayMs);
-        }
+        this.pendingWheelZoom = { point, delta };
+        requestAnimationFrame(this.processWheelZoom);
       }
     }
   }
+
+  private processWheelZoom = (): void => {
+    if (this.pendingWheelZoom && this.interactionApi) {
+      const { point, delta } = this.pendingWheelZoom;
+      this.pendingWheelZoom = null;
+      void this.zoomInteraction.zoomToPoint(point, delta, this.interactionApi);
+    }
+  };
 
   protected wheelDeltaToPixels(deltaY: number, deltaMode: number): number {
     // Cached values are an optimization we can use given mouseWheel

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -154,15 +154,9 @@ export class ZoomInteraction extends MouseInteraction {
     this.startPt = undefined;
   }
 
-  public async zoom(
-    delta: number,
-    api: InteractionApi,
-    extraDelayMs?: number,
-  ): Promise<void> {
-    await this.runWheelZoomInteraction(
-      api,
-      () => api.zoomCamera(this.getDirectionalDelta(delta)),
-      extraDelayMs,
+  public async zoom(delta: number, api: InteractionApi): Promise<void> {
+    await this.runWheelZoomInteraction(api, () =>
+      api.zoomCamera(this.getDirectionalDelta(delta)),
     );
   }
 
@@ -170,12 +164,9 @@ export class ZoomInteraction extends MouseInteraction {
     pt: Point.Point,
     delta: number,
     api: InteractionApi,
-    extraDelayMs?: number,
   ): Promise<void> {
-    await this.runWheelZoomInteraction(
-      api,
-      () => api.zoomCameraToPoint(pt, this.getDirectionalDelta(delta)),
-      extraDelayMs,
+    await this.runWheelZoomInteraction(api, () =>
+      api.zoomCameraToPoint(pt, this.getDirectionalDelta(delta)),
     );
   }
 
@@ -189,12 +180,9 @@ export class ZoomInteraction extends MouseInteraction {
     await api.endInteraction();
   }
 
-  private resetInteractionTimer(
-    api: InteractionApi,
-    extraDelayMs?: number,
-  ): void {
+  private resetInteractionTimer(api: InteractionApi): void {
     this.stopInteractionTimer();
-    this.startInteractionTimer(api, extraDelayMs);
+    this.startInteractionTimer(api);
   }
 
   private getDirectionalDelta(delta: number): number {
@@ -204,20 +192,21 @@ export class ZoomInteraction extends MouseInteraction {
   }
 
   /**
-   * If this value gets too low, can cause animation jitter in certain scenarios
+   * the amount of delay until interaction is considered done or paused so final frames will be fetched
+   * If this value gets too low, can cause animation jitter in certain scenarios due to latency differences
+   * between partial and final frames
    */
-  private getInteractionDelay(): number {
-    return this.interactionConfigProvider().mouseWheelInteractionEndDebounce;
-  }
+  private getInteractionDelay = (): number =>
+    this.interactionConfigProvider().mouseWheelInteractionEndDebounce;
 
   /**
-   * Uses a configured interaction delay, but certain interactions like wheel zoom benefit from extra delay
+   * Will use configured mouseWheelInteractionEndDebounce delay
    */
-  private startInteractionTimer(api: InteractionApi, extraDelayMs = 0): void {
+  private startInteractionTimer(api: InteractionApi): void {
     this.interactionTimer = window.setTimeout(async () => {
       this.interactionTimer = undefined;
       await this.endInteraction(api);
-    }, extraDelayMs + this.getInteractionDelay());
+    }, this.getInteractionDelay());
   }
 
   private stopInteractionTimer(): void {
@@ -230,13 +219,12 @@ export class ZoomInteraction extends MouseInteraction {
   private async runWheelZoomInteraction(
     api: InteractionApi,
     f: () => void | Promise<void>,
-    extraDelayMs?: number,
   ): Promise<void> {
     if (!this.isTransforming) {
       await this.beginInteraction(api);
     }
 
-    this.resetInteractionTimer(api, extraDelayMs);
+    this.resetInteractionTimer(api);
     f();
   }
 }

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -180,9 +180,12 @@ export class ZoomInteraction extends MouseInteraction {
     await api.endInteraction();
   }
 
-  private resetInteractionTimer(api: InteractionApi): void {
+  private resetInteractionTimer(
+    api: InteractionApi,
+    extraDelayMs?: number,
+  ): void {
     this.stopInteractionTimer();
-    this.startInteractionTimer(api);
+    this.startInteractionTimer(api, extraDelayMs);
   }
 
   private getDirectionalDelta(delta: number): number {
@@ -200,13 +203,13 @@ export class ZoomInteraction extends MouseInteraction {
     this.interactionConfigProvider().mouseWheelInteractionEndDebounce;
 
   /**
-   * Will use configured mouseWheelInteractionEndDebounce delay
+   * Will use configured mouseWheelInteractionEndDebounce delay, certain interactions like wheel zoom benefit from extra delay
    */
-  private startInteractionTimer(api: InteractionApi): void {
+  private startInteractionTimer(api: InteractionApi, extraDelayMs = 0): void {
     this.interactionTimer = window.setTimeout(async () => {
       this.interactionTimer = undefined;
       await this.endInteraction(api);
-    }, this.getInteractionDelay());
+    }, extraDelayMs + this.getInteractionDelay());
   }
 
   private stopInteractionTimer(): void {
@@ -224,7 +227,7 @@ export class ZoomInteraction extends MouseInteraction {
       await this.beginInteraction(api);
     }
 
-    this.resetInteractionTimer(api);
+    this.resetInteractionTimer(api, 48); // extra delay of approx 3 frames at 60fps
     f();
   }
 }

--- a/packages/viewer/src/lib/types/interactions.ts
+++ b/packages/viewer/src/lib/types/interactions.ts
@@ -48,6 +48,6 @@ export const defaultInteractionConfig: InteractionConfig = {
   coarsePointerThreshold: 3,
   interactionDelay: 75,
   useMinimumPerspectiveZoomDistance: true,
-  mouseWheelInteractionEndDebounce: 400,
+  mouseWheelInteractionEndDebounce: 320,
   reverseMouseWheelDirection: false,
 };


### PR DESCRIPTION
## Summary
Use a zoom accumulator and requestAnimationFrame to handle zoomToPoint queue for a series of scroll wheel events instead of a loop of setTimeouts

## Test Plan
Do various zoom behaviors on example pages with a larger model especially with a external mouse with a scroll wheel. See fewer frames flashing

## Release Notes
Further improve zoom frame flashing issue

## Possible Regressions
None

## Dependencies
n/a