### PR TITLE
[PLAT-9287] add ariaLabel for viewer-button

### DIFF
--- a/packages/viewer/src/components.d.ts
+++ b/packages/viewer/src/components.d.ts
@@ -894,7 +894,13 @@ export namespace Components {
      */
     viewer?: HTMLVertexViewerElement;
   }
-  interface VertexViewerButton {}
+  interface VertexViewerButton {
+    /**
+     * Accessible name applied to the internal native button. Use this for icon-only buttons or when the slotted content does not provide a name.
+     * @default null
+     */
+    ariaLabel: string | null;
+  }
   interface VertexViewerDefaultToolbar {
     /**
      * The duration of animations, in milliseconds. Defaults to `1000`.
@@ -4081,7 +4087,13 @@ declare namespace LocalJSX {
      */
     viewer?: HTMLVertexViewerElement;
   }
-  interface VertexViewerButton {}
+  interface VertexViewerButton {
+    /**
+     * Accessible name applied to the internal native button. Use this for icon-only buttons or when the slotted content does not provide a name.
+     * @default null
+     */
+    ariaLabel?: string | null;
+  }
   interface VertexViewerDefaultToolbar {
     /**
      * The duration of animations, in milliseconds. Defaults to `1000`.
@@ -5357,6 +5369,9 @@ declare namespace LocalJSX {
     operationType: VolumeIntersectionQueryType;
     mode: VolumeIntersectionQueryMode;
   }
+  interface VertexViewerButtonAttributes {
+    ariaLabel: string | null;
+  }
   interface VertexViewerDefaultToolbarAttributes {
     placement: ViewerToolbarPlacement;
     direction: ViewerToolbarGroupDirection;
@@ -5700,7 +5715,24 @@ declare namespace LocalJSX {
           keyof VertexViewerBoxQueryToolAttributes as `prop:${K}`
       ]?: VertexViewerBoxQueryTool[K];
     };
-    'vertex-viewer-button': VertexViewerButton;
+    'vertex-viewer-button': Omit<
+      VertexViewerButton,
+      keyof VertexViewerButtonAttributes
+    > & {
+      [
+        K in keyof VertexViewerButton & keyof VertexViewerButtonAttributes
+      ]?: VertexViewerButton[K];
+    } & {
+      [
+        K in keyof VertexViewerButton &
+          keyof VertexViewerButtonAttributes as `attr:${K}`
+      ]?: VertexViewerButtonAttributes[K];
+    } & {
+      [
+        K in keyof VertexViewerButton &
+          keyof VertexViewerButtonAttributes as `prop:${K}`
+      ]?: VertexViewerButton[K];
+    };
     'vertex-viewer-default-toolbar': Omit<
       VertexViewerDefaultToolbar,
       keyof VertexViewerDefaultToolbarAttributes

--- a/packages/viewer/src/components/viewer-button/readme.md
+++ b/packages/viewer/src/components/viewer-button/readme.md
@@ -24,7 +24,25 @@ customize the styling to your application.
 <vertex-viewer-button class="btn">Click Me</vertex-viewer-button>
 ```
 
+## Accessibility
+
+For icon-only buttons, provide an `aria-label`. The component applies this
+value to its internal native `<button>`, making the accessible name available
+to assistive technology.
+
+```html
+<vertex-viewer-button aria-label="Fit all">
+  <vertex-viewer-icon name="fit-all" size="md"></vertex-viewer-icon>
+</vertex-viewer-button>
+```
+
 <!-- Auto Generated Below -->
+
+## Properties
+
+| Property    | Attribute    | Description                                                                                                                                | Type             | Default |
+| ----------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- | ------- |
+| `ariaLabel` | `aria-label` | Accessible name applied to the internal native button. Use this for icon-only buttons or when the slotted content does not provide a name. | `null \| string` | `null`  |
 
 ## Dependencies
 

--- a/packages/viewer/src/components/viewer-button/viewer-button.spec.ts
+++ b/packages/viewer/src/components/viewer-button/viewer-button.spec.ts
@@ -12,6 +12,18 @@ describe('<vertex-viewer-button>', () => {
     const btn = page.root?.shadowRoot?.querySelector('button');
     const slot = btn?.querySelector('slot');
     expect(btn).toBeDefined();
+    // The button should not have an aria-label attribute since not provided
+    expect(btn).not.toHaveAttribute('aria-label');
     expect(slot).toBeDefined();
+  });
+
+  it('forwards its accessible name to the internal button', async () => {
+    const page = await newSpecPage({
+      components: [ViewerButton],
+      html: `<vertex-viewer-button aria-label="Fit all"></vertex-viewer-button>`,
+    });
+
+    const btn = page.root?.shadowRoot?.querySelector('button');
+    expect(btn).toEqualAttribute('aria-label', 'Fit all');
   });
 });

--- a/packages/viewer/src/components/viewer-button/viewer-button.tsx
+++ b/packages/viewer/src/components/viewer-button/viewer-button.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host } from '@stencil/core';
+import { Component, h, Host, Prop } from '@stencil/core';
 
 @Component({
   tag: 'vertex-viewer-button',
@@ -6,10 +6,17 @@ import { Component, h, Host } from '@stencil/core';
   shadow: true,
 })
 export class ViewerButton {
+  /**
+   * Accessible name applied to the internal native button. Use this for
+   * icon-only buttons or when the slotted content does not provide a name.
+   */
+  @Prop({ attribute: 'aria-label' })
+  public ariaLabel: string | null = null;
+
   public render(): h.JSX.IntrinsicElements {
     return (
       <Host>
-        <button class="viewer-button">
+        <button class="viewer-button" aria-label={this.ariaLabel}>
           <slot></slot>
         </button>
       </Host>

--- a/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.spec.ts
+++ b/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.spec.ts
@@ -30,6 +30,7 @@ describe('<vertex-viewer-default-toolbar>', () => {
         '[data-testid="fit-all-btn"]',
       );
       expect(btn).toBeDefined();
+      expect(btn).toEqualAttribute('aria-label', 'Fit all');
     });
 
     it('performs fit all with animation when fit all button is clicked', async () => {

--- a/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.tsx
+++ b/packages/viewer/src/components/viewer-default-toolbar/viewer-default-toolbar.tsx
@@ -54,6 +54,7 @@ export class ViewerDefaultToolbar {
           data-direction={this.direction}
         >
           <vertex-viewer-button
+            aria-label="Fit all"
             class="group-item btn"
             data-testid="fit-all-btn"
             onClick={() => this.viewAll()}


### PR DESCRIPTION
## Summary
`viewer-button` accepts an optional aria label to improve accessibility 

Used on default toolbar icon button

## Test Plan
Should show up in DOM inspection or if using screen-reader tools. 

## Release Notes
Improve a11y for viewer-button. 

## Possible Regressions
None expected

## Dependencies
n/a - stacked on prettier branch so I don't have to potentially re-apply prettier fixes
