### PR TITLE
[PLAT-5195] Zoom accumulator + requestAnimationFrame & other race fixes for zoom events

### DIFF
--- a/packages/viewer/src/lib/interactions/__tests__/interactionApi.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/interactionApi.spec.ts
@@ -186,6 +186,20 @@ describe(InteractionApi, () => {
       expect(streamApi.replaceCamera).toHaveBeenCalledTimes(1);
     });
 
+    it('reuses the same correlation ID for render option clones', async () => {
+      await api.beginInteraction();
+      await api.zoomCameraToPoint(Point.create(10, 10), 1);
+      await api.zoomCameraToPoint(Point.create(10, 10), 1);
+      await api.endInteraction();
+
+      const correlationIds = (streamApi.replaceCamera as jest.Mock).mock.calls
+        .map(([payload]) => payload.frameCorrelationId?.value)
+        .filter((id) => id != null);
+
+      expect(correlationIds).toHaveLength(2);
+      expect(new Set(correlationIds).size).toBe(1);
+    });
+
     it('prevents zooming past the hit point when configured', async () => {
       const configuredApi = createInteractionApi({
         interactionConfigProvider: () => ({

--- a/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
+++ b/packages/viewer/src/lib/interactions/__tests__/mouseInteractions.spec.ts
@@ -270,8 +270,10 @@ describe(ZoomInteraction, () => {
         mouseWheelInteractionEndDebounce: timeoutDelay,
       };
     };
-    function delay(): Promise<void> {
-      return new Promise((resolve) => setTimeout(resolve, timeoutDelay + 10));
+    function delay(extraDelayMs = 0): Promise<void> {
+      return new Promise((resolve) =>
+        setTimeout(resolve, timeoutDelay + extraDelayMs + 10),
+      );
     }
 
     it('only begins interaction once within interaction timeout', async () => {
@@ -286,7 +288,7 @@ describe(ZoomInteraction, () => {
     it('ends interaction after interaction timeout', async () => {
       const interaction = new ZoomInteraction(interactionConfigProvider);
       interaction.zoom(1, api);
-      await delay();
+      await delay(48); // zoom has extra delay of approx 3 frames at 60fp
       expect(api.endInteraction).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
+++ b/packages/viewer/src/lib/interactions/baseInteractionHandler.ts
@@ -40,6 +40,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
   private lastMoveEvent?: BaseEvent;
   private interactionTimer?: number;
   private keyboardControls = false;
+  private pendingWheelZoom: { point: Point.Point; delta: number } | null = null;
 
   protected disableIndividualInteractions = false;
 
@@ -85,6 +86,7 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     this.element?.removeEventListener('mousedown', this.handleDoubleClick);
     this.element?.removeEventListener('wheel', this.handleMouseWheel);
     this.element = undefined;
+    this.pendingWheelZoom = null;
   }
 
   public onPrimaryInteractionTypeChange(listener: Listener<void>): Disposable {
@@ -313,38 +315,27 @@ export abstract class BaseInteractionHandler implements InteractionHandler {
     ) {
       const delta =
         -this.wheelDeltaToPixels(event.deltaY, event.deltaMode) / 10;
-      const rect = this.element.getBoundingClientRect();
-      const point = getMouseClientPosition(event, rect);
-      const scrollSize = Math.abs(event.deltaY);
 
-      if (scrollSize < 12) {
-        // For small wheel movements, send a single zoom event.
-        void this.zoomInteraction.zoomToPoint(
-          point,
-          delta,
-          this.interactionApi,
-        );
+      if (this.pendingWheelZoom) {
+        // Accumulate wheel input and process on next frame for smooth zooming
+        // assumed that mouse position is not meaningfully changing during rapid wheel zoom
+        this.pendingWheelZoom.delta += delta;
       } else {
-        const divisions = Math.min(10, Math.ceil(scrollSize / 12));
-        const zoomDelta = delta / divisions;
-        // For larger wheel movements, divide the delta into multiple zoom events with increasing delay
-        // which approximates a smooth zoom deceleration curve for the end user.
-        for (let i = 1; i <= divisions; i++) {
-          const delayMs = i * 5;
-          window.setTimeout(() => {
-            if (this.interactionApi != null) {
-              this.zoomInteraction.zoomToPoint(
-                point,
-                zoomDelta,
-                this.interactionApi,
-                delayMs,
-              );
-            }
-          }, delayMs);
-        }
+        const rect = this.element.getBoundingClientRect();
+        const point = getMouseClientPosition(event, rect);
+        this.pendingWheelZoom = { point, delta };
+        requestAnimationFrame(this.processWheelZoom);
       }
     }
   }
+
+  private processWheelZoom = (): void => {
+    if (this.pendingWheelZoom && this.interactionApi) {
+      const { point, delta } = this.pendingWheelZoom;
+      this.pendingWheelZoom = null;
+      void this.zoomInteraction.zoomToPoint(point, delta, this.interactionApi);
+    }
+  };
 
   protected wheelDeltaToPixels(deltaY: number, deltaMode: number): number {
     // Cached values are an optimization we can use given mouseWheel

--- a/packages/viewer/src/lib/interactions/interactionApi.ts
+++ b/packages/viewer/src/lib/interactions/interactionApi.ts
@@ -9,7 +9,7 @@ import {
   Vector3,
 } from '@vertexvis/geometry';
 import { StreamApi } from '@vertexvis/stream-api';
-import { Disposable } from '@vertexvis/utils';
+import { Disposable, UUID } from '@vertexvis/utils';
 
 import { ReceivedFrame } from '../..';
 import { Cursor, CursorManager } from '../cursors';
@@ -209,9 +209,10 @@ export abstract class InteractionApi<T extends Camera = Camera> {
    * mark the end of an interaction.
    */
   public async beginInteraction(
-    renderOptions: CameraRenderOptions = {},
+    renderOptions = this.activeRenderOptions ?? {},
   ): Promise<void> {
     if (!this.isInteracting()) {
+      renderOptions.correlationId ??= UUID.create();
       this.activeRenderOptions = renderOptions;
       this.interactionStartedEmitter.emit();
       this.sceneLoadingPromise = this.getScene();

--- a/packages/viewer/src/lib/interactions/mouseInteractions.ts
+++ b/packages/viewer/src/lib/interactions/mouseInteractions.ts
@@ -56,7 +56,7 @@ export class RotateInteraction extends MouseInteraction {
   ): void {
     if (this.currentPosition == null) {
       this.currentPosition = Point.create(event.screenX, event.screenY);
-      api.beginInteraction();
+      api.beginInteraction({ skipCameraValidation: true });
     }
   }
 
@@ -88,7 +88,7 @@ export class RotatePointInteraction extends MouseInteraction {
     if (this.currentPosition == null) {
       this.currentPosition = Point.create(event.screenX, event.screenY);
       this.startingPosition = canvasPosition;
-      api.beginInteraction();
+      api.beginInteraction({ skipCameraValidation: true });
     }
   }
 
@@ -131,7 +131,7 @@ export class ZoomInteraction extends MouseInteraction {
       const rect = element.getBoundingClientRect();
       const point = getMouseClientPosition(event, rect);
       this.startPt = point;
-      await api.beginInteraction();
+      await api.beginInteraction({ skipCameraValidation: true });
     }
   }
 
@@ -154,15 +154,9 @@ export class ZoomInteraction extends MouseInteraction {
     this.startPt = undefined;
   }
 
-  public async zoom(
-    delta: number,
-    api: InteractionApi,
-    extraDelayMs?: number,
-  ): Promise<void> {
-    await this.runWheelZoomInteraction(
-      api,
-      () => api.zoomCamera(this.getDirectionalDelta(delta)),
-      extraDelayMs,
+  public async zoom(delta: number, api: InteractionApi): Promise<void> {
+    await this.runWheelZoomInteraction(api, () =>
+      api.zoomCamera(this.getDirectionalDelta(delta)),
     );
   }
 
@@ -170,23 +164,20 @@ export class ZoomInteraction extends MouseInteraction {
     pt: Point.Point,
     delta: number,
     api: InteractionApi,
-    extraDelayMs?: number,
   ): Promise<void> {
-    await this.runWheelZoomInteraction(
-      api,
-      () => api.zoomCameraToPoint(pt, this.getDirectionalDelta(delta)),
-      extraDelayMs,
-    );
+    await this.runWheelZoomInteraction(api, async () => {
+      await api.zoomCameraToPoint(pt, this.getDirectionalDelta(delta));
+    });
   }
 
   private async beginInteraction(api: InteractionApi): Promise<void> {
     this.isTransforming = true;
-    await api.beginInteraction();
+    await api.beginInteraction({ skipCameraValidation: true });
   }
 
   private async endInteraction(api: InteractionApi): Promise<void> {
-    this.isTransforming = false;
     await api.endInteraction();
+    this.isTransforming = false;
   }
 
   private resetInteractionTimer(
@@ -204,14 +195,15 @@ export class ZoomInteraction extends MouseInteraction {
   }
 
   /**
-   * If this value gets too low, can cause animation jitter in certain scenarios
+   * the amount of delay until interaction is considered done or paused so final frames will be fetched
+   * If this value gets too low, can cause animation jitter in certain scenarios due to latency differences
+   * between partial and final frames
    */
-  private getInteractionDelay(): number {
-    return this.interactionConfigProvider().mouseWheelInteractionEndDebounce;
-  }
+  private getInteractionDelay = (): number =>
+    this.interactionConfigProvider().mouseWheelInteractionEndDebounce;
 
   /**
-   * Uses a configured interaction delay, but certain interactions like wheel zoom benefit from extra delay
+   * Will use configured mouseWheelInteractionEndDebounce delay, certain interactions like wheel zoom benefit from extra delay
    */
   private startInteractionTimer(api: InteractionApi, extraDelayMs = 0): void {
     this.interactionTimer = window.setTimeout(async () => {
@@ -230,14 +222,13 @@ export class ZoomInteraction extends MouseInteraction {
   private async runWheelZoomInteraction(
     api: InteractionApi,
     f: () => void | Promise<void>,
-    extraDelayMs?: number,
   ): Promise<void> {
     if (!this.isTransforming) {
       await this.beginInteraction(api);
     }
 
-    this.resetInteractionTimer(api, extraDelayMs);
-    f();
+    this.resetInteractionTimer(api, 48); // extra delay of approx 3 frames at 60fps
+    await f();
   }
 }
 
@@ -255,7 +246,7 @@ export class PanInteraction extends MouseInteraction {
     if (this.currentPosition == null) {
       this.currentPosition = Point.create(event.screenX, event.screenY);
       this.canvasRect = element.getBoundingClientRect();
-      api.beginInteraction();
+      api.beginInteraction({ skipCameraValidation: true });
     }
   }
 
@@ -285,7 +276,7 @@ export class TwistInteraction extends MouseInteraction {
   ): void {
     this.currentPosition = Point.create(event.offsetX, event.offsetY);
     this.canvasRect = element.getBoundingClientRect();
-    api.beginInteraction();
+    api.beginInteraction({ skipCameraValidation: true });
   }
 
   public drag(event: MouseEvent, api: InteractionApi): void {
@@ -310,7 +301,7 @@ export class PivotInteraction extends MouseInteraction {
   ): void {
     if (this.currentPosition == null) {
       this.currentPosition = Point.create(event.screenX, event.screenY);
-      api.beginInteraction();
+      api.beginInteraction({ skipCameraValidation: true });
     }
   }
 

--- a/packages/viewer/src/lib/types/interactions.ts
+++ b/packages/viewer/src/lib/types/interactions.ts
@@ -48,6 +48,6 @@ export const defaultInteractionConfig: InteractionConfig = {
   coarsePointerThreshold: 3,
   interactionDelay: 75,
   useMinimumPerspectiveZoomDistance: true,
-  mouseWheelInteractionEndDebounce: 400,
+  mouseWheelInteractionEndDebounce: 360,
   reverseMouseWheelDirection: false,
 };


### PR DESCRIPTION
## Summary
- Use a zoom accumulator and requestAnimationFrame to handle zoomToPoint queue for a series of scroll wheel events instead of a loop of setTimeouts. 
- Improve reuse of renderOptions
- Take advantage of skipCameraValidation in mouseEvents, where the starting and intermediate frames should be safe
- move isTransforming flags after promise of begin/endInteraction to prevent edge case race condition with rapid fire zoom events

replaces #812 as I was trying on top of #814 

## Test Plan
Do various zoom behaviors on example pages with a larger model especially with a external mouse with a scroll wheel. See fewer frames flashing

## Release Notes
Further improve zoom frame flashing issue

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
