### PR TITLE
[PLAT-9120] Update Github action versions

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -58,14 +58,14 @@ jobs:
     needs: [build]
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: build-artifact
           path: packages
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -81,14 +81,14 @@ jobs:
     needs: [build]
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: build-artifact
           path: packages
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: yarn

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -44,7 +44,7 @@ jobs:
       publish: ${{ steps.detect-publish.outputs.publish }}
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Detect publish"
         id: "detect-publish"
         run: |
@@ -59,14 +59,16 @@ jobs:
       contents: write
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: build-artifact
           path: packages
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
+        env:
+          NODE_AUTH_TOKEN: "${{ secrets.NPMJS_ACCESS_TOKEN }}"
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -95,14 +97,16 @@ jobs:
       contents: write
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: build-artifact
           path: packages
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
+        env:
+          NODE_AUTH_TOKEN: "${{ secrets.NPMJS_ACCESS_TOKEN }}"
         with:
           node-version-file: .nvmrc
           cache: yarn

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -42,14 +42,16 @@ jobs:
       contents: write
     steps:
       - name: "Checkout changes"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: build-artifact
           path: packages
       - name: Setup NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
+        env:
+          NODE_AUTH_TOKEN: "${{ secrets.NPMJS_ACCESS_TOKEN }}"
         with:
           node-version-file: .nvmrc
           cache: yarn


### PR DESCRIPTION
## Summary

Follow-up to #828 - noticed a number of the Github actions versions weren't on latest. This PR updates those to use the latest versions, with only one notable addition. The `setup-node` action now has `NODE_AUTH_TOKEN: "${{ secrets.NPMJS_ACCESS_TOKEN }}"` defined as an environment variable. While we set this later in the workflow, this action was updated to remove a dummy `NODE_AUTH_TOKEN` during setup which would cause this step to fail without an explicitly provided value. 

## Test Plan

- Verify publishing continues to work as expected

## Release Notes

N/A

## Possible Regressions

Publishing canary / testing / release

## Dependencies

N/A
