### PR TITLE
[PLAT-9120] Fix Typedoc publishing to Github pages

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -76,61 +76,28 @@ jobs:
         run: "yarn install"
       - name: "Test"
         run: "yarn test:ci"
-  # docs:
-  #   runs-on: ubuntu-latest
-  #   needs: [build]
-  #   steps:
-  #     - name: "Checkout changes"
-  #       uses: actions/checkout@v6
-  #     - name: "Download build artifacts"
-  #       uses: actions/download-artifact@v5
-  #       with:
-  #         name: build-artifact
-  #         path: packages
-  #     - name: Setup NodeJS
-  #       uses: actions/setup-node@v6
-  #       with:
-  #         node-version-file: .nvmrc
-  #         cache: yarn
-  #         cache-dependency-path: yarn.lock
-  #     - name: Enable Corepack
-  #       run: corepack enable
-  #     - name: "Install"
-  #       run: "yarn install"
-  #     - name: "Generate docs"
-  #       run: "yarn generate:docs"
-  #     - name: "Test docs"
-  #       run: git add -f docs/
   docs:
     runs-on: ubuntu-latest
     needs: [build]
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v5
         with:
           name: build-artifact
           path: packages
       - name: Setup NodeJS
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v6
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
+      - name: Enable Corepack
+        run: corepack enable
       - name: "Install"
         run: "yarn install"
       - name: "Generate docs"
         run: "yarn generate:docs"
-      - name: "Upload docs as pages artifact"
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs
-      - name: "Deploy docs to GitHub Pages"
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: "Test docs"
+        run: git add -f docs/

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -76,28 +76,61 @@ jobs:
         run: "yarn install"
       - name: "Test"
         run: "yarn test:ci"
+  # docs:
+  #   runs-on: ubuntu-latest
+  #   needs: [build]
+  #   steps:
+  #     - name: "Checkout changes"
+  #       uses: actions/checkout@v6
+  #     - name: "Download build artifacts"
+  #       uses: actions/download-artifact@v5
+  #       with:
+  #         name: build-artifact
+  #         path: packages
+  #     - name: Setup NodeJS
+  #       uses: actions/setup-node@v6
+  #       with:
+  #         node-version-file: .nvmrc
+  #         cache: yarn
+  #         cache-dependency-path: yarn.lock
+  #     - name: Enable Corepack
+  #       run: corepack enable
+  #     - name: "Install"
+  #       run: "yarn install"
+  #     - name: "Generate docs"
+  #       run: "yarn generate:docs"
+  #     - name: "Test docs"
+  #       run: git add -f docs/
   docs:
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: packages
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version-file: .nvmrc
-          cache: yarn
-          cache-dependency-path: yarn.lock
-      - name: Enable Corepack
-        run: corepack enable
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: "Install"
         run: "yarn install"
       - name: "Generate docs"
         run: "yarn generate:docs"
-      - name: "Test docs"
-        run: git add -f docs/
+      - name: "Upload docs as pages artifact"
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs
+      - name: "Deploy docs to GitHub Pages"
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -122,7 +122,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [publish-release]
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -122,37 +122,35 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    needs: [publish-release]
+    needs: [build]
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: packages
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version-file: .nvmrc
-          cache: yarn
-          cache-dependency-path: yarn.lock
-          registry-url: https://registry.npmjs.org
-          scope: "@vertexvis"
-      - name: Enable Corepack
-        run: corepack enable
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: "Install"
         run: "yarn install"
       - name: "Generate docs"
         run: "yarn generate:docs"
-      - name: "Publish docs"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add -f docs/
-          git commit -m "new docs"
-          git push -f origin HEAD:gh-pages
+      - name: "Upload docs as pages artifact"
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs
+      - name: "Deploy docs to GitHub Pages"
+        id: deployment
+        uses: actions/deploy-pages@v5
+


### PR DESCRIPTION
## Summary

Fixes our deployment of our Typedoc documentation to Github pages. After introducing the signed commit requirements, the previous approach was failing to push a commit to the `gh-pages` branch, which we've seen in some other repositories. This PR updates the workflow to use the `actions/upload-pages-artifact` and `actions/deploy-pages` actions to avoid the need to manually commit and push to the `gh-pages` branch.

For an example of this workflow succeeding, see https://github.com/Vertexvis/vertex-web-sdk/actions/runs/30845403521/job/91792838980. Note that this will still only run when we fully release the SDK, so merging this PR will not cause a new deployment to occur, but the workflow linked here for testing has pushed the latest documentation.

## Test Plan

- Verify updated docs are available at https://vertexvis.github.io/vertex-web-sdk/index.html
- Verify on next release that documentation is pushed successfully

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
